### PR TITLE
Update student mutations for string returns

### DIFF
--- a/src/graphql/mutations/AddConfusionTSMutation.graphql
+++ b/src/graphql/mutations/AddConfusionTSMutation.graphql
@@ -9,12 +9,5 @@ mutation AddConfusionTS(
     sessionId: $sessionId
     difficulty: $difficulty
     speed: $speed
-  ) {
-    id
-    confusionTS {
-      difficulty
-      speed
-      createdAt
-    }
-  }
+  )
 }

--- a/src/graphql/mutations/AddFeedbackMutation.graphql
+++ b/src/graphql/mutations/AddFeedbackMutation.graphql
@@ -1,10 +1,3 @@
 mutation AddFeedback($fp: ID, $sessionId: ID!, $content: String!) {
-  addFeedback(fp: $fp, sessionId: $sessionId, content: $content) {
-    id
-    feedbacks {
-      id
-      content
-      votes
-    }
-  }
+  addFeedback(fp: $fp, sessionId: $sessionId, content: $content)
 }

--- a/src/graphql/mutations/AddResponseMutation.graphql
+++ b/src/graphql/mutations/AddResponseMutation.graphql
@@ -3,7 +3,5 @@ mutation AddResponse(
   $instanceId: ID!
   $response: QuestionInstance_ResponseInput!
 ) {
-  addResponse(fp: $fp, instanceId: $instanceId, response: $response) {
-    id
-  }
+  addResponse(fp: $fp, instanceId: $instanceId, response: $response)
 }


### PR DESCRIPTION
Actions performed by students should only return success strings. They might have leaked information before these changes (unpublished feedbacks etc.).