### PR TITLE
Integrate react-helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-addons-css-transition-group": "^15.6.0",
     "react-apollo": "^1.4.3",
     "react-dom": "^15.6.1",
+    "react-helmet": "^5.1.3",
     "react-intl": "^2.3.0",
     "react-rangeslider": "^2.1.0",
     "react-redux": "^5.0.6",

--- a/src/components/common/sidebar/Sidebar.js
+++ b/src/components/common/sidebar/Sidebar.js
@@ -10,7 +10,7 @@ import SidebarItem from './SidebarItem'
 type Props = {
   activeItem: string,
   children: any,
-  head: 'next/head',
+  head: any,
   items: Array<{
     label: string | React.Element<any>,
     href: string,

--- a/src/components/confusion/ConfusionBarometer.js
+++ b/src/components/confusion/ConfusionBarometer.js
@@ -9,7 +9,7 @@ import { withCSS } from '../../lib'
 import ConfusionSection from './ConfusionSection'
 
 type Props = {
-  head: 'next/head',
+  head: any,
   intl: $IntlShape,
   isActive: boolean,
   handleActiveToggle: () => mixed,

--- a/src/components/confusion/ConfusionSlider.js
+++ b/src/components/confusion/ConfusionSlider.js
@@ -6,7 +6,7 @@ import Slider from 'react-rangeslider'
 import { withCSS } from '../../lib'
 
 type Props = {
-  head: 'next/head',
+  head: any,
   title?: React.Element<any>,
   value: number,
   handleChange: (newValue: number) => mixed,

--- a/src/components/feedbacks/FeedbackChannel.js
+++ b/src/components/feedbacks/FeedbackChannel.js
@@ -14,7 +14,7 @@ type Props = {
     id: string,
     votes: number,
   }>,
-  head: 'next/head',
+  head: any,
   intl: $IntlShape,
   isActive?: boolean,
   isPublic?: boolean,

--- a/src/components/layouts/StudentLayout.js
+++ b/src/components/layouts/StudentLayout.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
+import { Helmet } from 'react-helmet'
 import { Button } from 'semantic-ui-react'
 
 import { initLogging, withCSS } from '../../lib'
@@ -12,6 +13,7 @@ class StudentLayout extends Component {
   props: {
     children: any,
     head: 'next/head',
+    pageTitle: string,
     sidebar: {
       handleItemChange: (newItem: string) => mixed,
     },
@@ -39,7 +41,7 @@ class StudentLayout extends Component {
   }
 
   render() {
-    const { children, head, sidebar, title } = this.props
+    const { children, head, pageTitle, sidebar, title } = this.props
 
     const sidebarItems = [
       {
@@ -64,6 +66,10 @@ class StudentLayout extends Component {
     return (
       <div className="studentLayout">
         {head}
+
+        <Helmet>
+          <title>{pageTitle}</title>
+        </Helmet>
 
         <div className="header">
           <Button basic icon="content" onClick={this.handleSidebarToggle} />

--- a/src/components/layouts/StudentLayout.js
+++ b/src/components/layouts/StudentLayout.js
@@ -68,7 +68,9 @@ class StudentLayout extends Component {
         {head}
 
         <Helmet>
-          <title>{pageTitle}</title>
+          <title>
+            {pageTitle}
+          </title>
         </Helmet>
 
         <div className="header">

--- a/src/components/layouts/StudentLayout.js
+++ b/src/components/layouts/StudentLayout.js
@@ -12,7 +12,7 @@ import Sidebar from '../common/sidebar/Sidebar'
 class StudentLayout extends Component {
   props: {
     children: any,
-    head: 'next/head',
+    head: any,
     pageTitle: string,
     sidebar: {
       handleItemChange: (newItem: string) => mixed,

--- a/src/components/layouts/TeacherLayout.js
+++ b/src/components/layouts/TeacherLayout.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react'
 import Router from 'next/router'
 import { FormattedMessage } from 'react-intl'
+import { Helmet } from 'react-helmet'
 
 import { initLogging, withCSS } from '../../lib'
 
@@ -26,6 +27,7 @@ class TeacherLayout extends Component {
       },
       title: string,
     },
+    pageTitle: string,
     sidebar: {
       activeItem: string,
     },
@@ -56,7 +58,7 @@ class TeacherLayout extends Component {
   }
 
   render() {
-    const { actionButton, children, intl, head, navbar, sidebar } = this.props
+    const { actionButton, children, intl, head, navbar, pageTitle, sidebar } = this.props
 
     const sidebarItems = [
       {
@@ -83,6 +85,12 @@ class TeacherLayout extends Component {
     return (
       <div className="teacherLayout">
         {head}
+
+        <Helmet>
+          <title>
+            {pageTitle}
+          </title>
+        </Helmet>
 
         {navbar &&
           <div className="navbar">

--- a/src/components/layouts/TeacherLayout.js
+++ b/src/components/layouts/TeacherLayout.js
@@ -14,7 +14,7 @@ class TeacherLayout extends Component {
   props: {
     actionButton: React.Element<any>,
     children: any,
-    head: 'next/head',
+    head: any,
     intl: $IntlShape,
     navbar: {
       accountShort: string,

--- a/src/components/questions/TagList.js
+++ b/src/components/questions/TagList.js
@@ -12,7 +12,7 @@ import type { TagListType } from '../../queries/queries'
 type Props = {
   activeTags: Array<string>,
   data: TagListType,
-  head: 'next/head',
+  head: any,
   handleTagClick: () => mixed,
 }
 

--- a/src/lib/withCSS.js
+++ b/src/lib/withCSS.js
@@ -1,4 +1,4 @@
-import Head from 'next/head'
+import { Helmet } from 'react-helmet'
 import React from 'react'
 
 // take in a ComposedComponent and a list of semantic ui css file links
@@ -8,7 +8,7 @@ const WithCSS = (ComposedComponent, links) => {
   // TODO: extension => check whether link is semantic or full
   // HACK: this might lead to duplicate link declarations in <head>
   const head = (
-    <Head>
+    <Helmet>
       {links.map((link) => {
         // if a full URL is given as a link, directly include it
         if (link.substr(0, 4) === 'http') {
@@ -25,7 +25,7 @@ const WithCSS = (ComposedComponent, links) => {
           />
         )
       })}
-    </Head>
+    </Helmet>
   )
 
   // return the enhanced component, passing head and remaining props

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -2,6 +2,7 @@
 // TODO: enable flow for this file?
 
 import Document, { Head, Main, NextScript } from 'next/document'
+import Helmet from 'react-helmet'
 import React from 'react'
 
 // The document (which is SSR-only) needs to be customized to expose the locale
@@ -13,9 +14,27 @@ export default class IntlDocument extends Document {
 
     return {
       ...props,
+      helmet: Helmet.renderStatic(),
       locale,
       localeDataScript,
     }
+  }
+
+  // should render on <html>
+  get helmetHtmlAttrComponents() {
+    return this.props.helmet.htmlAttributes.toComponent()
+  }
+
+  // should render on <body>
+  get helmetBodyAttrComponents() {
+    return this.props.helmet.bodyAttributes.toComponent()
+  }
+
+  // should render on <head>
+  get helmetHeadComponents() {
+    return Object.keys(this.props.helmet)
+      .filter(el => el !== 'htmlAttributes' && el !== 'bodyAttributes')
+      .map(el => this.props.helmet[el].toComponent())
   }
 
   render() {
@@ -24,13 +43,15 @@ export default class IntlDocument extends Document {
       ?features=Intl.~locale.${this.props.locale}`
 
     return (
-      <html lang={this.props.locale}>
+      <html lang={this.props.locale} {...this.helmetHtmlAttrComponents}>
         <Head>
           <meta httpEquiv="Content-type" content="text/html; charset=utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta httpEquiv="X-UA-Compatible" content="IE=Edge" />
+
+          {this.helmetHeadComponents}
         </Head>
-        <body>
+        <body {...this.helmetBodyAttrComponents}>
           <Main />
           <script src={polyfill} />
           <script

--- a/src/pages/questions/index.js
+++ b/src/pages/questions/index.js
@@ -93,6 +93,10 @@ class Index extends Component {
         actionButton={actionButton}
         intl={intl}
         navbar={navbarConfig}
+        pageTitle={intl.formatMessage({
+          defaultMessage: 'Question Pool',
+          id: 'teacher.questionPool.pageTitle',
+        })}
         sidebar={{ activeItem: 'questionPool' }}
       >
         <div className="questionPool">

--- a/src/pages/sessions/index.js
+++ b/src/pages/sessions/index.js
@@ -39,7 +39,15 @@ class Index extends Component {
     }
 
     return (
-      <TeacherLayout intl={intl} navbar={navbarConfig} sidebar={{ activeItem: 'sessionHistory' }}>
+      <TeacherLayout
+        intl={intl}
+        navbar={navbarConfig}
+        pageTitle={intl.formatMessage({
+          defaultMessage: 'Session History',
+          id: 'teacher.sessionHistory.pageTitle',
+        })}
+        sidebar={{ activeItem: 'sessionHistory' }}
+      >
         <div className="sessionHistory">
           <SessionList intl={intl} />
         </div>

--- a/src/pages/sessions/running.js
+++ b/src/pages/sessions/running.js
@@ -75,7 +75,15 @@ class Running extends Component {
     const activeUser = data.allUsers[0]
 
     return (
-      <TeacherLayout intl={intl} navbar={navbarConfig} sidebar={{ activeItem: 'runningSession' }}>
+      <TeacherLayout
+        intl={intl}
+        navbar={navbarConfig}
+        pageTitle={intl.formatMessage({
+          defaultMessage: 'Running Session',
+          id: 'teacher.runningSession.pageTitle',
+        })}
+        sidebar={{ activeItem: 'runningSession' }}
+      >
         <div className="runningSession">
           <div className="sessionProgress">
             <SessionTimeline intl={intl} blocks={activeUser.activeSession.blocks} />

--- a/src/pages/student/session.js
+++ b/src/pages/student/session.js
@@ -15,7 +15,7 @@ import StudentLayout from '../../components/layouts/StudentLayout'
 
 class Session extends React.Component {
   props: {
-    head: 'next/head',
+    head: any,
     intl: $IntlShape,
   }
 

--- a/src/pages/student/session.js
+++ b/src/pages/student/session.js
@@ -74,6 +74,7 @@ class Session extends React.Component {
 
     return (
       <StudentLayout
+        pageTitle="Session #1762"
         sidebar={{
           activeItem: this.state.sidebarActiveItem,
           handleItemChange: this.handleSidebarItemChange,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6117,6 +6117,15 @@ react-dom@15, react-dom@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-helmet@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.1.3.tgz#cd40626593a29eecf684b6d38d711f44c48188af"
+  dependencies:
+    deep-equal "^1.0.1"
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-side-effect "^1.1.0"
+
 react-hot-loader@3.0.0-beta.7:
   version "3.0.0-beta.7"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz#d5847b8165d731c4d5b30d86d5d4716227a0fa83"
@@ -6228,6 +6237,13 @@ react-resize-detector@0.4.1:
   resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-0.4.1.tgz#19f8b993e1e869e2879344e20dc23c4fac28b256"
   dependencies:
     prop-types "^15.5.8"
+
+react-side-effect@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.3.tgz#512c25abe0dec172834c4001ec5c51e04d41bc5c"
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react-simple-di@^1.2.0:
   version "1.2.0"
@@ -6819,6 +6835,10 @@ shallowequal@0.2.x, shallowequal@^0.2.2:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   dependencies:
     lodash.keys "^3.1.2"
+
+shallowequal@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
**GENERAL**
- Integrate react-helmet in base next `_document` (server-side rendering)
- Update `withCSS` to make use of react-helmet instead of next/head
  - This allows for deduplication of links in head
- Integrate a `pageTitle` prop in layouts and pass it from all pages
- Update flow types for head prop (next/head to any)

**DEPENDENCIES**
- Install react-helmet