### PR TITLE
Apollo Server 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sanitize-html": "1.18.2",
     "semantic-ui-react": "0.81.1",
     "styled-jsx-plugin-sass": "0.2.4",
-    "subscriptions-transport-ws": "0.9.9",
+    "subscriptions-transport-ws": "0.9.11",
     "url-loader": "1.0.1",
     "webpack": "3.12.0",
     "yup": "0.25.1"

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "assignees": ["rschlaefli"],
   "labels": ["dependencies"],
   "reviewers": ["rschlaefli"],
-  "schedule": ["after 9am and before 4pm on monday and wednesday"],
+  "schedule": ["after 7pm and before 8am on every weekday"],
   "semanticCommits": false,
   "timezone": "Europe/Zurich",
   "packageRules": [
@@ -42,7 +42,13 @@
       "automerge": "minor"
     },
     {
-      "packageNames": ["jest", "react-addons-test-utils", "enzyme", "cypress", "babel-jest"],
+      "packageNames": [
+        "jest",
+        "react-addons-test-utils",
+        "enzyme",
+        "cypress",
+        "babel-jest"
+      ],
       "groupName": "test",
       "automerge": "minor"
     },

--- a/src/lib/initApollo.js
+++ b/src/lib/initApollo.js
@@ -6,11 +6,11 @@ import fetch from 'isomorphic-unfetch'
 import { ApolloClient } from 'apollo-client'
 import { BatchHttpLink } from 'apollo-link-batch-http'
 import { onError } from 'apollo-link-error'
-import { withClientState } from 'apollo-link-state'
+// import { withClientState } from 'apollo-link-state'
 import { ApolloLink, split } from 'apollo-link'
 import { WebSocketLink } from 'apollo-link-ws'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
-import { createPersistedQueryLink } from 'apollo-link-persisted-queries'
+// import { createPersistedQueryLink } from 'apollo-link-persisted-queries'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { getMainDefinition } from 'apollo-utilities'
 
@@ -21,28 +21,6 @@ let apolloClient = null
 if (ssrMode) {
   global.fetch = fetch
 }
-
-// HACK: this is a copy of the default persisted-queries disable function
-// it needs to be provided as the config passed in is not yet merged with defaults
-// otherwise it would lead to ".disable not defined" style errors...
-/* const defaultDisable = ({ graphQLErrors, operation }) => {
-  // if the server doesn't support persisted queries, don't try anymore
-  if (
-    graphQLErrors &&
-    graphQLErrors.some(({ message }) => message === 'PersistedQueryNotSupported')
-  ) {
-    return true
-  }
-
-  const { response } = operation.getContext()
-  // if the server responds with bad request
-  // apollo-server responds with 400 for GET and 500 for POST when no query is found
-  if (response && response.status && (response.status === 400 || response.status === 500)) {
-    return true
-  }
-
-  return false
-} */
 
 function create(initialState) {
   const cache = new InMemoryCache({
@@ -82,12 +60,18 @@ function create(initialState) {
   }
 
   const link = ApolloLink.from([
-    withClientState({
+    /* TODO: work with persisted queries
+      createPersistedQueryLink({
+      // we need to pass both disable and generateHash (or it will bug)
+      // disable: defaultDisable,
+      generateHash: ({ documentId }) => documentId,
+    }), */
+    /* withClientState({
       cache,
       resolvers: {
         // TODO: add useful resolvers for local state
       },
-    }),
+    }), */
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors) {
         // TODO: log errors to sentry?
@@ -97,11 +81,6 @@ function create(initialState) {
         )
       }
       if (networkError) console.log(`[Network error]: ${networkError}`)
-    }),
-    createPersistedQueryLink({
-      // we need to pass both disable and generateHash (or it will bug)
-      // disable: defaultDisable,
-      generateHash: ({ documentId }) => documentId,
     }),
     httpLink,
   ])

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -66,9 +66,7 @@ module.exports = (phase) => {
 
   // development only configuration
   if (phase === DEVELOPMENT_SERVER) {
-    config = {
-      ...config,
-    }
+    // do something in dev only?
   }
 
   // build only configuration

--- a/src/pages/sessions/evaluation.js
+++ b/src/pages/sessions/evaluation.js
@@ -136,7 +136,10 @@ export default compose(
     }),
   }),
   // if the query is still loading, display nothing
-  branch(({ data }) => data.loading, renderNothing),
+  branch(
+    ({ data: { loading, session } }) => loading || !session,
+    renderNothing,
+  ),
   // override the session evaluation query with a polling query
   branch(
     ({ data: { session } }) => session.status === SESSION_STATUS.RUNNING,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5990,9 +5990,9 @@ event-stream@~3.3.0:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter3@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+eventemitter3@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
 events@^1.0.0:
   version "1.1.1"
@@ -14545,18 +14545,18 @@ stylis@3.4.10:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.10.tgz#a135cab4b9ff208e327fbb5a6fde3fa991c638ee"
 
-subscriptions-transport-ws@0.9.9:
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.9.tgz#8a0bdc4c31df2e90e92901047fd8961deb138acc"
+subscriptions-transport-ws@0.9.11:
+  version "0.9.11"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.11.tgz#76e9dd7ec1bd0aa0331eca9b7074e66ce626d13a"
   dependencies:
     backo2 "^1.0.2"
-    eventemitter3 "^2.0.3"
+    eventemitter3 "^3.1.0"
     iterall "^1.2.1"
     lodash.assign "^4.2.0"
     lodash.isobject "^3.0.2"
     lodash.isstring "^4.0.1"
     symbol-observable "^1.0.4"
-    ws "^3.0.0"
+    ws "^5.2.0"
 
 supports-color@5.1.0:
   version "5.1.0"
@@ -15844,6 +15844,12 @@ ws@^4.0.0:
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
+
+ws@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
+  dependencies:
+    async-limiter "~1.0.0"
 
 x-xss-protection@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Migrate the codebase to the Apollo Server 2.0 codebase.

**DEPENDENCIES**
- Upgrade `subscriptions-transport-ws` to 0.9.11

**GENERAL**
- Cleanup Apollo initialization procedures
- Disable Apollo client state until needed
- Change local subscriptions endpoint to `/graphql`

**MISC**
- Change renovate schedule to perform daily upgrades outside of working hours
- (fix) Don't break when a session loaded for evaluation does not exist (=> white page)
