### PR TITLE
Updating babel-plugin-transform-inline-environment-variables to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "babel-plugin-add-react-displayname": "^0.0.4",
     "babel-plugin-inline-dotenv": "^1.1.1",
     "babel-plugin-react-intl": "^2.3.1",
-    "babel-plugin-transform-inline-environment-variables": "^0.1.1",
+    "babel-plugin-transform-inline-environment-variables": "^0.2.0",
     "classnames": "^2.2.5",
     "dotenv": "^4.0.0",
     "express": "^4.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,9 +1075,9 @@ babel-plugin-transform-function-bind@^6.22.0:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-inline-environment-variables@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.1.1.tgz#257ccd8ff6941c55384fa60607c97105bb125664"
+babel-plugin-transform-inline-environment-variables@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.2.0.tgz#37dad411a819667fd69c33e72f7a14ea1a50ba98"
 
 babel-plugin-transform-object-rest-spread@6.22.0:
   version "6.22.0"


### PR DESCRIPTION

Please update [babel-plugin-transform-inline-environment-variables](https://npmjs.org/package/babel-plugin-transform-inline-environment-variables) to version 0.2.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

