### PR TITLE
Confusion Barometer

### DIFF
--- a/src/components/__snapshots__/storyshots.test.js.snap
+++ b/src/components/__snapshots__/storyshots.test.js.snap
@@ -284,7 +284,7 @@ exports[`Storyshots common/navbar Navbar 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-4219433326"
+            className="jsx-1862355618"
             href="/sessions/running"
           >
             <button
@@ -396,7 +396,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-4219433326"
+      className="jsx-1862355618"
       href="/sessions/running"
     >
       <button

--- a/src/components/common/navbar/SessionArea.js
+++ b/src/components/common/navbar/SessionArea.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Icon, Menu, Popup } from 'semantic-ui-react'
+import { Button, Icon, Menu, Popup, List } from 'semantic-ui-react'
 import { intlShape, FormattedMessage } from 'react-intl'
 
 const propTypes = {
@@ -12,6 +12,51 @@ const propTypes = {
 const defaultProps = {
   runtime: undefined,
   sessionId: undefined,
+}
+
+const changelog = {
+  new: [
+    {
+      items: [
+        'Multiple-choice questions can be created and evaluated.',
+        'One can define solutions for SC- and MC-questions and display them while presenting the results (optional).',
+        'More advanced visualizations for all question types, including word clouds and aggregated tables.',
+      ],
+      text: 'Extended question types and visualizations',
+    },
+    {
+      items: [
+        'Questions can be grouped into sessions and question blocks.',
+        'Each session could e.g. correspond to a single lecture.',
+        'A question block is part of a session and represents a group of questions that are evaluated simultaneously.',
+        'The parts of a session are activated on a predefined timeline.',
+      ],
+      text: 'Sessions & question blocks',
+    },
+    {
+      items: [
+        'The new feedback channel enables the collection of open text feedbacks over the course of the entire session (optional).',
+        'It also allows the students to give feedback on the speed and difficulty of the session at any point in time (optional).',
+      ],
+      text: 'Feedback-Channel (experimental)',
+    },
+    {
+      items: [
+        'Currently supported languages are English and German.',
+        'The tool is easily translateable to other languages (open-source).',
+      ],
+      text: 'Support for multiple languages',
+    },
+  ],
+  upcoming: [
+    { text: 'Advanced session management (quick creation, copying and other modifications).' },
+    {
+      text:
+        'On-the-fly modification of running sessions (e.g., adding questions while a session is already running and starting "empty" sessions).',
+    },
+    { text: 'Overall improvements for performance and user experience.' },
+    { text: 'Open-source documentation to encourage collaboration.' },
+  ],
 }
 
 const SessionArea = ({ intl, runtime, sessionId }) => (
@@ -45,22 +90,48 @@ const SessionArea = ({ intl, runtime, sessionId }) => (
     >
       <Popup.Content>
         <div className="popupContent">
-          <h3>Latest release</h3>
-          <ul>
-            <li>bla</li>
-          </ul>
+          <h3>New features (major)</h3>
+          <List bulleted>
+            {changelog.new.map(({ text, items }) => (
+              <List.Item>
+                {items ? <h4>{text}</h4> : text}
+                {items && <List.List>{items.map(item => <List.Item>{item}</List.Item>)}</List.List>}
+              </List.Item>
+            ))}
+          </List>
 
           <h3>Upcoming features</h3>
-          <ul>
-            <li>hello world integration</li>
-          </ul>
+          <List bulleted>
+            {changelog.upcoming.map(({ text, items }) => (
+              <List.Item>
+                {items ? <h4>{text}</h4> : text}
+                {items && <List.List>{items.map(item => <List.Item>{item}</List.Item>)}</List.List>}
+              </List.Item>
+            ))}
+          </List>
+          <p>
+            <strong>
+              A public roadmap will be made available and will show the planned features in more
+              detail.
+            </strong>
+          </p>
         </div>
       </Popup.Content>
     </Popup>
 
     <style jsx>{`
+      h3 {
+        font-size: 1.2rem;
+      }
+
+      h4 {
+        font-size: 1rem;
+        margin: 0;
+      }
+
       .popupContent {
-        padding: 1rem;
+        padding: 0;
+        width: 35rem;
       }
     `}</style>
   </React.Fragment>

--- a/src/components/common/navbar/SessionArea.js
+++ b/src/components/common/navbar/SessionArea.js
@@ -48,13 +48,14 @@ const changelog = {
       text: 'Support for multiple languages',
     },
   ],
-  upcoming: [
+  planned: [
+    { text: 'Many overall improvements for performance and user experience.' },
     { text: 'Advanced session management (quick creation, copying and other modifications).' },
     {
       text:
         'On-the-fly modification of running sessions (e.g., adding questions while a session is already running and starting "empty" sessions).',
     },
-    { text: 'Overall improvements for performance and user experience.' },
+
     { text: 'Open-source documentation to encourage collaboration.' },
   ],
 }
@@ -100,9 +101,9 @@ const SessionArea = ({ intl, runtime, sessionId }) => (
             ))}
           </List>
 
-          <h3>Upcoming features</h3>
+          <h3>Planned features</h3>
           <List bulleted>
-            {changelog.upcoming.map(({ text, items }) => (
+            {changelog.planned.map(({ text, items }) => (
               <List.Item>
                 {items ? <h4>{text}</h4> : text}
                 {items && <List.List>{items.map(item => <List.Item>{item}</List.Item>)}</List.List>}

--- a/src/components/confusion/ConfusionBarometer.js
+++ b/src/components/confusion/ConfusionBarometer.js
@@ -4,6 +4,7 @@ import { Checkbox } from 'semantic-ui-react'
 import { FormattedMessage, intlShape } from 'react-intl'
 import { compose, withProps } from 'recompose'
 import _sumBy from 'lodash/sumBy'
+import moment from 'moment'
 
 import ConfusionSection from './ConfusionSection'
 
@@ -49,8 +50,8 @@ const ConfusionBarometer = ({
         return (
           <React.Fragment>
             <ConfusionSection
-              data={confusionTS.map(({ createdAt, difficulty, difficultyRunning }) => ({
-                timestamp: createdAt,
+              data={confusionTS.map(({ timestamp, difficulty, difficultyRunning }) => ({
+                timestamp,
                 value: difficulty,
                 valueRunning: difficultyRunning,
               }))}
@@ -60,8 +61,8 @@ const ConfusionBarometer = ({
               })}
             />
             <ConfusionSection
-              data={confusionTS.map(({ createdAt, speed, speedRunning }) => ({
-                timestamp: createdAt,
+              data={confusionTS.map(({ timestamp, speed, speedRunning }) => ({
+                timestamp,
                 value: speed,
                 valueRunning: speedRunning,
               }))}
@@ -132,11 +133,11 @@ export default compose(
       return [
         ...acc,
         {
-          createdAt,
           difficulty,
-          speed,
           difficultyRunning,
+          speed,
           speedRunning,
+          timestamp: moment(createdAt).format('H:mm:ss'),
         },
       ]
     }, []),

--- a/src/components/confusion/ConfusionBarometer.js
+++ b/src/components/confusion/ConfusionBarometer.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Checkbox } from 'semantic-ui-react'
 import { FormattedMessage, intlShape } from 'react-intl'
+import { compose, withProps } from 'recompose'
+import _sumBy from 'lodash/sumBy'
 
 import ConfusionSection from './ConfusionSection'
 
@@ -47,9 +49,10 @@ const ConfusionBarometer = ({
         return (
           <React.Fragment>
             <ConfusionSection
-              data={confusionTS.map(({ createdAt, difficulty }) => ({
+              data={confusionTS.map(({ createdAt, difficulty, difficultyRunning }) => ({
                 timestamp: createdAt,
                 value: difficulty,
+                valueRunning: difficultyRunning,
               }))}
               title={intl.formatMessage({
                 defaultMessage: 'Difficulty',
@@ -57,9 +60,10 @@ const ConfusionBarometer = ({
               })}
             />
             <ConfusionSection
-              data={confusionTS.map(({ createdAt, speed }) => ({
+              data={confusionTS.map(({ createdAt, speed, speedRunning }) => ({
                 timestamp: createdAt,
                 value: speed,
+                valueRunning: speedRunning,
               }))}
               title={intl.formatMessage({
                 defaultMessage: 'Speed',
@@ -116,4 +120,25 @@ const ConfusionBarometer = ({
 ConfusionBarometer.propTypes = propTypes
 ConfusionBarometer.defaultProps = defaultProps
 
-export default ConfusionBarometer
+export default compose(
+  withProps(({ confusionTS }) => ({
+    confusionTS: confusionTS.reduce((acc, { createdAt, speed, difficulty }) => {
+      const tempAcc = [...acc, { difficulty, speed }]
+
+      // calculate the running average for difficulty and speed
+      const difficultyRunning = _sumBy(tempAcc, 'difficulty') / tempAcc.length
+      const speedRunning = _sumBy(tempAcc, 'speed') / tempAcc.length
+
+      return [
+        ...acc,
+        {
+          createdAt,
+          difficulty,
+          speed,
+          difficultyRunning,
+          speedRunning,
+        },
+      ]
+    }, []),
+  })),
+)(ConfusionBarometer)

--- a/src/components/confusion/ConfusionSection.js
+++ b/src/components/confusion/ConfusionSection.js
@@ -7,7 +7,6 @@ import {
   ResponsiveContainer,
   XAxis,
   YAxis,
-  Legend,
   CartesianGrid,
 } from 'recharts'
 import { FormattedMessage } from 'react-intl'
@@ -39,18 +38,22 @@ const ConfusionSection = ({ data, title }) => (
             <LineChart
               data={data}
               margin={{
-                top: 0,
-                right: 0,
-                left: 0,
                 bottom: 0,
+                left: 0,
+                right: 0,
+                top: 0,
               }}
             >
-              <CartesianGrid strokeDasharray="3 3" />
-              <Legend />
-              <XAxis dataKey="createdAt" />
-              <YAxis domain={[-5, 5]} ticks={[-5, 0, 5]} />
+              <CartesianGrid strokeDasharray="5 5" />
+              <XAxis dataKey="timestamp" padding={{ right: 10 }} />
+              <YAxis
+                domain={[-5, 5]}
+                minTickGap={1}
+                padding={{ bottom: 10, top: 10 }}
+                ticks={[-5, -3, -1, 1, 3, 5]}
+              />
               <ReferenceLine stroke="red" y={0} />
-              <Line dataKey="value" name="value" stroke="#8884d8" type="step" />
+              <Line dataKey="value" stroke="lightgrey" type="monotone" />
               <Line dataKey="valueRunning" name="running average" stroke="green" type="monotone" />
             </LineChart>
           </ResponsiveContainer>

--- a/src/components/confusion/ConfusionSection.js
+++ b/src/components/confusion/ConfusionSection.js
@@ -1,6 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Line, LineChart, ReferenceLine, ResponsiveContainer, XAxis, YAxis } from 'recharts'
+import {
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  Legend,
+  CartesianGrid,
+} from 'recharts'
 import { FormattedMessage } from 'react-intl'
 
 const propTypes = {
@@ -27,11 +36,22 @@ const ConfusionSection = ({ data, title }) => (
         // otherwise render a chart
         return (
           <ResponsiveContainer>
-            <LineChart data={data}>
-              <XAxis dataKey="timestamp" />
-              <YAxis domain={[-5, 5]} />
+            <LineChart
+              data={data}
+              margin={{
+                top: 0,
+                right: 0,
+                left: 0,
+                bottom: 0,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <Legend />
+              <XAxis dataKey="createdAt" />
+              <YAxis domain={[-5, 5]} ticks={[-5, 0, 5]} />
               <ReferenceLine stroke="red" y={0} />
-              <Line dataKey="value" stroke="#8884d8" type="monotone" />
+              <Line dataKey="value" name="value" stroke="#8884d8" type="step" />
+              <Line dataKey="valueRunning" name="running average" stroke="green" type="monotone" />
             </LineChart>
           </ResponsiveContainer>
         )
@@ -42,6 +62,8 @@ const ConfusionSection = ({ data, title }) => (
       .confusionSection {
         display: flex;
         flex-direction: column;
+
+        height: 15rem;
 
         .chart {
           flex: 1;

--- a/src/components/feedbacks/FeedbackChannel.js
+++ b/src/components/feedbacks/FeedbackChannel.js
@@ -57,7 +57,7 @@ const FeedbackChannel = ({
         disabled={!isActive}
         label={intl.formatMessage({
           defaultMessage: 'Publish questions',
-          id: 'runningSession.feedbackChannel.string.publishQuestions',
+          id: 'runningSession.feedbackChannel.publishQuestions',
         })}
         value={isPublic}
         onChange={handlePublicToggle}

--- a/src/components/questions/creation/ContentInput.js
+++ b/src/components/questions/creation/ContentInput.js
@@ -36,9 +36,6 @@ const ContentInput = ({ input: { value, onChange }, meta: { dirty, invalid }, di
       <textarea disabled={disabled} name="content" value={value} onChange={onChange} />
     </Form.Field>
 
-    <ReactTooltip delayHide={250} id="contentHelp" place="right">
-      <span>Enter the question to ask the audience.</span>
-    </ReactTooltip>
     <style jsx>{`
       @import 'src/theme';
 

--- a/src/components/sessions/SessionTimeline.js
+++ b/src/components/sessions/SessionTimeline.js
@@ -30,7 +30,7 @@ const getMessage = (intl, num, max) => {
     return {
       icon: 'play',
       label: intl.formatMessage({
-        defaultMessage: 'Start session',
+        defaultMessage: 'Open first block',
         id: 'runningSession.button.start',
       }),
     }

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -42,7 +42,7 @@
   "createQuestion.titleInput.label": "Fragetitel",
   "createQuestion.titleInput.tooltip":
     "Geben Sie einen kurzen, zusammenfassenden Titel für die Frage ein. Dieser dient lediglich zur besseren Übersicht.",
-  "questionDetails.usageHistory": "Verwendungsübersicht",
+  "questionDetails.usageHistory": "Verwendet am",
   "questionDetails.button.view": "Ansehen",
   "questionDetails.button.edit": "Editieren",
   "questionList.string.noQuestions": "Sie haben noch keine Fragen erstellt.",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -101,5 +101,13 @@
   "form.shortname.invalid": "Bitte ein gültiges Accountkürzel angeben (3-6 Zeichen).",
   "form.passwordRepeat.invalid": "Bitte sicherstellen, dass Passwörter übereinstimmen.",
   "form.institution.invalid": "Bitte eine gültige Institution angeben.",
-  "runningSession.noRunningSession": "Momentan läuft keine Session.."
+  "runningSession.noRunningSession": "Momentan läuft keine Session..",
+  "runningSession.button.start": "Ersten Frageblock aktivieren",
+  "runningSession.button.closeBlock": "Aktiven Frageblock schliessen",
+  "runningSession.button.finish": "Session beenden",
+  "runningSession.button.openBlock": "Nächsten Frageblock aktivieren",
+  "runningSession.confusion.difficulty": "Schwierigkeit",
+  "runningSession.confusion.speed": "Geschwindigkeit",
+  "common.string.activated": "Aktiviert",
+  "runningSession.feedbackChannel.publishQuestions": "Feedbacks veröffentlichen"
 }

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -100,5 +100,6 @@
   "form.password.invalid": "Bitte ein gültiges Passwort angeben (8+ Zeichen).",
   "form.shortname.invalid": "Bitte ein gültiges Accountkürzel angeben (3-6 Zeichen).",
   "form.passwordRepeat.invalid": "Bitte sicherstellen, dass Passwörter übereinstimmen.",
-  "form.institution.invalid": "Bitte eine gültige Institution angeben."
+  "form.institution.invalid": "Bitte eine gültige Institution angeben.",
+  "runningSession.noRunningSession": "Momentan läuft keine Session.."
 }

