### PR TITLE
[WIP] Improvements for recompose

### DIFF
--- a/src/pages/questions/create.js
+++ b/src/pages/questions/create.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import { compose, withHandlers, withProps } from 'recompose'
+import { compose, withHandlers, mapProps } from 'recompose'
 import { graphql } from 'react-apollo'
 import { intlShape } from 'react-intl'
 
@@ -18,7 +18,7 @@ const propTypes = {
   tags: PropTypes.array.isRequired,
 }
 
-const CreateQuestion = ({
+export const CreateQuestion = ({
   tags, intl, handleDiscard, handleSave,
 }) => (
   <TeacherLayout
@@ -43,8 +43,10 @@ CreateQuestion.propTypes = propTypes
 
 export default compose(
   withData,
-  pageWithIntl,
   graphql(TagListQuery),
+  mapProps(({ data }) => ({
+    tags: data.tags,
+  })),
   graphql(CreateQuestionMutation),
   withHandlers({
     // handle discarding a new question
@@ -77,7 +79,5 @@ export default compose(
       }
     },
   }),
-  withProps(({ data }) => ({
-    tags: data.tags,
-  })),
+  pageWithIntl,
 )(CreateQuestion)

--- a/src/pages/questions/index.js
+++ b/src/pages/questions/index.js
@@ -171,9 +171,8 @@ Index.propTypes = propTypes
 
 export default compose(
   withData,
-  pageWithIntl,
-  withState('creationMode', 'setCreationMode', false),
-  withState('droppedQuestions', 'setDroppedQuestions', []),
+  withState('creationMode', 'setCreationMode', false), // creationMode, setCreationMode
+  withState('droppedQuestions', 'setDroppedQuestions', []), // creationMode, setCreationMode, droppedQuestions, setDroppedQuestions
   withState('filters', 'setFilters', {
     tags: [],
     title: null,
@@ -221,20 +220,20 @@ export default compose(
         }
       }),
   }),
-  graphql(StartSessionMutation),
+  graphql(StartSessionMutation, { name: 'startSession' }),
+  graphql(CreateSessionMutation, { name: 'createSession' }),
   withHandlers({
     // handle starting an existing or newly created session
-    handleStartSession: ({ mutate }) => id =>
-      mutate({
+    handleStartSession: ({ startSession }) => id =>
+      startSession({
         refetchQueries: [{ query: RunningSessionQuery }],
         variables: { id },
       }),
   }),
-  graphql(CreateSessionMutation),
   withHandlers({
     // handle creating a new session
     handleCreateSession: ({
-      mutate,
+      createSession,
       handleCreationModeToggle,
       handleStartSession,
     }) => type => async ({ sessionName, questions }) => {
@@ -243,7 +242,7 @@ export default compose(
         const blocks = questions.map(question => ({ questions: [question.id] }))
 
         // create a new session
-        const result = await mutate({
+        const result = await createSession({
           refetchQueries: [{ query: SessionListQuery }],
           variables: { blocks, name: sessionName },
         })
@@ -261,4 +260,5 @@ export default compose(
       }
     },
   }),
+  pageWithIntl,
 )(Index)

--- a/src/pages/sessions/running.js
+++ b/src/pages/sessions/running.js
@@ -146,13 +146,14 @@ export default compose(
       <LoadingTeacherLayout intl={intl} pageId="runningSession" title="Running Session" />
     )),
   ),
-  graphql(EndSessionMutation),
+  graphql(EndSessionMutation, { name: 'endSession' }),
+  graphql(UpdateSessionSettingsMutation, { name: 'updateSessionSettings' }),
   withHandlers({
     // handle ending the currently running session
-    handleEndSession: ({ data, mutate }) => async () => {
+    handleEndSession: ({ data, endSession }) => async () => {
       try {
         // run the mutation
-        await mutate({
+        await endSession({
           refetchQueries: [{ query: RunningSessionQuery }],
           variables: { id: data.user.runningSession.id },
         })
@@ -164,12 +165,11 @@ export default compose(
         console.error(message)
       }
     },
-  }),
-  graphql(UpdateSessionSettingsMutation),
-  withHandlers({
-    handleUpdateSettings: ({ data, mutate }) => ({ settings }) => async () => {
+
+    // handle session settings updates
+    handleUpdateSettings: ({ data, updateSessionSettings }) => ({ settings }) => async () => {
       try {
-        await mutate({
+        await updateSessionSettings({
           variables: { sessionId: data.user.runningSession.id, settings },
         })
       } catch ({ message }) {


### PR DESCRIPTION
Improve usage of recompose and structure of `compose()` calls

**GENERAL**
- [ ] Always use pageWithIntl last in the "pipeline"
- [ ] Make use of mapProps instead of withProps wherever possible
- [ ] Change naming of graphql `mutate` with options instead of using multiple withHandlers