### PR TITLE
User registration

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,8 @@ fi
 echo "Lockfile not found, initializing application..."
 
 echo "Replacing environment variables..."
-sed -i 's;__SENTRY__;'"$SENTRY"';g' ./env
-sed -i 's;__LOGROCKET__;'"$LOGROCKET"';g' ./env
+sed -i 's;__SENTRY__;'"$SENTRY"';g' ./.env
+sed -i 's;__LOGROCKET__;'"$LOGROCKET"';g' ./.env
 
 echo "Building application sources..."
 yarn run build

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "recharts": "^1.0.0-alpha.2",
     "redux": "^3.7.2",
     "redux-form": "^7.0.3",
-    "semantic-ui-react": "^0.71.0"
+    "semantic-ui-react": "^0.71.0",
+    "validator": "^8.0.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.0",

--- a/src/components/common/navbar/Navbar.js
+++ b/src/components/common/navbar/Navbar.js
@@ -39,16 +39,7 @@ const Navbar = ({
 }: Props) =>
   (<div className="navbar">
     <Helmet>
-      {createLinks([
-        'button',
-        'divider',
-        'dropdown',
-        'icon',
-        'image',
-        'input',
-        'menu',
-        'popup',
-      ])}
+      {createLinks(['button', 'divider', 'dropdown', 'icon', 'image', 'input', 'menu', 'popup'])}
     </Helmet>
 
     <div className="sideArea">

--- a/src/components/common/navbar/Navbar.js
+++ b/src/components/common/navbar/Navbar.js
@@ -39,7 +39,7 @@ const Navbar = ({
 }: Props) =>
   (<div className="navbar">
     <Helmet>
-      {createLinks(undefined, [
+      {createLinks([
         'button',
         'divider',
         'dropdown',

--- a/src/components/common/sidebar/Sidebar.js
+++ b/src/components/common/sidebar/Sidebar.js
@@ -27,7 +27,7 @@ const defaultProps = {
 const Sidebar = ({ activeItem, children, items, visible, handleSidebarItemClick }: Props) =>
   (<div className="sidebar">
     <Helmet>
-      {createLinks(undefined, ['menu', 'sidebar'])}
+      {createLinks(['menu', 'sidebar'])}
     </Helmet>
 
     <SemanticSidebar.Pushable>

--- a/src/components/confusion/ConfusionBarometer.js
+++ b/src/components/confusion/ConfusionBarometer.js
@@ -21,7 +21,7 @@ const defaultProps = {
 const ConfusionBarometer = ({ intl, isActive, handleActiveToggle }: Props) =>
   (<div className="confusionBarometer">
     <Helmet>
-      {createLinks(undefined, ['checkbox'])}
+      {createLinks(['checkbox'])}
     </Helmet>
 
     <h2>

--- a/src/components/confusion/ConfusionSlider.js
+++ b/src/components/confusion/ConfusionSlider.js
@@ -22,7 +22,7 @@ const ConfusionSlider = ({ title, value, handleChange }: Props) =>
     <Helmet>
       {createLinks(
         ['https://unpkg.com/react-rangeslider@2.1.0/umd/randeslider.min.css'],
-        undefined,
+
       )}
     </Helmet>
 

--- a/src/components/confusion/ConfusionSlider.js
+++ b/src/components/confusion/ConfusionSlider.js
@@ -20,10 +20,7 @@ const defaultProps = {
 const ConfusionSlider = ({ title, value, handleChange }: Props) =>
   (<div className="confusionSlider">
     <Helmet>
-      {createLinks(
-        ['https://unpkg.com/react-rangeslider@2.1.0/umd/randeslider.min.css'],
-
-      )}
+      {createLinks(['https://unpkg.com/react-rangeslider@2.1.0/umd/randeslider.min.css'])}
     </Helmet>
 
     {title &&

--- a/src/components/feedbacks/FeedbackChannel.js
+++ b/src/components/feedbacks/FeedbackChannel.js
@@ -37,7 +37,7 @@ const FeedbackChannel = ({
 }: Props) =>
   (<div className="feedbackChannel">
     <Helmet>
-      {createLinks(undefined, ['checkbox'])}
+      {createLinks(['checkbox'])}
     </Helmet>
 
     <h2>

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -1,9 +1,10 @@
 // @flow
 
 import React from 'react'
+import isEmail from 'validator/lib/isEmail'
 import { FormattedMessage } from 'react-intl'
 import { Field, reduxForm } from 'redux-form'
-import { Button } from 'semantic-ui-react'
+import { Button, Form } from 'semantic-ui-react'
 import { Helmet } from 'react-helmet'
 
 import { createLinks } from '../../lib'
@@ -13,60 +14,75 @@ type Props = {
     firsName: string,
     lastName: string,
     email: string,
-    shortName: string,
+    shortname: string,
     password: string,
     passwordRepeat: string,
     useCase: string,
   }) => mixed,
 }
 
-const RegistrationForm = ({ handleSubmit }: Props) =>
+const validate = ({ email = '', shortname, password, passworRepeat }) => {
+  const errors = {}
+  if (isEmail(email)) {
+    errors.email = 'Fail email'
+  }
+  return errors
+}
+
+const renderField = ({ input, label, type, meta: { touched, error, warning } }) =>
+  (<Field error={error}>
+    <label forHtml={input.name}>
+      {label}
+    </label>
+    <input {...input} type={type} />
+  </Field>)
+
+const RegistrationForm = ({ email, handleSubmit }: Props) =>
   (<form className="ui form" onSubmit={handleSubmit}>
     <Helmet>
       {createLinks(['button', 'form'])}
     </Helmet>
 
+    {email}
+
     <div className="personal">
-      <div className="field">
-        <label htmlFor="firstName">
-          <FormattedMessage id="common.string.firstname" defaultMessage="First name" />
-        </label>
-        <Field name="firstName" component="input" type="text" />
+      <div>
+        <Field name="firstName" component={renderField} type="text" />
       </div>
-      <div className="field">
+      <div>
         <label htmlFor="lastName">
           <FormattedMessage id="common.string.lastName" defaultMessage="Last name" />
         </label>
-        <Field name="lastName" component="input" type="text" />
+        <Field name="lastName" component={renderField} type="text" />
       </div>
-      <div className="field">
+      <div>
         <label htmlFor="email">
           <FormattedMessage id="common.string.email" defaultMessage="Email" />
         </label>
-        <Field name="email" component="input" type="email" />
+        <Field name="email" component={renderField} type="email" />
       </div>
     </div>
 
     <div className="account">
-      <div className="field">
+      <div>
         <label htmlFor="shortname">
           <FormattedMessage id="common.string.shortname" defaultMessage="Shortname" />
         </label>
-        <Field name="shortname" component="input" type="text" />
+        <Field name="shortname" component={renderField} type="text" />
       </div>
-      <div className="field">
+      <div>
         <label htmlFor="password">
           <FormattedMessage id="common.string.password" defaultMessage="Password" />
         </label>
-        <Field name="password" component="input" type="password" />
+        <Field name="password" component={renderField} type="password" />
       </div>
-      <div className="field">
+      <div>
         <label htmlFor="passwordRepeat">
           <FormattedMessage id="common.string.passwordRepeat" defaultMessage="Repeat password" />
         </label>
-        <Field name="passwordRepeat" component="input" type="password" />
+        <Field name="passwordRepeat" component={renderField} type="password" />
       </div>
-      <div className="field">
+      <div>
         <label htmlFor="useCase">
           <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
         </label>
@@ -115,4 +131,5 @@ const RegistrationForm = ({ handleSubmit }: Props) =>
 
 export default reduxForm({
   form: 'registration',
+  validate,
 })(RegistrationForm)

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -2,14 +2,22 @@
 
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Field } from 'redux-form'
+import { Field, reduxForm } from 'redux-form'
 import { Button } from 'semantic-ui-react'
 import { Helmet } from 'react-helmet'
 
 import { createLinks } from '../../lib'
 
 type Props = {
-  handleSubmit: () => mixed
+  handleSubmit: (values: {
+    firsName: string,
+    lastName: string,
+    email: string,
+    shortName: string,
+    password: string,
+    passwordRepeat: string,
+    useCase: string,
+  }) => mixed,
 }
 
 const RegistrationForm = ({ handleSubmit }: Props) =>
@@ -105,4 +113,6 @@ const RegistrationForm = ({ handleSubmit }: Props) =>
     `}</style>
   </form>)
 
-export default RegistrationForm
+export default reduxForm({
+  form: 'registration',
+})(RegistrationForm)

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -62,8 +62,8 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({
-          id: 'common.form.firstName.label',
           defaultMessage: 'First name',
+          id: 'common.form.firstName.label',
         })}
         name="firstName"
         type="text"
@@ -73,8 +73,8 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({
-          id: 'common.form.lastName.label',
           defaultMessage: 'Last name',
+          id: 'common.form.lastName.label',
         })}
         name="lastName"
         type="text"
@@ -83,7 +83,10 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         required
         component={SemanticInput}
         intl={intl}
-        label={intl.formatMessage({ id: 'common.form.email.label', defaultMessage: 'Email' })}
+        label={intl.formatMessage({
+          defaultMessage: 'Email',
+          id: 'common.form.email.label',
+        })}
         name="email"
         type="email"
       />
@@ -95,8 +98,8 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({
-          id: 'registration.form.shortname.label',
           defaultMessage: 'Shortname',
+          id: 'registration.form.shortname.label',
         })}
         name="shortname"
         type="text"
@@ -106,8 +109,8 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({
-          id: 'registration.form.password.label',
           defaultMessage: 'Password',
+          id: 'registration.form.password.label',
         })}
         name="password"
         type="password"
@@ -117,8 +120,8 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({
-          id: 'registration.form.passwordRepeat.label',
           defaultMessage: 'Repeat password',
+          id: 'registration.form.passwordRepeat.label',
         })}
         name="passwordRepeat"
         type="password"
@@ -126,15 +129,15 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
       <div className="field">
         <label htmlFor="useCase">
           <FormattedMessage
-            id="registration.form.useCase.label"
             defaultMessage="Use case description"
+            id="registration.form.useCase.label"
           />
         </label>
         <Field name="useCase" component="textarea" type="text" />
       </div>
 
       <Button primary floated="right" type="submit">
-        <FormattedMessage id="common.form.button.submit" defaultMessage="Submit" />
+        <FormattedMessage defaultMessage="Submit" id="common.form.button.submit" />
       </Button>
     </div>
 

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -28,11 +28,11 @@ type Props = {
 const validate = ({ firstName = '', lastName = '', email = '', shortname = '', password = '', passwordRepeat = '', useCase = '' }) => {
   const errors = {}
 
-  if (!isAlpha(firstName && isLength(firstName, { min: 1, max: undefined }))) {
+  if (!isAlpha(firstName && isLength(firstName, { max: undefined, min: 1 }))) {
     errors.firstName = 'registration.form.firstName.invalid'
   }
 
-  if (!isAlpha(lastName) && isLength(lastName, { min: 1, max: undefined })) {
+  if (!isAlpha(lastName) && isLength(lastName, { max: undefined, min: 1 })) {
     errors.lastName = 'registration.form.lastName.invalid'
   }
 
@@ -54,6 +54,10 @@ const validate = ({ firstName = '', lastName = '', email = '', shortname = '', p
   // both password fields need to match
   if (passwordRepeat !== password) {
     errors.passwordRepeat = 'registration.form.passwordRepeat.invalid'
+  }
+
+  if (!isAlpha(useCase)) {
+    errors.useCase = 'registration.form.useCase.invalid'
   }
 
   return errors

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -4,10 +4,11 @@ import React from 'react'
 import isEmail from 'validator/lib/isEmail'
 import { FormattedMessage } from 'react-intl'
 import { Field, reduxForm } from 'redux-form'
-import { Button, Form } from 'semantic-ui-react'
+import { Button } from 'semantic-ui-react'
 import { Helmet } from 'react-helmet'
 
 import { createLinks } from '../../lib'
+import { SemanticInput } from './components'
 
 type Props = {
   handleSubmit: (values: {
@@ -21,70 +22,38 @@ type Props = {
   }) => mixed,
 }
 
-const validate = ({ email = '', shortname, password, passworRepeat }) => {
+const validate = ({ email = '' }) => {
   const errors = {}
-  if (isEmail(email)) {
+
+  if (!isEmail(email)) {
     errors.email = 'Fail email'
   }
+
   return errors
 }
 
-const renderField = ({ input, label, type, meta: { touched, error, warning } }) =>
-  (<Field error={error}>
-    <label forHtml={input.name}>
-      {label}
-    </label>
-    <input {...input} type={type} />
-  </Field>)
-
-const RegistrationForm = ({ email, handleSubmit }: Props) =>
-  (<form className="ui form" onSubmit={handleSubmit}>
+const RegistrationForm = ({ handleSubmit }: Props) =>
+  (<form className="ui form error" onSubmit={handleSubmit}>
     <Helmet>
-      {createLinks(['button', 'form'])}
+      {createLinks(['button', 'form', 'icon', 'textarea'])}
     </Helmet>
 
-    {email}
-
     <div className="personal">
-      <div className="field">
-        <label htmlFor="firstName">
-          <FormattedMessage id="common.string.firstName" defaultMessage="First name" />
-        </label>
-        <Field name="firstName" component="input" type="text" />
-      </div>
-      <div className="field">
-        <label htmlFor="lastName">
-          <FormattedMessage id="common.string.lastName" defaultMessage="Last name" />
-        </label>
-        <Field name="lastName" component="input" type="text" />
-      </div>
-      <div className="field">
-        <label htmlFor="email">
-          <FormattedMessage id="common.string.email" defaultMessage="Email" />
-        </label>
-        <Field name="email" component="input" type="email" />
-      </div>
+      <Field required component={SemanticInput} label="First name" name="firstName" type="text" />
+      <Field required component={SemanticInput} label="Last name" name="lastName" type="text" />
+      <Field required component={SemanticInput} label="Email" name="email" type="email" />
     </div>
 
     <div className="account">
-      <div className="field">
-        <label htmlFor="shortname">
-          <FormattedMessage id="common.string.shortname" defaultMessage="Shortname" />
-        </label>
-        <Field name="shortname" component="input" type="text" />
-      </div>
-      <div className="field">
-        <label htmlFor="password">
-          <FormattedMessage id="common.string.password" defaultMessage="Password" />
-        </label>
-        <Field name="password" component="input" type="password" />
-      </div>
-      <div className="field">
-        <label htmlFor="passwordRepeat">
-          <FormattedMessage id="common.string.passwordRepeat" defaultMessage="Repeat password" />
-        </label>
-        <Field name="passwordRepeat" component="input" type="password" />
-      </div>
+      <Field required component={SemanticInput} label="Shortname" name="shortname" type="text" />
+      <Field required component={SemanticInput} label="Password" name="password" type="password" />
+      <Field
+        required
+        component={SemanticInput}
+        label="Repeat password"
+        name="passwordRepeat"
+        type="password"
+      />
       <div className="field">
         <label htmlFor="useCase">
           <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
@@ -134,5 +103,5 @@ const RegistrationForm = ({ email, handleSubmit }: Props) =>
 
 export default reduxForm({
   form: 'registration',
-  // validate,
+  validate,
 })(RegistrationForm)

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -12,6 +12,7 @@ import { createLinks } from '../../lib'
 import { SemanticInput } from './components'
 
 type Props = {
+  intl: $IntlShape,
   handleSubmit: (values: {
     firstName: string,
     lastName: string,
@@ -45,24 +46,25 @@ const validate = ({ email = '', shortname = '', password = '', passwordRepeat = 
   return errors
 }
 
-const RegistrationForm = ({ handleSubmit }: Props) =>
+const RegistrationForm = ({ intl, handleSubmit }: Props) =>
   (<form className="ui form error" onSubmit={handleSubmit}>
     <Helmet>
       {createLinks(['button', 'form', 'icon', 'textarea'])}
     </Helmet>
 
     <div className="personal">
-      <Field required component={SemanticInput} label="First name" name="firstName" type="text" />
-      <Field required component={SemanticInput} label="Last name" name="lastName" type="text" />
-      <Field required component={SemanticInput} label="Email" name="email" type="email" />
+      <Field required component={SemanticInput} intl={intl} label="First name" name="firstName" type="text" />
+      <Field required component={SemanticInput} intl={intl} label="Last name" name="lastName" type="text" />
+      <Field required component={SemanticInput} intl={intl} label="Email" name="email" type="email" />
     </div>
 
     <div className="account">
-      <Field required component={SemanticInput} label="Shortname" name="shortname" type="text" />
-      <Field required component={SemanticInput} label="Password" name="password" type="password" />
+      <Field required component={SemanticInput} intl={intl} label="Shortname" name="shortname" type="text" />
+      <Field required component={SemanticInput} intl={intl} label="Password" name="password" type="password" />
       <Field
         required
         component={SemanticInput}
+        intl={intl}
         label="Repeat password"
         name="passwordRepeat"
         type="password"

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -49,10 +49,10 @@ const RegistrationForm = ({ handleSubmit }: Props) =>
 
     <div className="account">
       <div className="field">
-        <label htmlFor="shortName">
-          <FormattedMessage id="common.string.shortName" defaultMessage="Shortname" />
+        <label htmlFor="shortname">
+          <FormattedMessage id="common.string.shortname" defaultMessage="Shortname" />
         </label>
-        <Field name="shortName" component="input" type="text" />
+        <Field name="shortname" component="input" type="text" />
       </div>
       <div className="field">
         <label htmlFor="password">

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -1,0 +1,108 @@
+// @flow
+
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Field } from 'redux-form'
+import { Button } from 'semantic-ui-react'
+import { Helmet } from 'react-helmet'
+
+import { createLinks } from '../../lib'
+
+type Props = {
+  handleSubmit: () => mixed
+}
+
+const RegistrationForm = ({ handleSubmit }: Props) =>
+  (<form className="ui form" onSubmit={handleSubmit}>
+    <Helmet>
+      {createLinks(['button', 'form'])}
+    </Helmet>
+
+    <div className="personal">
+      <div className="field">
+        <label htmlFor="firstName">
+          <FormattedMessage id="common.string.firstname" defaultMessage="First name" />
+        </label>
+        <Field name="firstName" component="input" type="text" />
+      </div>
+      <div className="field">
+        <label htmlFor="lastName">
+          <FormattedMessage id="common.string.lastName" defaultMessage="Last name" />
+        </label>
+        <Field name="lastName" component="input" type="text" />
+      </div>
+      <div className="field">
+        <label htmlFor="email">
+          <FormattedMessage id="common.string.email" defaultMessage="Email" />
+        </label>
+        <Field name="email" component="input" type="email" />
+      </div>
+    </div>
+
+    <div className="account">
+      <div className="field">
+        <label htmlFor="shortName">
+          <FormattedMessage id="common.string.shortName" defaultMessage="Shortname" />
+        </label>
+        <Field name="shortName" component="input" type="text" />
+      </div>
+      <div className="field">
+        <label htmlFor="password">
+          <FormattedMessage id="common.string.password" defaultMessage="Password" />
+        </label>
+        <Field name="password" component="input" type="password" />
+      </div>
+      <div className="field">
+        <label htmlFor="passwordRepeat">
+          <FormattedMessage id="common.string.passwordRepeat" defaultMessage="Repeat password" />
+        </label>
+        <Field name="passwordRepeat" component="input" type="password" />
+      </div>
+      <div className="field">
+        <label htmlFor="useCase">
+          <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
+        </label>
+        <Field name="useCase" component="textarea" type="text" />
+      </div>
+
+      <Button primary floated="right" type="submit">
+        <FormattedMessage id="common.string.submit" defaultMessage="Submit" />
+      </Button>
+    </div>
+
+    <style jsx>{`
+      .form {
+        display: flex;
+        flex-direction: column;
+      }
+      .account {
+        margin-top: 1rem;
+      }
+
+      @media all and (min-width: 768px) {
+        .form {
+          flex-flow: row wrap;
+        }
+        .personal,
+        .account {
+          flex: 1 1 50%;
+        }
+        .personal {
+          padding-right: .5rem;
+        }
+        .account {
+          margin: 0;
+          padding-left: .5rem;
+        }
+      }
+
+      @media all and (min-width: 991px) {
+        .form {
+          border: 1px solid lightgrey;
+          padding: 1rem;
+        }
+      }
+    `}</style>
+  </form>)
+
+export default RegistrationForm

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import isEmail from 'validator/lib/isEmail'
+import isLength from 'validator/lib/isLength'
 import { FormattedMessage } from 'react-intl'
 import { Field, reduxForm } from 'redux-form'
 import { Button } from 'semantic-ui-react'
@@ -12,7 +13,7 @@ import { SemanticInput } from './components'
 
 type Props = {
   handleSubmit: (values: {
-    firsName: string,
+    firstName: string,
     lastName: string,
     email: string,
     shortname: string,
@@ -22,11 +23,23 @@ type Props = {
   }) => mixed,
 }
 
-const validate = ({ email = '' }) => {
+const validate = ({ email = '', shortname = '', password = '', passwordRepeat = '' }) => {
   const errors = {}
 
   if (!isEmail(email)) {
     errors.email = 'Fail email'
+  }
+
+  if (!isLength(shortname, { max: 6, min: 3 })) {
+    errors.shortname = 'Invalid shortname'
+  }
+
+  if (!isLength(password, { max: undefined, min: 7 })) {
+    errors.password = 'Too short'
+  }
+
+  if (passwordRepeat !== password) {
+    errors.passwordRepeat = 'Not the same'
   }
 
   return errors

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -46,43 +46,46 @@ const RegistrationForm = ({ email, handleSubmit }: Props) =>
     {email}
 
     <div className="personal">
-      <div>
-        <Field name="firstName" component={renderField} type="text" />
+      <div className="field">
+        <label htmlFor="firstName">
+          <FormattedMessage id="common.string.firstName" defaultMessage="First name" />
+        </label>
+        <Field name="firstName" component="input" type="text" />
       </div>
-      <div>
+      <div className="field">
         <label htmlFor="lastName">
           <FormattedMessage id="common.string.lastName" defaultMessage="Last name" />
         </label>
-        <Field name="lastName" component={renderField} type="text" />
+        <Field name="lastName" component="input" type="text" />
       </div>
-      <div>
+      <div className="field">
         <label htmlFor="email">
           <FormattedMessage id="common.string.email" defaultMessage="Email" />
         </label>
-        <Field name="email" component={renderField} type="email" />
+        <Field name="email" component="input" type="email" />
       </div>
     </div>
 
     <div className="account">
-      <div>
+      <div className="field">
         <label htmlFor="shortname">
           <FormattedMessage id="common.string.shortname" defaultMessage="Shortname" />
         </label>
-        <Field name="shortname" component={renderField} type="text" />
+        <Field name="shortname" component="input" type="text" />
       </div>
-      <div>
+      <div className="field">
         <label htmlFor="password">
           <FormattedMessage id="common.string.password" defaultMessage="Password" />
         </label>
-        <Field name="password" component={renderField} type="password" />
+        <Field name="password" component="input" type="password" />
       </div>
-      <div>
+      <div className="field">
         <label htmlFor="passwordRepeat">
           <FormattedMessage id="common.string.passwordRepeat" defaultMessage="Repeat password" />
         </label>
-        <Field name="passwordRepeat" component={renderField} type="password" />
+        <Field name="passwordRepeat" component="input" type="password" />
       </div>
-      <div>
+      <div className="field">
         <label htmlFor="useCase">
           <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
         </label>
@@ -131,5 +134,5 @@ const RegistrationForm = ({ email, handleSubmit }: Props) =>
 
 export default reduxForm({
   form: 'registration',
-  validate,
+  // validate,
 })(RegistrationForm)

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -27,20 +27,24 @@ type Props = {
 const validate = ({ email = '', shortname = '', password = '', passwordRepeat = '' }) => {
   const errors = {}
 
+  // the email address needs to be valid
   if (!isEmail(email)) {
-    errors.email = 'Fail email'
+    errors.email = 'registration.form.email.invalid'
   }
 
+  // the shortname is allowed to be within 3 to 6 chars
   if (!isLength(shortname, { max: 6, min: 3 })) {
-    errors.shortname = 'Invalid shortname'
+    errors.shortname = 'registration.form.shortname.invalid'
   }
 
+  // password should at least have 7 characters (or more?)
   if (!isLength(password, { max: undefined, min: 7 })) {
-    errors.password = 'Too short'
+    errors.password = 'registration.form.password.invalid'
   }
 
+  // both password fields need to match
   if (passwordRepeat !== password) {
-    errors.passwordRepeat = 'Not the same'
+    errors.passwordRepeat = 'registration.form.passwordRepeat.invalid'
   }
 
   return errors
@@ -53,31 +57,84 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
     </Helmet>
 
     <div className="personal">
-      <Field required component={SemanticInput} intl={intl} label="First name" name="firstName" type="text" />
-      <Field required component={SemanticInput} intl={intl} label="Last name" name="lastName" type="text" />
-      <Field required component={SemanticInput} intl={intl} label="Email" name="email" type="email" />
-    </div>
-
-    <div className="account">
-      <Field required component={SemanticInput} intl={intl} label="Shortname" name="shortname" type="text" />
-      <Field required component={SemanticInput} intl={intl} label="Password" name="password" type="password" />
       <Field
         required
         component={SemanticInput}
         intl={intl}
-        label="Repeat password"
+        label={intl.formatMessage({
+          id: 'common.form.firstName.label',
+          defaultMessage: 'First name',
+        })}
+        name="firstName"
+        type="text"
+      />
+      <Field
+        required
+        component={SemanticInput}
+        intl={intl}
+        label={intl.formatMessage({
+          id: 'common.form.lastName.label',
+          defaultMessage: 'Last name',
+        })}
+        name="lastName"
+        type="text"
+      />
+      <Field
+        required
+        component={SemanticInput}
+        intl={intl}
+        label={intl.formatMessage({ id: 'common.form.email.label', defaultMessage: 'Email' })}
+        name="email"
+        type="email"
+      />
+    </div>
+
+    <div className="account">
+      <Field
+        required
+        component={SemanticInput}
+        intl={intl}
+        label={intl.formatMessage({
+          id: 'registration.form.shortname.label',
+          defaultMessage: 'Shortname',
+        })}
+        name="shortname"
+        type="text"
+      />
+      <Field
+        required
+        component={SemanticInput}
+        intl={intl}
+        label={intl.formatMessage({
+          id: 'registration.form.password.label',
+          defaultMessage: 'Password',
+        })}
+        name="password"
+        type="password"
+      />
+      <Field
+        required
+        component={SemanticInput}
+        intl={intl}
+        label={intl.formatMessage({
+          id: 'registration.form.passwordRepeat.label',
+          defaultMessage: 'Repeat password',
+        })}
         name="passwordRepeat"
         type="password"
       />
       <div className="field">
         <label htmlFor="useCase">
-          <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
+          <FormattedMessage
+            id="registration.form.useCase.label"
+            defaultMessage="Use case description"
+          />
         </label>
         <Field name="useCase" component="textarea" type="text" />
       </div>
 
       <Button primary floated="right" type="submit">
-        <FormattedMessage id="common.string.submit" defaultMessage="Submit" />
+        <FormattedMessage id="common.form.button.submit" defaultMessage="Submit" />
       </Button>
     </div>
 

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -25,7 +25,15 @@ type Props = {
   }) => mixed,
 }
 
-const validate = ({ firstName = '', lastName = '', email = '', shortname = '', password = '', passwordRepeat = '', useCase = '' }) => {
+const validate = ({
+  firstName = '',
+  lastName = '',
+  email = '',
+  shortname = '',
+  password = '',
+  passwordRepeat = '',
+  useCase = '',
+}) => {
   const errors = {}
 
   if (!isAlpha(firstName && isLength(firstName, { max: undefined, min: 1 }))) {

--- a/src/components/forms/RegistrationForm.js
+++ b/src/components/forms/RegistrationForm.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import isAlpha from 'validator/lib/isAlpha'
 import isEmail from 'validator/lib/isEmail'
 import isLength from 'validator/lib/isLength'
 import { FormattedMessage } from 'react-intl'
@@ -24,8 +25,16 @@ type Props = {
   }) => mixed,
 }
 
-const validate = ({ email = '', shortname = '', password = '', passwordRepeat = '' }) => {
+const validate = ({ firstName = '', lastName = '', email = '', shortname = '', password = '', passwordRepeat = '', useCase = '' }) => {
   const errors = {}
+
+  if (!isAlpha(firstName && isLength(firstName, { min: 1, max: undefined }))) {
+    errors.firstName = 'registration.form.firstName.invalid'
+  }
+
+  if (!isAlpha(lastName) && isLength(lastName, { min: 1, max: undefined })) {
+    errors.lastName = 'registration.form.lastName.invalid'
+  }
 
   // the email address needs to be valid
   if (!isEmail(email)) {
@@ -33,7 +42,7 @@ const validate = ({ email = '', shortname = '', password = '', passwordRepeat = 
   }
 
   // the shortname is allowed to be within 3 to 6 chars
-  if (!isLength(shortname, { max: 6, min: 3 })) {
+  if (!isAlpha(shortname) || !isLength(shortname, { max: 6, min: 3 })) {
     errors.shortname = 'registration.form.shortname.invalid'
   }
 
@@ -58,7 +67,6 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
 
     <div className="personal">
       <Field
-        required
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({
@@ -69,7 +77,6 @@ const RegistrationForm = ({ intl, handleSubmit }: Props) =>
         type="text"
       />
       <Field
-        required
         component={SemanticInput}
         intl={intl}
         label={intl.formatMessage({

--- a/src/components/forms/components/SemanticInput.js
+++ b/src/components/forms/components/SemanticInput.js
@@ -3,10 +3,10 @@
 
 import React from 'react'
 import { Form, Icon } from 'semantic-ui-react'
+import { FormattedMessage } from 'react-intl'
 
 type Props = {
   disabled?: boolean,
-  error?: boolean,
   input: {
     name: string,
     value: string,
@@ -16,8 +16,8 @@ type Props = {
     onDrop: () => mixed,
     onFocus: () => mixed,
   },
-  intl?: $IntlShape,
-  label: string,
+  intl: $IntlShape,
+  label?: string,
   meta: {
     active: boolean,
     asyncValidating: boolean,
@@ -43,8 +43,7 @@ type Props = {
 
 const defaultProps = {
   disabled: false,
-  error: undefined,
-  intl: undefined,
+  label: undefined,
   placeholder: undefined,
   required: false,
   width: undefined,
@@ -52,40 +51,37 @@ const defaultProps = {
 
 const SemanticInput = ({
   disabled,
-  error,
   input,
   intl,
   label,
-  meta: { error: metaError, invalid, touched },
+  meta: { error, invalid, touched },
   placeholder,
   required,
   width,
   ...rest
 }: Props) => {
-  // translate the label if intl was injected. otherwise use it directly.
-  const inputLabel = intl ? intl.formatMessage({ id: label }) : label
-
-  // calculate the error message
-  const errorContent = error || metaError
-  const errorMessage = intl ? intl.formatMessage({ id: errorContent }) : errorContent
-
   // construct field props
-  const fieldProps = { disabled, error: error || (touched && metaError), required, width }
+  const fieldProps = { disabled, error: touched && invalid, required, width }
 
   return (
     <Form.Field {...fieldProps}>
       {label &&
         <label forHtml={input.name}>
-          {inputLabel}
+          <FormattedMessage id={label} />
         </label>}
 
-      <input {...input} {...rest} placeholder={placeholder || inputLabel} />
+      <input
+        {...input}
+        {...rest}
+        placeholder={(placeholder || label) && intl.formatMessage({ id: placeholder || label })}
+      />
 
       {touched &&
         invalid &&
+        error &&
         <div className="errorMessage">
           <Icon name="hand pointer" />
-          {errorMessage}
+          <FormattedMessage id={error} />
         </div>}
 
       <style jsx>{`

--- a/src/components/forms/components/SemanticInput.js
+++ b/src/components/forms/components/SemanticInput.js
@@ -61,20 +61,21 @@ const SemanticInput = ({
   ...rest
 }: Props) => {
   // construct field props
+  // define an erroneous field as a field that has been touched and is invalid
   const fieldProps = { disabled, error: touched && invalid, required, width }
+
+  // construct input props
+  // define the default placeholder to be equal to the label
+  const inputProps = { placeholder: label, ...rest }
 
   return (
     <Form.Field {...fieldProps}>
       {label &&
         <label forHtml={input.name}>
-          <FormattedMessage id={label} />
+          {label}
         </label>}
 
-      <input
-        {...input}
-        {...rest}
-        placeholder={(placeholder || label) && intl.formatMessage({ id: placeholder || label })}
-      />
+      <input {...input} {...inputProps} />
 
       {touched &&
         invalid &&

--- a/src/components/forms/components/SemanticInput.js
+++ b/src/components/forms/components/SemanticInput.js
@@ -1,0 +1,109 @@
+// @flow
+/* eslint-disable jsx-a11y/label-has-for */
+
+import React from 'react'
+import { Form, Icon } from 'semantic-ui-react'
+
+type Props = {
+  disabled?: boolean,
+  error?: boolean,
+  input: {
+    name: string,
+    value: string,
+    onBlur: () => mixed,
+    onChange: () => mixed,
+    onDragStart: () => mixed,
+    onDrop: () => mixed,
+    onFocus: () => mixed,
+  },
+  intl?: $IntlShape,
+  label: string,
+  meta: {
+    active: boolean,
+    asyncValidating: boolean,
+    autofilled: boolean,
+    dirty: boolean,
+    error: ?string,
+    form: string,
+    initial: ?string,
+    invalid: boolean,
+    pristine: boolean,
+    submitFailed: boolean,
+    submitting: boolean,
+    touched: boolean,
+    valid: boolean,
+    visited: boolean,
+    warning: ?string,
+    dispatch: () => mixed,
+  },
+  placeholder?: string,
+  required?: boolean,
+  width?: number,
+}
+
+const defaultProps = {
+  disabled: false,
+  error: undefined,
+  intl: undefined,
+  placeholder: undefined,
+  required: false,
+  width: undefined,
+}
+
+const SemanticInput = ({
+  disabled,
+  error,
+  input,
+  intl,
+  label,
+  meta: { error: metaError, invalid, touched },
+  placeholder,
+  required,
+  width,
+  ...rest
+}: Props) => {
+  // translate the label if intl was injected. otherwise use it directly.
+  const inputLabel = intl ? intl.formatMessage({ id: label }) : label
+
+  // calculate the error message
+  const errorContent = error || metaError
+  const errorMessage = intl ? intl.formatMessage({ id: errorContent }) : errorContent
+
+  // construct field props
+  const fieldProps = { disabled, error: error || (touched && metaError), required, width }
+
+  return (
+    <Form.Field {...fieldProps}>
+      {label &&
+        <label forHtml={input.name}>
+          {inputLabel}
+        </label>}
+
+      <input {...input} {...rest} placeholder={placeholder || inputLabel} />
+
+      {touched &&
+        invalid &&
+        <div className="errorMessage">
+          <Icon name="hand pointer" />
+          {errorMessage}
+        </div>}
+
+      <style jsx>{`
+        .errorMessage {
+          // TODO: improve styling
+          background-color: #fff6f6;
+          border: 1px solid #e0b4b4;
+          border-top: none;
+          box-shadow: 2px 2px 3px 0px rgba(0, 0, 0, 0.05);
+          color: #9f3a38;
+          font-size: .9rem;
+          padding: .3rem .5rem;
+        }
+      `}</style>
+    </Form.Field>
+  )
+}
+
+SemanticInput.defaultProps = defaultProps
+
+export default SemanticInput

--- a/src/components/forms/components/index.js
+++ b/src/components/forms/components/index.js
@@ -1,1 +1,3 @@
+/* eslint-disable import/prefer-default-export */
+
 export { default as SemanticInput } from './SemanticInput'

--- a/src/components/forms/components/index.js
+++ b/src/components/forms/components/index.js
@@ -1,0 +1,1 @@
+export { default as SemanticInput } from './SemanticInput'

--- a/src/components/layouts/StaticLayout.js
+++ b/src/components/layouts/StaticLayout.js
@@ -34,6 +34,8 @@ class StaticLayout extends Component {
           {children}
         </div>
 
+        <footer>&copy; IBF</footer>
+
         <style jsx global>{`
           * {
             font-family: 'Open Sans', sans-serif;
@@ -51,6 +53,12 @@ class StaticLayout extends Component {
             display: flex;
             flex-direction: column;
             min-height: 100vh;
+          }
+
+          footer {
+            background-color: lightgrey;
+            border-top: 2px solid orange;
+            padding: 1rem;
           }
         `}</style>
       </div>

--- a/src/components/layouts/StaticLayout.js
+++ b/src/components/layouts/StaticLayout.js
@@ -1,0 +1,61 @@
+// @flow
+
+import React, { Component } from 'react'
+import { Helmet } from 'react-helmet'
+
+import { createLinks, initLogging } from '../../lib'
+
+class StaticLayout extends Component {
+  props: {
+    children: any,
+    pageTitle: string,
+  }
+
+  state = {}
+
+  componentWillMount() {
+    // initialize sentry and logrocket (if appropriately configured)
+    initLogging()
+  }
+
+  render() {
+    const { children, pageTitle } = this.props
+
+    return (
+      <div className="staticLayout">
+        <Helmet>
+          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans'], ['reset'])}
+          <title>
+            {pageTitle}
+          </title>
+        </Helmet>
+
+        <div className="content">
+          {children}
+        </div>
+
+        <style jsx global>{`
+          * {
+            font-family: 'Open Sans', sans-serif;
+          }
+          html {
+            font-size: 16px;
+          }
+          body {
+            font-size: 1rem;
+          }
+        `}</style>
+
+        <style jsx>{`
+          .staticLayout {
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+          }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default StaticLayout

--- a/src/components/layouts/StaticLayout.js
+++ b/src/components/layouts/StaticLayout.js
@@ -24,7 +24,7 @@ class StaticLayout extends Component {
     return (
       <div className="staticLayout">
         <Helmet>
-          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans','reset'])}
+          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans', 'reset'])}
           <title>
             {pageTitle}
           </title>

--- a/src/components/layouts/StaticLayout.js
+++ b/src/components/layouts/StaticLayout.js
@@ -24,7 +24,7 @@ class StaticLayout extends Component {
     return (
       <div className="staticLayout">
         <Helmet>
-          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans'], ['reset'])}
+          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans','reset'])}
           <title>
             {pageTitle}
           </title>

--- a/src/components/layouts/StudentLayout.js
+++ b/src/components/layouts/StudentLayout.js
@@ -66,9 +66,14 @@ class StudentLayout extends Component {
     return (
       <div className="studentLayout">
         <Helmet>
-          {createLinks(
-            ['https://fonts.googleapis.com/css?family=Open Sans', 'reset', 'button', 'icon', 'menu', 'sidebar'],
-          )}
+          {createLinks([
+            'https://fonts.googleapis.com/css?family=Open Sans',
+            'reset',
+            'button',
+            'icon',
+            'menu',
+            'sidebar',
+          ])}
           <title>
             {pageTitle}
           </title>

--- a/src/components/layouts/StudentLayout.js
+++ b/src/components/layouts/StudentLayout.js
@@ -67,8 +67,7 @@ class StudentLayout extends Component {
       <div className="studentLayout">
         <Helmet>
           {createLinks(
-            ['https://fonts.googleapis.com/css?family=Open Sans'],
-            ['reset', 'button', 'icon', 'menu', 'sidebar'],
+            ['https://fonts.googleapis.com/css?family=Open Sans', 'reset', 'button', 'icon', 'menu', 'sidebar'],
           )}
           <title>
             {pageTitle}

--- a/src/components/layouts/TeacherLayout.js
+++ b/src/components/layouts/TeacherLayout.js
@@ -81,7 +81,7 @@ class TeacherLayout extends Component {
     return (
       <div className="teacherLayout">
         <Helmet>
-          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans'], ['reset'])}
+          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans','reset'])}
           <title>
             {pageTitle}
           </title>

--- a/src/components/layouts/TeacherLayout.js
+++ b/src/components/layouts/TeacherLayout.js
@@ -81,7 +81,7 @@ class TeacherLayout extends Component {
     return (
       <div className="teacherLayout">
         <Helmet>
-          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans','reset'])}
+          {createLinks(['https://fonts.googleapis.com/css?family=Open Sans', 'reset'])}
           <title>
             {pageTitle}
           </title>

--- a/src/components/questions/TagList.js
+++ b/src/components/questions/TagList.js
@@ -32,7 +32,7 @@ const TagList = ({ activeTags, data, handleTagClick }: Props) => {
   return (
     <List selection size="large">
       <Helmet>
-        {createLinks(undefined, ['list'])}
+        {createLinks(['list'])}
       </Helmet>
 
       {data.tags.map((tag) => {

--- a/src/lib/utils/__snapshots__/css.test.js.snap
+++ b/src/lib/utils/__snapshots__/css.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createLinks works with full urls 1`] = `
+Array [
+  <link
+    href="http://www.google.com"
+    rel="stylesheet"
+/>,
+]
+`;
+
+exports[`createLinks works with semantic components 1`] = `
+Array [
+  <link
+    href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/dropdown.min.css"
+    rel="stylesheet"
+/>,
+  <link
+    href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/header.min.css"
+    rel="stylesheet"
+/>,
+  <link
+    href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/menu.min.css"
+    rel="stylesheet"
+/>,
+]
+`;

--- a/src/lib/utils/css.js
+++ b/src/lib/utils/css.js
@@ -4,21 +4,18 @@
 
 import React from 'react'
 
-function createLinks(
-  linksFull?: Array<string> = [],
-  linksSemantic?: Array<string> = [],
-): Array<any> {
-  const links = [
-    ...linksFull,
-    ...linksSemantic.map(
-      file =>
-        `https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/${file}.min.css`,
-    ),
-  ]
-
-  const elements = links.map(link => <link key={link} rel="stylesheet" href={link} />)
-
-  return elements
+function createLinks(links: Array<string> = []): Array<*> {
+  return links.map(link =>
+    (<link
+      key={link}
+      rel="stylesheet"
+      href={
+        link.substr(0, 4) === 'http'
+          ? link
+          : `https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/${link}.min.css`
+      }
+    />),
+  )
 }
 
 export { createLinks }

--- a/src/lib/utils/css.test.js
+++ b/src/lib/utils/css.test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { createLinks } from './css'
+
+describe('createLinks', () => {
+  it('works with full urls', () => {
+    expect(createLinks(['http://www.google.com'])).toEqual([
+      <link rel="stylesheet" href="http://www.google.com" />,
+    ])
+  })
+
+  it('works with semantic components', () => {
+    expect(createLinks(['dropdown', 'header', 'menu'])).toEqual([
+      <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/dropdown.min.css"
+      />,
+      <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/header.min.css"
+      />,
+      <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/menu.min.css"
+      />,
+    ])
+  })
+})

--- a/src/lib/utils/css.test.js
+++ b/src/lib/utils/css.test.js
@@ -1,28 +1,11 @@
-import React from 'react'
-
 import { createLinks } from './css'
 
 describe('createLinks', () => {
   it('works with full urls', () => {
-    expect(createLinks(['http://www.google.com'])).toEqual([
-      <link rel="stylesheet" href="http://www.google.com" />,
-    ])
+    expect(createLinks(['http://www.google.com'])).toMatchSnapshot()
   })
 
   it('works with semantic components', () => {
-    expect(createLinks(['dropdown', 'header', 'menu'])).toEqual([
-      <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/dropdown.min.css"
-      />,
-      <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/header.min.css"
-      />,
-      <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/components/menu.min.css"
-      />,
-    ])
+    expect(createLinks(['dropdown', 'header', 'menu'])).toMatchSnapshot()
   })
 })

--- a/src/lib/withCSS.js
+++ b/src/lib/withCSS.js
@@ -1,0 +1,22 @@
+// @flow
+
+import React from 'react'
+import { Helmet } from 'react-helmet'
+
+import { createLinks } from './utils/css'
+
+function withCSS(WrappedComponent: any, links: Array<string>) {
+  const WithCSS = (props: any) =>
+    (<div>
+      <Helmet>
+        {createLinks(links)}
+      </Helmet>
+      <WrappedComponent {...props} />
+    </div>)
+
+  WithCSS.displayName = `WithCSS(${WrappedComponent.displayName || WrappedComponent.name})`
+
+  return WithCSS
+}
+
+export default withCSS

--- a/src/pages/user/__snapshots__/registration.test.js.snap
+++ b/src/pages/user/__snapshots__/registration.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Snapshot-Testing Works 1`] = `
+<div
+  className="staticLayout"
+  data-jsx={663962063}
+>
+  <div
+    className="content"
+    data-jsx={663962063}
+  >
+    <div
+      className="registration"
+      data-jsx={645662128}
+    >
+      hello world
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/user/__snapshots__/registration.test.js.snap
+++ b/src/pages/user/__snapshots__/registration.test.js.snap
@@ -3,18 +3,211 @@
 exports[`Snapshot-Testing Works 1`] = `
 <div
   className="staticLayout"
-  data-jsx={663962063}
+  data-jsx={2161656035}
 >
   <div
     className="content"
-    data-jsx={663962063}
+    data-jsx={2161656035}
   >
     <div
       className="registration"
-      data-jsx={645662128}
+      data-jsx={1990206599}
     >
-      hello world
+      <h1
+        data-jsx={1990206599}
+      >
+        <span>
+          Registration
+        </span>
+      </h1>
+      <form
+        className="ui form error"
+        data-jsx={2689033462}
+        onSubmit={[Function]}
+      >
+        <div
+          className="personal"
+          data-jsx={2689033462}
+        >
+          <div
+            className="field"
+          >
+            <label
+              data-jsx={2917643520}
+              forHtml="firstName"
+            >
+              First name
+            </label>
+            <input
+              data-jsx={2917643520}
+              name="firstName"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              placeholder="First name"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            className="field"
+          >
+            <label
+              data-jsx={2917643520}
+              forHtml="lastName"
+            >
+              Last name
+            </label>
+            <input
+              data-jsx={2917643520}
+              name="lastName"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              placeholder="Last name"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            className="required field"
+          >
+            <label
+              data-jsx={2917643520}
+              forHtml="email"
+            >
+              Email
+            </label>
+            <input
+              data-jsx={2917643520}
+              name="email"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              placeholder="Email"
+              type="email"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          className="account"
+          data-jsx={2689033462}
+        >
+          <div
+            className="required field"
+          >
+            <label
+              data-jsx={2917643520}
+              forHtml="shortname"
+            >
+              Shortname
+            </label>
+            <input
+              data-jsx={2917643520}
+              name="shortname"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              placeholder="Shortname"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            className="required field"
+          >
+            <label
+              data-jsx={2917643520}
+              forHtml="password"
+            >
+              Password
+            </label>
+            <input
+              data-jsx={2917643520}
+              name="password"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              placeholder="Password"
+              type="password"
+              value=""
+            />
+          </div>
+          <div
+            className="required field"
+          >
+            <label
+              data-jsx={2917643520}
+              forHtml="passwordRepeat"
+            >
+              Repeat password
+            </label>
+            <input
+              data-jsx={2917643520}
+              name="passwordRepeat"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              placeholder="Repeat password"
+              type="password"
+              value=""
+            />
+          </div>
+          <div
+            className="field"
+            data-jsx={2689033462}
+          >
+            <label
+              data-jsx={2689033462}
+              htmlFor="useCase"
+            >
+              <span>
+                Use case description
+              </span>
+            </label>
+            <textarea
+              name="useCase"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onDragStart={[Function]}
+              onDrop={[Function]}
+              onFocus={[Function]}
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            className="ui primary right floated button"
+            disabled={undefined}
+            onClick={[Function]}
+            tabIndex={undefined}
+            type="submit"
+          >
+            <span>
+              Submit
+            </span>
+          </button>
+        </div>
+      </form>
     </div>
   </div>
+  <footer
+    data-jsx={2161656035}
+  >
+    © IBF
+  </footer>
 </div>
 `;

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -1,14 +1,19 @@
 // @flow
 
 import React from 'react'
+import { Helmet } from 'react-helmet'
+import { Button, Segment } from 'semantic-ui-react'
+import { Field, reduxForm } from 'redux-form'
+import { FormattedMessage } from 'react-intl'
 
-import { withData, pageWithIntl } from '../../lib'
+import { createLinks, withData, pageWithIntl } from '../../lib'
 
 import StaticLayout from '../../components/layouts/StaticLayout'
 
 class Registration extends React.Component {
   props: {
     intl: $IntlShape,
+    handleSubmit: () => mixed,
   }
 
   state: {}
@@ -19,15 +24,105 @@ class Registration extends React.Component {
   }
 
   render() {
-    const { intl } = this.props
+    const { intl, handleSubmit } = this.props
 
     return (
       <StaticLayout>
         <div className="registration">
-          hello world
+          <Helmet>
+            {createLinks(['button', 'form', 'segment'])}
+          </Helmet>
+
+          <h1>
+            <FormattedMessage id="user.registration.title" defaultMessage="Registration" />
+          </h1>
+
+          <form className="ui form" onSubmit={handleSubmit}>
+            <div className="personal">
+              <div className="field">
+                <label htmlFor="firstName">
+                  <FormattedMessage id="common.string.firstname" defaultMessage="First name" />
+                </label>
+                <Field name="firstName" component="input" type="text" />
+              </div>
+              <div className="field">
+                <label htmlFor="lastName">
+                  <FormattedMessage id="common.string.lastName" defaultMessage="Last name" />
+                </label>
+                <Field name="lastName" component="input" type="text" />
+              </div>
+              <div className="field">
+                <label htmlFor="email">
+                  <FormattedMessage id="common.string.email" defaultMessage="Email" />
+                </label>
+                <Field name="email" component="input" type="email" />
+              </div>
+            </div>
+
+            <div className="account">
+              <div className="field">
+                <label htmlFor="shortName">
+                  <FormattedMessage id="common.string.shortName" defaultMessage="Shortname" />
+                </label>
+                <Field name="shortName" component="input" type="text" />
+              </div>
+              <div className="field">
+                <label htmlFor="password">
+                  <FormattedMessage id="common.string.password" defaultMessage="Password" />
+                </label>
+                <Field name="password" component="input" type="password" />
+              </div>
+              <div className="field">
+                <label htmlFor="passwordRepeat">
+                  <FormattedMessage
+                    id="common.string.passwordRepeat"
+                    defaultMessage="Repeat password"
+                  />
+                </label>
+                <Field name="passwordRepeat" component="input" type="password" />
+              </div>
+              <div className="field">
+                <label htmlFor="useCase">
+                  <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
+                </label>
+                <Field name="useCase" component="textarea" type="text" />
+              </div>
+
+              <Button primary floated="right" type="submit">
+                Submit
+              </Button>
+            </div>
+          </form>
+
           <style jsx>{`
             .registration {
+              padding: 0 1rem 1rem 1rem;
+            }
+
+            .form {
               display: flex;
+              flex-direction: column;
+            }
+
+            .account {
+              margin-top: 1rem;
+            }
+
+            @media all and (min-width: 768px) {
+              .form {
+                flex-flow: row wrap;
+              }
+              .personal,
+              .account {
+                flex: 1 1 50%;
+              }
+              .personal {
+                padding-right: .5rem;
+              }
+              .account {
+                margin: 0;
+                padding-left: .5rem;
+              }
             }
           `}</style>
         </div>
@@ -36,4 +131,8 @@ class Registration extends React.Component {
   }
 }
 
-export default withData(pageWithIntl(Registration))
+export default withData(
+  reduxForm({
+    form: 'registration',
+  })(pageWithIntl(Registration)),
+)

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -1,0 +1,39 @@
+// @flow
+
+import React from 'react'
+
+import { withData, pageWithIntl } from '../../lib'
+
+import StaticLayout from '../../components/layouts/StaticLayout'
+
+class Registration extends React.Component {
+  props: {
+    intl: $IntlShape,
+  }
+
+  state: {}
+
+  constructor(props) {
+    super(props)
+    this.state = {}
+  }
+
+  render() {
+    const { intl } = this.props
+
+    return (
+      <StaticLayout>
+        <div className="registration">
+          hello world
+          <style jsx>{`
+            .registration {
+              display: flex;
+            }
+          `}</style>
+        </div>
+      </StaticLayout>
+    )
+  }
+}
+
+export default withData(pageWithIntl(Registration))

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -1,14 +1,13 @@
 // @flow
 
 import React from 'react'
-import { Helmet } from 'react-helmet'
-import { Button, Segment } from 'semantic-ui-react'
-import { Field, reduxForm } from 'redux-form'
+import { reduxForm } from 'redux-form'
 import { FormattedMessage } from 'react-intl'
 
-import { createLinks, withData, pageWithIntl } from '../../lib'
+import { withData, pageWithIntl } from '../../lib'
 
 import StaticLayout from '../../components/layouts/StaticLayout'
+import RegistrationForm from '../../components/forms/RegistrationForm'
 
 class Registration extends React.Component {
   props: {
@@ -23,116 +22,38 @@ class Registration extends React.Component {
     this.state = {}
   }
 
+  handleSubmit = (values: any) => {
+    console.dir(values)
+  }
+
   render() {
-    const { intl, handleSubmit } = this.props
+    const { intl } = this.props
 
     return (
-      <StaticLayout>
+      <StaticLayout
+        pageTitle={intl.formatMessage({
+          defaultMessage: 'Registration',
+          id: 'user.registration.pageTitle',
+        })}
+      >
         <div className="registration">
-          <Helmet>
-            {createLinks(['button', 'form', 'segment'])}
-          </Helmet>
-
           <h1>
             <FormattedMessage id="user.registration.title" defaultMessage="Registration" />
           </h1>
 
-          <form className="ui form" onSubmit={handleSubmit}>
-            <div className="personal">
-              <div className="field">
-                <label htmlFor="firstName">
-                  <FormattedMessage id="common.string.firstname" defaultMessage="First name" />
-                </label>
-                <Field name="firstName" component="input" type="text" />
-              </div>
-              <div className="field">
-                <label htmlFor="lastName">
-                  <FormattedMessage id="common.string.lastName" defaultMessage="Last name" />
-                </label>
-                <Field name="lastName" component="input" type="text" />
-              </div>
-              <div className="field">
-                <label htmlFor="email">
-                  <FormattedMessage id="common.string.email" defaultMessage="Email" />
-                </label>
-                <Field name="email" component="input" type="email" />
-              </div>
-            </div>
-
-            <div className="account">
-              <div className="field">
-                <label htmlFor="shortName">
-                  <FormattedMessage id="common.string.shortName" defaultMessage="Shortname" />
-                </label>
-                <Field name="shortName" component="input" type="text" />
-              </div>
-              <div className="field">
-                <label htmlFor="password">
-                  <FormattedMessage id="common.string.password" defaultMessage="Password" />
-                </label>
-                <Field name="password" component="input" type="password" />
-              </div>
-              <div className="field">
-                <label htmlFor="passwordRepeat">
-                  <FormattedMessage
-                    id="common.string.passwordRepeat"
-                    defaultMessage="Repeat password"
-                  />
-                </label>
-                <Field name="passwordRepeat" component="input" type="password" />
-              </div>
-              <div className="field">
-                <label htmlFor="useCase">
-                  <FormattedMessage id="common.string.useCase" defaultMessage="Use case" />
-                </label>
-                <Field name="useCase" component="textarea" type="text" />
-              </div>
-
-              <Button primary floated="right" type="submit">
-                Submit
-              </Button>
-            </div>
-          </form>
+          <RegistrationForm onSubmit={this.handleSubmit} />
 
           <style jsx>{`
             .registration {
-              padding: 0 1rem 1rem 1rem;
+              padding: 1rem;
             }
-
-            .form {
-              display: flex;
-              flex-direction: column;
-            }
-
-            .account {
-              margin-top: 1rem;
-            }
-
-            @media all and (min-width: 768px) {
-              .form {
-                flex-flow: row wrap;
-              }
-              .personal,
-              .account {
-                flex: 1 1 50%;
-              }
-              .personal {
-                padding-right: .5rem;
-              }
-              .account {
-                margin: 0;
-                padding-left: .5rem;
-              }
+            h1 {
+              margin-top: 0;
             }
 
             @media all and (min-width: 991px) {
               .registration {
                 margin: 0 15%;
-              }
-
-              .form {
-                border: 1px solid lightgrey;
-                padding: 1rem;
               }
             }
           `}</style>

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react'
-import { reduxForm } from 'redux-form'
 import { FormattedMessage } from 'react-intl'
 
 import { withData, pageWithIntl } from '../../lib'
@@ -22,7 +21,7 @@ class Registration extends React.Component {
     this.state = {}
   }
 
-  handleSubmit = (values: any) => {
+  handleSubmit = (values) => {
     console.dir(values)
   }
 
@@ -63,8 +62,4 @@ class Registration extends React.Component {
   }
 }
 
-export default withData(
-  reduxForm({
-    form: 'registration',
-  })(pageWithIntl(Registration)),
-)
+export default withData(pageWithIntl(Registration))

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -2,27 +2,29 @@
 
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { graphql } from 'react-apollo'
 
 import { withData, pageWithIntl } from '../../lib'
 
 import StaticLayout from '../../components/layouts/StaticLayout'
 import RegistrationForm from '../../components/forms/RegistrationForm'
+import { RegistrationMutation } from '../../queries/mutations'
 
 class Registration extends React.Component {
   props: {
+    createUser: ({ variables: { email: string, password: string, shortname: string } }) => mixed,
     intl: $IntlShape,
     handleSubmit: () => mixed,
   }
 
-  state: {}
-
-  constructor(props) {
-    super(props)
-    this.state = {}
-  }
-
   handleSubmit = (values) => {
-    console.dir(values)
+    this.props.createUser({
+      variables: {
+        email: values.email,
+        password: values.password,
+        shortname: values.shortname,
+      },
+    })
   }
 
   render() {
@@ -62,4 +64,6 @@ class Registration extends React.Component {
   }
 }
 
-export default withData(pageWithIntl(Registration))
+export default withData(
+  pageWithIntl(graphql(RegistrationMutation, { name: 'createUser' })(Registration)),
+)

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -124,6 +124,17 @@ class Registration extends React.Component {
                 padding-left: .5rem;
               }
             }
+
+            @media all and (min-width: 991px) {
+              .registration {
+                margin: 0 15%;
+              }
+
+              .form {
+                border: 1px solid lightgrey;
+                padding: 1rem;
+              }
+            }
           `}</style>
         </div>
       </StaticLayout>

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -41,7 +41,7 @@ class Registration extends React.Component {
             <FormattedMessage id="user.registration.title" defaultMessage="Registration" />
           </h1>
 
-          <RegistrationForm onSubmit={this.handleSubmit} />
+          <RegistrationForm intl={intl} onSubmit={this.handleSubmit} />
 
           <style jsx>{`
             .registration {

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -4,11 +4,10 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { graphql } from 'react-apollo'
 
-import { withData, pageWithIntl } from '../../lib'
-
 import StaticLayout from '../../components/layouts/StaticLayout'
 import RegistrationForm from '../../components/forms/RegistrationForm'
 import { RegistrationMutation } from '../../queries/mutations'
+import { withData, pageWithIntl } from '../../lib'
 
 class Registration extends React.Component {
   props: {

--- a/src/pages/user/registration.test.js
+++ b/src/pages/user/registration.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import Registration from './registration'
+
+// HACK: workaround for https://github.com/Semantic-Org/Semantic-UI-React/issues/1702
+jest.mock('react-dom', () => ({
+  findDOMNode: jest.fn(() => {}),
+}))
+
+describe('Snapshot-Testing', () => {
+  it('Works', () => {
+    const component = renderer.create(<Registration />)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/queries/mutations.js
+++ b/src/queries/mutations.js
@@ -5,12 +5,15 @@ import { gql } from 'react-apollo'
 type RegistrationMutationType = {}
 
 const RegistrationMutation = gql`
-  mutation CreateUser($email: string!, $password: string!) {
-    createUser(authProvider: { email: { $email, $password } }) {
+  mutation CreateUser($email: String!, $password: String!, $shortname: String!) {
+    createUser(
+      authProvider: { email: { email: $email, password: $password } }
+      shortname: $shortname
+    ) {
       email
+      shortname
     }
   }
-
 `
 
 export { RegistrationMutation }

--- a/src/queries/mutations.js
+++ b/src/queries/mutations.js
@@ -1,1 +1,17 @@
-// TODO: mutations here
+// @flow
+
+import { gql } from 'react-apollo'
+
+type RegistrationMutationType = {}
+
+const RegistrationMutation = gql`
+  mutation CreateUser($email: string!, $password: string!) {
+    createUser(authProvider: { email: { $email, $password } }) {
+      email
+    }
+  }
+
+`
+
+export { RegistrationMutation }
+export type { RegistrationMutationType }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7471,6 +7471,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+validator@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-8.0.0.tgz#00d6ec230ab5d3353ab1174162a96462b947bdbd"
+
 vary@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"


### PR DESCRIPTION
**GENERAL**
- Implement frontend parts of user registration
  - New page on `/user/registration`
  - `RegistrationForm` component with form validation and translated error messages
  - Connected to Graph.cool using the createUser mutation
- Add a `StaticLayout` component for registration, login, landing page etc.
- Add `SemanticInput` component (first part of semantic-form-components 1.0.0)

**MISC**
- Optimize `createLinks` css helper
- (fix) Error with `.env` in entrypoint script

**DEPENDENCIES**
- Install `validator` (js string validation library)