### PR TITLE
Small fixes

### DIFF
--- a/src/components/__snapshots__/storyshots.test.js.snap
+++ b/src/components/__snapshots__/storyshots.test.js.snap
@@ -1322,10 +1322,10 @@ exports[`Storyshots evaluation/components Chart 1`] = `
 exports[`Storyshots evaluation/components EvaluationListItem 1`] = `
 <div>
   <div
-    className="jsx-725384191 evaluationListItem"
+    className="jsx-3000948528 evaluationListItem"
   >
     <div
-      className="jsx-725384191 colorSquare"
+      className="jsx-3000948528 colorSquare"
     >
       <i
         aria-hidden="true"
@@ -1333,21 +1333,21 @@ exports[`Storyshots evaluation/components EvaluationListItem 1`] = `
       />
     </div>
     <div
-      className="jsx-725384191 content"
+      className="jsx-3000948528 content"
     >
       hello world
     </div>
     <div
-      className="jsx-725384191 marker"
+      className="jsx-3000948528 marker"
     >
       MIN
     </div>
   </div>
   <div
-    className="jsx-610594514 evaluationListItem"
+    className="jsx-3664683677 evaluationListItem"
   >
     <div
-      className="jsx-610594514 colorSquare"
+      className="jsx-3664683677 colorSquare"
     >
       <i
         aria-hidden="true"
@@ -1355,30 +1355,30 @@ exports[`Storyshots evaluation/components EvaluationListItem 1`] = `
       />
     </div>
     <div
-      className="jsx-610594514 content"
+      className="jsx-3664683677 content"
     >
       hello world 2
     </div>
   </div>
   <div
-    className="jsx-91056044 evaluationListItem"
+    className="jsx-3779267427 evaluationListItem"
   >
     <div
-      className="jsx-91056044 content"
+      className="jsx-3779267427 content"
     >
       hello world 3
     </div>
     <div
-      className="jsx-91056044 marker"
+      className="jsx-3779267427 marker"
     >
       MAX
     </div>
   </div>
   <div
-    className="jsx-91056044 evaluationListItem"
+    className="jsx-3779267427 evaluationListItem"
   >
     <div
-      className="jsx-91056044 content"
+      className="jsx-3779267427 content"
     >
       hello world 4
     </div>
@@ -1413,31 +1413,31 @@ exports[`Storyshots evaluation/components Possibilities (FREE_RANGE) 1`] = `
     className="jsx-3283260225"
   >
     <div
-      className="jsx-91056044 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-91056044 content"
-      >
-        10
-      </div>
-      <div
-        className="jsx-91056044 marker"
+        className="jsx-3779267427 marker"
       >
         MIN
       </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        10
+      </div>
     </div>
     <div
-      className="jsx-91056044 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-91056044 content"
-      >
-        20
-      </div>
-      <div
-        className="jsx-91056044 marker"
+        className="jsx-3779267427 marker"
       >
         MAX
+      </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        20
       </div>
     </div>
   </div>
@@ -1459,10 +1459,10 @@ exports[`Storyshots evaluation/components Possibilities (MC) 1`] = `
     className="jsx-3283260225"
   >
     <div
-      className="jsx-110067377 evaluationListItem"
+      className="jsx-4258134142 evaluationListItem"
     >
       <div
-        className="jsx-110067377 colorSquare"
+        className="jsx-4258134142 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1470,21 +1470,21 @@ exports[`Storyshots evaluation/components Possibilities (MC) 1`] = `
         />
       </div>
       <div
-        className="jsx-110067377 content"
+        className="jsx-4258134142 content"
       >
         This is the first possible answer
       </div>
       <div
-        className="jsx-110067377 marker"
+        className="jsx-4258134142 marker"
       >
         A
       </div>
     </div>
     <div
-      className="jsx-1709102229 evaluationListItem"
+      className="jsx-1949426394 evaluationListItem"
     >
       <div
-        className="jsx-1709102229 colorSquare"
+        className="jsx-1949426394 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1492,21 +1492,21 @@ exports[`Storyshots evaluation/components Possibilities (MC) 1`] = `
         />
       </div>
       <div
-        className="jsx-1709102229 content"
+        className="jsx-1949426394 content"
       >
         This is the second possible answer
       </div>
       <div