--- a/src/pages/join.js
+++ b/src/pages/join.js
@@ -221,7 +221,7 @@ export default compose(
   graphql(AddFeedbackMutation, { name: 'newFeedback' }),
   graphql(AddResponseMutation, { name: 'newResponse' }),
   withProps(({ newConfusionTS }) => ({
-    newConfusionTS: _throttle(newConfusionTS, 10000, { trailing: true }),
+    newConfusionTS: _throttle(newConfusionTS, 4000, { trailing: true }),
   })),
   withHandlers({
     // handle creation of a new confusion timestep

--- a/src/pages/sessions/running.js
+++ b/src/pages/sessions/running.js
@@ -182,7 +182,12 @@ export default compose(
     ({ data }) => data.loading || !data.runningSession,
     renderComponent(({ intl }) => (
       <LoadingTeacherLayout intl={intl} pageId="runningSession">
-        <Messager intl={intl} message="No currently running session..." />
+        <Messager
+          message={intl.formatMessage({
+            defaultMessage: 'No currently running session...',
+            id: 'runningSession.noRunningSession',
+          })}
+        />
       </LoadingTeacherLayout>
     )),
   ),


### PR DESCRIPTION
Improvements for the confusion barometer.

**GENERAL**
- Implement calculation of a running average from the confusion data.
- Improve layout for confusion sections.
- Reduce throttle for confusion to 4s.

**MISC**
- Remove second tooltip for question creation content.
- Add translation for missing running session.
- Add draft for the "Updates" changelog.
