### PR TITLE
Session List Enhancement

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -2,6 +2,9 @@
 $breakpoint-tablet: 768px;
 $breakpoint-desktop: 991px;
 
+// max width for question pool and session list
+$max-width: 1280px;
+
 // colors
 $color-primary: rgb(124, 184, 228); //7cb8e4 // 7cb8e4 // ff9c5a
 $color-primary-50p: rgba($color-primary, 0.5);

--- a/src/components/__snapshots__/storyshots.test.js.snap
+++ b/src/components/__snapshots__/storyshots.test.js.snap
@@ -4620,6 +4620,17 @@ exports[`Storyshots sessions SessionList 1`] = `
       No session is currently running.
     </span>
   </div>
+  <h2
+    className="jsx-1740248303"
+  >
+    <span>
+      Remaining sessions
+    </span>
+     
+    (
+    2
+    )
+  </h2>
   <div
     className="jsx-1740248303 session"
   >

--- a/src/components/__snapshots__/storyshots.test.js.snap
+++ b/src/components/__snapshots__/storyshots.test.js.snap
@@ -4611,20 +4611,20 @@ exports[`Storyshots sessions Session 1`] = `
 
 exports[`Storyshots sessions SessionList 1`] = `
 <div
-  className="jsx-1740248303"
+  className="jsx-3452742146"
 >
   <div
-    className="jsx-1740248303 session"
+    className="jsx-3452742146 session"
   >
     <span>
       No session is currently running.
     </span>
   </div>
   <h2
-    className="jsx-1740248303"
+    className="jsx-3452742146"
   >
     <span>
-      Remaining sessions
+      Planned sessions
     </span>
      
     (
@@ -4632,7 +4632,7 @@ exports[`Storyshots sessions SessionList 1`] = `
     )
   </h2>
   <div
-    className="jsx-1740248303 session"
+    className="jsx-3452742146 session"
   >
     <div
       className="jsx-2209149579 session"