-        className="jsx-1709102229 marker"
+        className="jsx-1949426394 marker"
       >
         B
       </div>
     </div>
     <div
-      className="jsx-4235792499 evaluationListItem"
+      className="jsx-1547578044 evaluationListItem"
     >
       <div
-        className="jsx-4235792499 colorSquare"
+        className="jsx-1547578044 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1514,21 +1514,21 @@ exports[`Storyshots evaluation/components Possibilities (MC) 1`] = `
         />
       </div>
       <div
-        className="jsx-4235792499 content"
+        className="jsx-1547578044 content"
       >
         This is the third possible answer
       </div>
       <div
-        className="jsx-4235792499 marker"
+        className="jsx-1547578044 marker"
       >
         C
       </div>
     </div>
     <div
-      className="jsx-2249623282 evaluationListItem"
+      className="jsx-2727709245 evaluationListItem"
     >
       <div
-        className="jsx-2249623282 colorSquare"
+        className="jsx-2727709245 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1536,12 +1536,12 @@ exports[`Storyshots evaluation/components Possibilities (MC) 1`] = `
         />
       </div>
       <div
-        className="jsx-2249623282 content"
+        className="jsx-2727709245 content"
       >
         This is the fourth possible answer
       </div>
       <div
-        className="jsx-2249623282 marker"
+        className="jsx-2727709245 marker"
       >
         D
       </div>
@@ -1565,10 +1565,10 @@ exports[`Storyshots evaluation/components Possibilities (SC) 1`] = `
     className="jsx-3283260225"
   >
     <div
-      className="jsx-110067377 evaluationListItem"
+      className="jsx-4258134142 evaluationListItem"
     >
       <div
-        className="jsx-110067377 colorSquare"
+        className="jsx-4258134142 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1576,21 +1576,21 @@ exports[`Storyshots evaluation/components Possibilities (SC) 1`] = `
         />
       </div>
       <div
-        className="jsx-110067377 content"
+        className="jsx-4258134142 content"
       >
         This is the first possible answer
       </div>
       <div
-        className="jsx-110067377 marker"
+        className="jsx-4258134142 marker"
       >
         A
       </div>
     </div>
     <div
-      className="jsx-1709102229 evaluationListItem"
+      className="jsx-1949426394 evaluationListItem"
     >
       <div
-        className="jsx-1709102229 colorSquare"
+        className="jsx-1949426394 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1598,21 +1598,21 @@ exports[`Storyshots evaluation/components Possibilities (SC) 1`] = `
         />
       </div>
       <div
-        className="jsx-1709102229 content"
+        className="jsx-1949426394 content"
       >
         This is the second possible answer
       </div>
       <div
-        className="jsx-1709102229 marker"
+        className="jsx-1949426394 marker"
       >
         B
       </div>
     </div>
     <div
-      className="jsx-4235792499 evaluationListItem"
+      className="jsx-1547578044 evaluationListItem"
     >
       <div
-        className="jsx-4235792499 colorSquare"
+        className="jsx-1547578044 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1620,21 +1620,21 @@ exports[`Storyshots evaluation/components Possibilities (SC) 1`] = `
         />
       </div>
       <div
-        className="jsx-4235792499 content"
+        className="jsx-1547578044 content"
       >
         This is the third possible answer
       </div>
       <div
-        className="jsx-4235792499 marker"
+        className="jsx-1547578044 marker"
       >
         C
       </div>
     </div>
     <div
-      className="jsx-2249623282 evaluationListItem"
+      className="jsx-2727709245 evaluationListItem"
     >
       <div
-        className="jsx-2249623282 colorSquare"
+        className="jsx-2727709245 colorSquare"
       >
         <i
           aria-hidden="true"
@@ -1642,12 +1642,12 @@ exports[`Storyshots evaluation/components Possibilities (SC) 1`] = `
         />
       </div>
       <div
-        className="jsx-2249623282 content"
+        className="jsx-2727709245 content"
       >
         This is the fourth possible answer
       </div>
       <div
-        className="jsx-2249623282 marker"
+        className="jsx-2727709245 marker"
       >
         D
       </div>
@@ -1671,157 +1671,101 @@ exports[`Storyshots evaluation/components Statistics 1`] = `
     className="jsx-521492810"
   >
     <div