@@ -4766,7 +4766,7 @@ exports[`Storyshots sessions SessionList 1`] = `
     </div>
   </div>
   <div
-    className="jsx-1740248303 session"
+    className="jsx-3452742146 session"
   >
     <div
       className="jsx-2209149579 session"

--- a/src/components/layouts/TeacherLayout.js
+++ b/src/components/layouts/TeacherLayout.js
@@ -50,8 +50,8 @@ const TeacherLayout = ({
     },
     {
       href: '/sessions',
-      label: <FormattedMessage defaultMessage="Sessions" id="teacher.sessionHistory.title" />,
-      name: 'sessionHistory',
+      label: <FormattedMessage defaultMessage="Session List" id="teacher.sessionList.title" />,
+      name: 'sessionList',
     },
     {
       href: '/sessions/running',

--- a/src/components/sessions/Session.js
+++ b/src/components/sessions/Session.js
@@ -29,7 +29,7 @@ const Session = ({
   <div className="session">
     <h2 className="title">{name}</h2>
     <div className="date">
-      <FormattedMessage defaultMessage="Created on" id="sessionHistory.string.createdOn" />{' '}
+      <FormattedMessage defaultMessage="Created on" id="sessionList.string.createdOn" />{' '}
       {moment(createdAt).format('DD.MM.YYYY HH:MM')}
     </div>
 

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -27,9 +27,22 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
     return <div>{error}</div>
   }
 
+  const sessionsAvailable = sessions.length !== 0
+
   return (
     <div>
-      {runningSession ? (
+      {!sessionsAvailable ? (
+        <div className="session">
+          <FormattedMessage
+            defaultMessage="No session was found."
+            id="sessionList.string.noSessions"
+          />
+        </div>
+      ) : (
+        []
+      )}
+
+      {sessionsAvailable && runningSession ? (
         <div className="session running">
           <h2>
             <FormattedMessage
@@ -40,12 +53,18 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           <Session {...runningSession} />
         </div>
       ) : (
+        []
+      )}
+
+      {sessionsAvailable && !runningSession ? (
         <div className="session">
           <FormattedMessage
             defaultMessage="No session is currently running."
             id="sessionList.string.noSessionRunning"
           />
         </div>
+      ) : (
+        []
       )}
 
       {runningSession && (

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -34,7 +34,7 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           <h2>
             <FormattedMessage
               defaultMessage="Running session"
-              id="sessionHistory.title.runningSession"
+              id="sessionList.title.runningSession"
             />
           </h2>
           <Session {...runningSession} />
@@ -43,7 +43,7 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
         <div className="session">
           <FormattedMessage
             defaultMessage="No session is currently running."
-            id="sessionHistory.string.noSessionRunning"
+            id="sessionList.string.noSessionRunning"
           />
         </div>
       )}
@@ -52,7 +52,7 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
         <h2>
           <FormattedMessage
             defaultMessage="Remaining sessions"
-            id="sessionHistory.title.remainingSessions"
+            id="sessionList.title.remainingSessions"
           />
         </h2>
       )}

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -27,7 +27,12 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
     return <div>{error}</div>
   }
 
+  const remainingSessions = sessions.filter(session => session.status === 'CREATED')
+  const completedSessions = sessions.filter(session => session.status === 'COMPLETED')
+
   const sessionsAvailable = sessions.length !== 0
+  const remainingSessionsAvailable = remainingSessions.length !== 0
+  const completedSessionsAvailable = completedSessions.length !== 0
 
   return (
     <div>
@@ -67,7 +72,7 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
         []
       )}
 
-      {runningSession && (
+      {remainingSessionsAvailable && (
         <h2>
           <FormattedMessage
             defaultMessage="Remaining sessions"
@@ -75,9 +80,23 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           />
         </h2>
       )}
+      {remainingSessionsAvailable &&
+        remainingSessions.map(session => (
+          <div className="session" key={session.id}>
+            <Session {...session} />
+          </div>
+        ))}
 
-      {sessionsAvailable &&
-        sessions.filter(session => session.status !== 'RUNNING').map(session => (
+      {completedSessionsAvailable && (
+        <h2>
+          <FormattedMessage
+            defaultMessage="Completed sessions"
+            id="sessionList.title.CompletedSessions"
+          />
+        </h2>
+      )}
+      {completedSessionsAvailable &&
+        completedSessions.map(session => (
           <div className="session" key={session.id}>
             <Session {...session} />
           </div>

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -77,7 +77,8 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           <FormattedMessage
             defaultMessage="Remaining sessions"
             id="sessionList.title.remainingSessions"
-          />
+          />{' '}
+          ({remainingSessions.length})
         </h2>
       )}
       {remainingSessionsAvailable &&
@@ -92,7 +93,8 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           <FormattedMessage
             defaultMessage="Completed sessions"
             id="sessionList.title.CompletedSessions"
-          />
+          />{' '}
+          ({completedSessions.length})
         </h2>
       )}
       {completedSessionsAvailable &&

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -75,11 +75,13 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           />
         </h2>
       )}
-      {sessions.map(session => (
-        <div className="session" key={session.id}>
-          <Session {...session} />
-        </div>
-      ))}
+
+      {sessionsAvailable &&
+        sessions.filter(session => session.status !== 'RUNNING').map(session => (
+          <div className="session" key={session.id}>
+            <Session {...session} />
+          </div>
+        ))}
 
       <style jsx>{`
         @import 'src/theme';

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -48,14 +48,16 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
       )}
 
       {sessionsAvailable && runningSession ? (
-        <div className="session running">
+        <div className="runningSession">
           <h2>
             <FormattedMessage
               defaultMessage="Running session"
               id="sessionList.title.runningSession"
             />
           </h2>
-          <Session {...runningSession} />
+          <div className="session">
+            <Session {...runningSession} />
+          </div>
         </div>
       ) : (
         []
@@ -75,8 +77,8 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
       {remainingSessionsAvailable && (
         <h2>
           <FormattedMessage
-            defaultMessage="Remaining sessions"
-            id="sessionList.title.remainingSessions"
+            defaultMessage="Planned sessions"
+            id="sessionList.title.plannedSessions"
           />{' '}
           ({remainingSessions.length})
         </h2>
@@ -92,7 +94,7 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
         <h2>
           <FormattedMessage
             defaultMessage="Completed sessions"
-            id="sessionList.title.CompletedSessions"
+            id="sessionList.title.completedSessions"
           />{' '}
           ({completedSessions.length})
         </h2>
@@ -116,9 +118,7 @@ export const SessionListPres = ({ error, runningSession, sessions }) => {
           background-color: #f9f9f9;
         }
 
-        .session.running {
-          padding: 0.5rem;
-
+        .runningSession > .session {
           background-color: $background-color;
           border: 1px solid $color-primary;
         }

--- a/src/pages/sessions/index.js
+++ b/src/pages/sessions/index.js
@@ -32,17 +32,17 @@ const Index = ({
         sortOrder: '',
       },
       title: intl.formatMessage({
-        defaultMessage: 'Sessions',
-        id: 'teacher.sessionHistory.title',
+        defaultMessage: 'Session List',
+        id: 'teacher.sessionList.title',
       }),
     }}
     pageTitle={intl.formatMessage({
-      defaultMessage: 'Sessions',
-      id: 'teacher.sessionHistory.pageTitle',
+      defaultMessage: 'Session List',
+      id: 'teacher.sessionList.pageTitle',
     })}
-    sidebar={{ activeItem: 'sessionHistory' }}
+    sidebar={{ activeItem: 'sessionList' }}
   >
-    <div className="sessionHistory">
+    <div className="sessionList">
       <SessionList
         handleCopySession={handleCopySession}
         handleStartSession={handleStartSession}
@@ -53,18 +53,18 @@ const Index = ({
     <style jsx>{`
       @import 'src/theme';
 
-      .sessionHistory {
+      .sessionList {
         padding: 1rem 0.7rem;
       }
 
       @include desktop-tablet-only {
-        .sessionHistory {
+        .sessionList {
           padding: 2rem;
         }
       }
 
       @include desktop-only {
-        .sessionHistory {
+        .sessionList {
           padding: 2rem 10%;
         }
       }

--- a/src/pages/sessions/index.js
+++ b/src/pages/sessions/index.js
@@ -59,13 +59,10 @@ const Index = ({
 
       @include desktop-tablet-only {
         .sessionList {
+          margin: auto;
           padding: 2rem;
-        }
-      }
 
-      @include desktop-only {
-        .sessionList {
-          padding: 2rem 10%;
+          max-width: $max-width;
         }
       }
     `}</style>


### PR DESCRIPTION
This PR enhances the session handling within the session list for lecturers.

**GENERAL**
- The session list is now consequently called session list (no more sessions or session history).
- The width is set to a maximum of 1280px.
- A message is displayed if no sessions are available.
- If a session is running it is no longer shown as a remaining session.
- The sessions within the session list are grouped by their status to running, remaining and completed sessions.
- A counter indicates the number of remaining and completed sessions.