-      className="jsx-865544459 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-865544459 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-865544459 content"
-      >
-        10
-      </div>
-      <div
-        className="jsx-865544459 marker"
+        className="jsx-3779267427 marker"
       >
         MIN
       </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        10
+      </div>
     </div>
     <div
-      className="jsx-764491627 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-764491627 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-764491627 content"
-      >
-        -
-      </div>
-      <div
-        className="jsx-764491627 marker"
+        className="jsx-3779267427 marker"
       >
         Q1
       </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        -
+      </div>
     </div>
     <div
-      className="jsx-725384191 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-725384191 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-725384191 content"
-      >
-        23
-      </div>
-      <div
-        className="jsx-725384191 marker"
+        className="jsx-3779267427 marker"
       >
         MEDIAN
       </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        23
+      </div>
     </div>
     <div
-      className="jsx-2393557874 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-2393557874 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-2393557874 content"
-      >
-        34.35
-      </div>
-      <div
-        className="jsx-2393557874 marker"
+        className="jsx-3779267427 marker"
       >
         MEAN
       </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        34.35
+      </div>
     </div>
     <div
-      className="jsx-764491627 evaluationListItem"
+      className="jsx-3779267427 evaluationListItem reverse"
     >
       <div
-        className="jsx-764491627 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-764491627 content"
-      >
-        -
-      </div>
-      <div
-        className="jsx-764491627 marker"
+        className="jsx-3779267427 marker"
       >
         Q3
       </div>
-    </div>
-    <div
-      className="jsx-865544459 evaluationListItem"
-    >
       <div
-        className="jsx-865544459 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-865544459 content"
-      >
-        100
-      </div>
-      <div
-        className="jsx-865544459 marker"
-      >
-        MAX
-      </div>
-    </div>
-    <div
-      className="jsx-865544459 evaluationListItem"
-    >
-      <div
-        className="jsx-865544459 colorSquare"
-      >
-        <i
-          aria-hidden="true"
-          className="square icon icon"
-        />
-      </div>
-      <div
-        className="jsx-865544459 content"
+        className="jsx-3779267427 content"
       >
         -
       </div>
+    </div>
+    <div
+      className="jsx-3779267427 evaluationListItem reverse"
+    >
       <div
-        className="jsx-865544459 marker"
+        className="jsx-3779267427 marker"
+      >
+        MAX
+      </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        100
+      </div>
+    </div>
+    <div
+      className="jsx-3779267427 evaluationListItem reverse"
+    >
+      <div
+        className="jsx-3779267427 marker"
       >
         SD
+      </div>
+      <div
+        className="jsx-3779267427 content"
+      >
+        -
       </div>
     </div>
   </div>

--- a/src/components/evaluation/EvaluationListItem.js
+++ b/src/components/evaluation/EvaluationListItem.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 
 import { Icon } from 'semantic-ui-react'
 
@@ -7,22 +8,28 @@ const propTypes = {
   children: PropTypes.element.isRequired,
   color: PropTypes.string,
   marker: PropTypes.string,
+  reverse: PropTypes.bool,
 }
 
 const defaultProps = {
   color: undefined,
   marker: undefined,
+  reverse: false,
 }
 
-const EvaluationListItem = ({ color, children, marker }) => (
-  <div className="evaluationListItem">
+const EvaluationListItem = ({
+  color, children, marker, reverse,
+}) => (
+  <div className={classNames('evaluationListItem', { reverse })}>
     {color && (
       <div className="colorSquare">
         <Icon name="square icon" />
       </div>
     )}
+
+    {marker && reverse && <div className="marker">{marker}</div>}
     <div className="content">{children}</div>
-    {marker && <div className="marker">{marker}</div>}
+    {marker && !reverse && <div className="marker">{marker}</div>}
 
     <style jsx>{`
       .evaluationListItem {
@@ -52,6 +59,15 @@ const EvaluationListItem = ({ color, children, marker }) => (
 
         .content {
           flex: 1;
+        }
+
+        &.reverse {
+          justify-content: space-between;
+
+          .marker,
+          .content {
+            flex: 0 0 auto;
+          }
         }
       }
     `}</style>

--- a/src/components/evaluation/Possibilities.js
+++ b/src/components/evaluation/Possibilities.js
@@ -56,11 +56,19 @@ const Possibilities = ({ questionOptions, questionType }) => (
             {(() => {
               const comp = []
               if (restrictions && _isNumber(restrictions.min)) {
-                comp.push(<EvaluationListItem marker="MIN">{restrictions.min}</EvaluationListItem>)
+                comp.push(
+                  <EvaluationListItem reverse marker="MIN">
+                    {restrictions.min}
+                  </EvaluationListItem>,
+                )
               }
 
               if (restrictions && _isNumber(restrictions.max)) {
-                comp.push(<EvaluationListItem marker="MAX">{restrictions.max}</EvaluationListItem>)
+                comp.push(
+                  <EvaluationListItem reverse marker="MAX">
+                    {restrictions.max}
+                  </EvaluationListItem>,
+                )
               }
 
               if (comp.length > 0) {

--- a/src/components/evaluation/Statistics.js
+++ b/src/components/evaluation/Statistics.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import _round from 'lodash/round'
 import { FormattedMessage } from 'react-intl'
 import { Input, Message } from 'semantic-ui-react'
+import _isNumber from 'lodash/isNumber'
 
 import { EvaluationListItem } from '.'
 
@@ -39,26 +40,26 @@ const Statistics = ({
     </h2>
 
     <div>
-      <EvaluationListItem color="white" marker="MIN">
-        {min ? _round(min, 2) : '-'}
+      <EvaluationListItem reverse /* color="white" */ marker="MIN">
+        {_isNumber(min) ? _round(min, 2) : '-'}
       </EvaluationListItem>
-      <EvaluationListItem color="black" marker="Q1">
-        {q1 ? _round(q1, 2) : '-'}
+      <EvaluationListItem reverse /* color="black" */ marker="Q1">
+        {_isNumber(q1) ? _round(q1, 2) : '-'}
       </EvaluationListItem>
-      <EvaluationListItem color="red" marker="MEDIAN">
-        {median ? _round(median, 2) : '-'}
+      <EvaluationListItem reverse /* color="red" */ marker="MEDIAN">
+        {_isNumber(median) ? _round(median, 2) : '-'}
       </EvaluationListItem>
-      <EvaluationListItem color="Blue" marker="MEAN">
-        {mean ? _round(mean, 2) : '-'}
+      <EvaluationListItem reverse /* color="Blue" */ marker="MEAN">
+        {_isNumber(mean) ? _round(mean, 2) : '-'}
       </EvaluationListItem>
-      <EvaluationListItem color="black" marker="Q3">
-        {q3 ? _round(q3, 2) : '-'}
+      <EvaluationListItem reverse /* color="black" */ marker="Q3">
+        {_isNumber(q3) ? _round(q3, 2) : '-'}
       </EvaluationListItem>
-      <EvaluationListItem color="white" marker="MAX">
-        {max ? _round(max, 2) : '-'}
+      <EvaluationListItem reverse /* color="white" */ marker="MAX">
+        {_isNumber(max) ? _round(max, 2) : '-'}
       </EvaluationListItem>
-      <EvaluationListItem color="white" marker="SD">
-        {sd ? _round(sd, 2) : '-'}
+      <EvaluationListItem reverse /* color="white" */ marker="SD">
+        {_isNumber(sd) ? _round(sd, 2) : '-'}
       </EvaluationListItem>
     </div>
 

--- a/src/components/evaluation/charts/BarChart.js
+++ b/src/components/evaluation/charts/BarChart.js
@@ -42,7 +42,7 @@ const calculatePercentage = (questionType, count, totalResponses) => {
 
   // only show percentage string if count is >0
   if (count > 0) {
-    return `${count} | ${_round(100 * (count / totalResponses), 2)} %`
+    return `${count} | ${_round(100 * (count / totalResponses), 1)} %`
   }
 
   // return an empty string so it doesn't clutter the visualization

--- a/src/components/evaluation/charts/BarChart.js
+++ b/src/components/evaluation/charts/BarChart.js
@@ -33,6 +33,22 @@ const defaultProps = {
   isSolutionShown: false,
 }
 
+// TODO: extract to libraries
+const calculatePercentage = (questionType, count, totalResponses) => {
+  // no percentages needed for other question types
+  if (questionType !== QUESTION_TYPES.SC) {
+    return count
+  }
+
+  // only show percentage string if count is >0
+  if (count > 0) {
+    return `${count} | ${_round(100 * (count / totalResponses), 2)} %`
+  }
+
+  // return an empty string so it doesn't clutter the visualization
+  return ''
+}
+
 const BarChart = ({ isSolutionShown, data, isColored }) => (
   <ResponsiveContainer>
     <BarChartComponent
@@ -108,10 +124,7 @@ export default withProps(({ data, questionType, totalResponses }) => ({
       correct,
       count,
       label: questionType === 'FREE_RANGE' ? +value : String.fromCharCode(65 + index),
-      percentage:
-        questionType === QUESTION_TYPES.SC
-          ? `${count} | ${_round(100 * (count / totalResponses), 2)} %`
-          : count,
+      percentage: calculatePercentage(questionType, count, totalResponses),
       value,
     })),
     o => o.label,

--- a/src/components/evaluation/charts/PieChart.js
+++ b/src/components/evaluation/charts/PieChart.js
@@ -79,7 +79,7 @@ export default withProps(({ data, totalResponses }) => ({
     correct,
     count,
     label: String.fromCharCode(65 + index),
-    percentage: `${count} | ${_round(100 * (count / totalResponses), 2)} %`,
+    percentage: `${count} | ${_round(100 * (count / totalResponses), 1)} %`,
     value,
   })),
 }))(PieChart)

--- a/src/components/layouts/EvaluationLayout.js
+++ b/src/components/layouts/EvaluationLayout.js
@@ -103,15 +103,22 @@ function EvaluationLayout({
 
         <div className="info">
           <Info totalResponses={totalResponses} />
-          <Checkbox
-            toggle
-            defaultChecked={showSolution}
-            label={intl.formatMessage({
-              defaultMessage: 'Show solution',
-              id: 'evaluation.showSolution.label',
-            })}
-            onChange={onToggleShowSolution}
-          />
+          {/* don't show 'show solution' check box for free and free range questions
+          and word cloud charts */
+          type !== 'FREE' &&
+            type !== 'FREE_RANGE' &&
+            activeVisualization !== 'WORD_CLOUD' && (
+              <Checkbox
+                toggle
+                defaultChecked={showSolution}
+                label={intl.formatMessage({
+                  defaultMessage: 'Show solution',
+                  id: 'evaluation.showSolution.label',
+                })}
+                onChange={onToggleShowSolution}
+              />
+            )}
+
           <VisualizationType
             activeVisualization={activeVisualization}
             intl={intl}

--- a/src/components/layouts/EvaluationLayout.js
+++ b/src/components/layouts/EvaluationLayout.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { intlShape } from 'react-intl'
-import { Checkbox, Menu } from 'semantic-ui-react'
+import { Checkbox, Dropdown, Menu } from 'semantic-ui-react'
 
 import { CommonLayout } from '.'
 import { Info, Possibilities, Statistics, VisualizationType } from '../evaluation'
@@ -66,36 +66,65 @@ function EvaluationLayout({
   return (
     <CommonLayout baseFontSize="22px" pageTitle={pageTitle}>
       <div className={`evaluationLayout ${type}`}>
-        {instanceSummary.length > 1 && (
-          <div className="instanceChooser">
-            <Menu fitted tabular>
-              <Menu.Item
-                className="hoverable"
-                disabled={activeInstance === 0}
-                icon="arrow left"
-                onClick={onChangeActiveInstance(activeInstance - 1)}
-              />
+        {(() => {
+          if (instanceSummary.length <= 0) {
+            return null
+          }
 
-              {instanceSummary.map(({ title, totalResponses: count }, index) => (
+          if (instanceSummary.length > 10) {
+            const dropdownOptions = instanceSummary.map(
+              ({ title, totalResponses: count }, index) => ({
+                key: index,
+                text: `${title} (${count})`,
+                value: index,
+              }),
+            )
+
+            return (
+              <div className="instanceDropdown">
+                <Dropdown
+                  search
+                  selection
+                  defaultValue={0}
+                  options={dropdownOptions}
+                  placeholder="Select Question"
+                  onChange={(param, data) => onChangeActiveInstance(data.value)()}
+                />
+              </div>
+            )
+          }
+
+          return (
+            <div className="instanceChooser">
+              <Menu fitted tabular>
                 <Menu.Item
-                  fitted
-                  active={index === activeInstance}
                   className="hoverable"
-                  onClick={onChangeActiveInstance(index)}
-                >
-                  {title.length > 15 ? `${title.substring(0, 15)} ...` : title} ({count})
-                </Menu.Item>
-              ))}
+                  disabled={activeInstance === 0}
+                  icon="arrow left"
+                  onClick={onChangeActiveInstance(activeInstance - 1)}
+                />
 
-              <Menu.Item
-                className="hoverable"
-                disabled={activeInstance + 1 === instanceSummary.length}
-                icon="arrow right"
-                onClick={onChangeActiveInstance(activeInstance + 1)}
-              />
-            </Menu>
-          </div>
-        )}
+                {instanceSummary.map(({ title, totalResponses: count }, index) => (
+                  <Menu.Item
+                    fitted
+                    active={index === activeInstance}
+                    className="hoverable"
+                    onClick={onChangeActiveInstance(index)}
+                  >
+                    {title.length > 15 ? `${title.substring(0, 15)} ...` : title} ({count})
+                  </Menu.Item>
+                ))}
+
+                <Menu.Item
+                  className="hoverable"
+                  disabled={activeInstance + 1 === instanceSummary.length}
+                  icon="arrow right"
+                  onClick={onChangeActiveInstance(activeInstance + 1)}
+                />
+              </Menu>
+            </div>
+          )
+        })()}
 
         <div className="questionDetails">
           <p>{description}</p>

--- a/src/pages/sessions/evaluation.js
+++ b/src/pages/sessions/evaluation.js
@@ -156,6 +156,7 @@ export default compose(
             ...activeInstance,
             results: {
               // HACK: versioning hardcoded
+              // TODO: !!!
               data: activeInstance.question.versions[0].options[
                 activeInstance.question.type
               ].choices.map((choice, index) => ({
@@ -169,10 +170,17 @@ export default compose(
         }
 
         if (QUESTION_GROUPS.FREE.includes(activeInstance.question.type)) {
+          let data = activeInstance.results ? activeInstance.results.FREE : []
+
+          // values in FREE_RANGE questions need to be numerical
+          if (activeInstance.question.type === QUESTION_TYPES.FREE_RANGE) {
+            data = data.map(({ value, ...rest }) => ({ ...rest, value: +value }))
+          }
+
           return {
             ...activeInstance,
             results: {
-              data: activeInstance.results ? activeInstance.results.FREE : [],
+              data,
               totalResponses: activeInstance.responses.length,
             },
           }

--- a/src/pages/sessions/evaluation.js
+++ b/src/pages/sessions/evaluation.js
@@ -155,9 +155,7 @@ export default compose(
           return {
             ...activeInstance,
             results: {
-              // HACK: versioning hardcoded
-              // TODO: !!!
-              data: activeInstance.question.versions[0].options[
+              data: activeInstance.question.versions[activeInstance.version].options[
                 activeInstance.question.type
               ].choices.map((choice, index) => ({
                 correct: choice.correct,
@@ -192,6 +190,7 @@ export default compose(
     return {
       activeInstances,
       instanceSummary: activeInstances.map(instance => ({
+        hasSolution: !!instance.solution,
         title: instance.question.title,
         totalResponses: instance.responses.length,
       })),
@@ -253,7 +252,7 @@ export default compose(
       if (question.type === QUESTION_TYPES.FREE_RANGE) {
         return {
           activeInstance,
-          handleChangeActiveInstance: index => () => handleChangeActiveInstance(index),
+          handleChangeActiveInstance,
           statistics: {
             bins,
             max: calculateMax(results),


### PR DESCRIPTION
Small layout and data representation fiexs and improvements.

**GENERAL**
- remove colors for statistics and reverse number and label order
- hide choices in bar chart with 0% of the responses
- convert free-range responses to numbers for proper sorting in table
- only show one decimal place in percentages in bar and pie charts
- hide 'show solution' checkbox for word cloud charts and free and free range questions
- show dropdown instead of tabs for evaluations with more than 10 questions
- fixed version hack (version 0) to active version