### PR TITLE
Editing Sessions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -25,7 +25,7 @@
            ]
         ],
         "plugins":[
-           "@babel/plugin-syntax-do-expressions",
+           "@babel/plugin-proposal-do-expressions",
            "@babel/plugin-proposal-pipeline-operator",
            "@babel/plugin-proposal-optional-chaining",
            "inline-dotenv",
@@ -68,7 +68,7 @@
                  ]
               }
            ],
-           "@babel/plugin-syntax-do-expressions",
+           "@babel/plugin-proposal-do-expressions",
            "@babel/plugin-proposal-pipeline-operator",
            "@babel/plugin-proposal-optional-chaining",
            "transform-inline-environment-variables",
@@ -101,7 +101,7 @@
            ]
         ],
         "plugins":[
-           "@babel/plugin-syntax-do-expressions",
+           "@babel/plugin-proposal-do-expressions",
            "@babel/plugin-proposal-pipeline-operator",
            "@babel/plugin-proposal-optional-chaining",
            "babel-plugin-inline-import-graphql-ast"

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,12 @@
     "sort-keys": 1,
     "global-require": 0,
 
+    "no-unused-expressions": 0,
+    "babel/no-unused-expressions": 1,
+
+    "quotes": 0,
+    "babel/quotes": [1, "single"],
+
     "import/extensions": 0,
     "import/prefer-default-export": 0,
     "import/no-dynamic-require": 0,

--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,3 +1,0 @@
-{
-  "schemaPath": "src/graphql/schema.graphql"
-}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@babel/core": "7.0.0-beta.51",
+    "@babel/plugin-proposal-do-expressions": "7.0.0-beta.51",
     "@babel/plugin-proposal-optional-chaining": "7.0.0-beta.51",
     "@babel/plugin-proposal-pipeline-operator": "7.0.0-beta.51",
-    "@babel/plugin-syntax-do-expressions": "7.0.0-beta.51",
     "@babel/plugin-transform-react-constant-elements": "7.0.0-beta.51",
     "@babel/preset-env": "7.0.0-beta.51",
     "@babel/runtime": "7.0.0-beta.51",

--- a/server.js
+++ b/server.js
@@ -176,14 +176,14 @@ app
           isProd && process.env.HELMET_CSP
             ? {
               directives: {
-                defaultSrc: ["'self'"],
-                fontSrc: ["'fonts.gstatic.com'", "'cdnjs.cloudflare.com'"],
+                defaultSrc: ['\'self\''],
+                fontSrc: ['\'fonts.gstatic.com\'', '\'cdnjs.cloudflare.com\''],
                 reportUri: process.env.HELMET_CSP_REPORT_URI,
-                scriptSrc: ["'cdn.polyfill.io'"],
+                scriptSrc: ['\'cdn.polyfill.io\''],
                 styleSrc: [
-                  "'maxcdn.bootstrapcdn.com'",
-                  "'fonts.googleapis.com'",
-                  "'cdnjs.cloudflare.com'",
+                  '\'maxcdn.bootstrapcdn.com\'',
+                  '\'fonts.googleapis.com\'',
+                  '\'cdnjs.cloudflare.com\'',
                 ],
               },
               reportOnly: true,

--- a/src/components/common/ListWithHeader.js
+++ b/src/components/common/ListWithHeader.js
@@ -21,7 +21,7 @@ const ListWithHeader = ({ children, items, limit }) => (
     {children && <span className="listHeader">{children}</span>}
 
     {items.length > limit ? (
-      <React.Fragment>
+      <>
         <List>{mapItems(items.slice(0, limit))}</List>
         <Popup
           hideOnScroll
@@ -33,7 +33,7 @@ const ListWithHeader = ({ children, items, limit }) => (
             <List>{mapItems(items.slice(limit))}</List>
           </div>
         </Popup>
-      </React.Fragment>
+      </>
     ) : (
       <List>{mapItems(items)}</List>
     )}

--- a/src/components/common/navbar/AccountArea.js
+++ b/src/components/common/navbar/AccountArea.js
@@ -13,7 +13,7 @@ const defaultProps = {
 }
 
 const AccountArea = ({ accountShort, onLogout }) => (
-  <React.Fragment>
+  <>
     <Dropdown item simple icon="user" text={`${accountShort} `}>
       <Dropdown.Menu>
         {/* <Dropdown.Item disabled>
@@ -24,7 +24,7 @@ const AccountArea = ({ accountShort, onLogout }) => (
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>
-  </React.Fragment>
+  </>
 )
 
 AccountArea.propTypes = propTypes

--- a/src/components/common/navbar/SearchArea.js
+++ b/src/components/common/navbar/SearchArea.js
@@ -53,7 +53,7 @@ const SearchArea = ({
     </Input>
 
     {withSorting && (
-      <React.Fragment>
+      <>
         <Button
           icon={`${_find(sortingTypes, { id: sortBy }).labelStart} ${
             sortOrder ? 'ascending' : 'descending'
@@ -69,7 +69,7 @@ const SearchArea = ({
           }))}
           onChange={(param, data) => handleSortByChange(data.value)}
         />
-      </React.Fragment>
+      </>
     )}
 
     <style jsx>

--- a/src/components/common/navbar/SessionArea.js
+++ b/src/components/common/navbar/SessionArea.js
@@ -35,11 +35,12 @@ const defaultProps = {
 }
 
 const SessionArea = ({ intl, sessionId }) => (
-  <React.Fragment>
+  <>
     <Menu.Item button>
       <Button
         icon
         as="a"
+        color={sessionId ? 'green' : undefined}
         disabled={!sessionId}
         href="/sessions/running"
         labelPosition="left"
@@ -183,7 +184,7 @@ const SessionArea = ({ intl, sessionId }) => (
         }
       `}
     </style>
-  </React.Fragment>
+  </>
 )
 
 SessionArea.propTypes = propTypes

--- a/src/components/confusion/ConfusionBarometer.js
+++ b/src/components/confusion/ConfusionBarometer.js
@@ -74,7 +74,7 @@ const ConfusionBarometer = ({
     {(() => {
       if (isActive) {
         return (
-          <React.Fragment>
+          <>
             <ConfusionSection
               data={confusionTS.map(
                 ({ timestamp, difficulty, difficultyRunning }) => ({
@@ -95,7 +95,7 @@ const ConfusionBarometer = ({
               title={intl.formatMessage(messages.speedTitle)}
               ylabel={intl.formatMessage(messages.speedRange)}
             />
-          </React.Fragment>
+          </>
         )
       }
 

--- a/src/components/forms/sessionCreation/SessionCreationForm.js
+++ b/src/components/forms/sessionCreation/SessionCreationForm.js
@@ -233,9 +233,9 @@ const SessionCreationForm = ({
 
             .questions {
               flex: 1;
-              padding: 0.25rem 0.5rem 1rem 0.5rem;
+              padding: 1rem 0.5rem 1rem 0.5rem;
               overflow: auto;
-              max-height: 20rem;
+              max-height: 23rem;
 
               .question:not(:first-child) {
                 margin-top: 3px;

--- a/src/components/layouts/EvaluationLayout.js
+++ b/src/components/layouts/EvaluationLayout.js
@@ -195,7 +195,7 @@ function EvaluationLayout({
         <div className="chart">{children}</div>
 
         {activeVisualization !== CHART_TYPES.TABLE && (
-          <React.Fragment>
+          <>
             {QUESTION_GROUPS.WITH_POSSIBILITIES.includes(type) && (
               <div className="optionDisplay">
                 <Possibilities
@@ -217,7 +217,7 @@ function EvaluationLayout({
                   />
                 </div>
             )}
-          </React.Fragment>
+          </>
         )}
 
         <style jsx>

--- a/src/components/questionTypes/FREE/FREEAnswerOptions.js
+++ b/src/components/questionTypes/FREE/FREEAnswerOptions.js
@@ -95,26 +95,28 @@ const FREEAnswerOptions = ({
 
       return (
         <div className="field">
-          {do {
-            if (options.restrictions.max !== null) {
-              <FormattedMessage
-                defaultMessage="Maximum value: {max}"
-                id="freeAnswer.maxValue"
-                values={{ max: options.restrictions.max }}
-              />
-            } else if (options.restrictions.min !== null) {
-              <FormattedMessage
-                defaultMessage="Minimum value: {min}"
-                id="freeAnswer.minValue"
-                values={{ min: options.restrictions.min }}
-              />
-            } else {
-              <FormattedMessage
-                defaultMessage="Unrestricted input (any number)"
-                id="freeAnswer.unrestricted"
-              />
-            }
-          }}
+          <div className="rangeInformation">
+            {do {
+              if (options.restrictions.max !== null) {
+                <FormattedMessage
+                  defaultMessage="Maximum value: {max}"
+                  id="freeAnswer.maxValue"
+                  values={{ max: options.restrictions.max }}
+                />
+              } else if (options.restrictions.min !== null) {
+                <FormattedMessage
+                  defaultMessage="Minimum value: {min}"
+                  id="freeAnswer.minValue"
+                  values={{ min: options.restrictions.min }}
+                />
+              } else {
+                <FormattedMessage
+                  defaultMessage="Unrestricted input (any number)"
+                  id="freeAnswer.unrestricted"
+                />
+              }
+            }}
+          </div>
 
           <textarea
             disabled={disabled}
@@ -168,6 +170,10 @@ const FREEAnswerOptions = ({
           .max {
             float: right;
           }
+        }
+
+        .rangeInformation {
+          margin-bottom: 1rem;
         }
 
         textarea {

--- a/src/components/questionTypes/FREE/FREEAnswerOptions.js
+++ b/src/components/questionTypes/FREE/FREEAnswerOptions.js
@@ -45,6 +45,7 @@ const FREEAnswerOptions = ({
     {(() => {
       if (
         questionType === QUESTION_TYPES.FREE_RANGE
+        && typeof options.restrictions !== 'undefined'
         && options.restrictions.min !== null
         && options.restrictions.max !== null
       ) {
@@ -94,6 +95,27 @@ const FREEAnswerOptions = ({
 
       return (
         <div className="field">
+          {do {
+            if (options.restrictions.max !== null) {
+              <FormattedMessage
+                defaultMessage="Maximum value: {max}"
+                id="freeAnswer.maxValue"
+                values={{ max: options.restrictions.max }}
+              />
+            } else if (options.restrictions.min !== null) {
+              <FormattedMessage
+                defaultMessage="Minimum value: {min}"
+                id="freeAnswer.minValue"
+                values={{ min: options.restrictions.min }}
+              />
+            } else {
+              <FormattedMessage
+                defaultMessage="Unrestricted input (any number)"
+                id="freeAnswer.unrestricted"
+              />
+            }
+          }}
+
           <textarea
             disabled={disabled}
             id="responseInput"
@@ -102,7 +124,7 @@ const FREEAnswerOptions = ({
 
           {questionType === QUESTION_TYPES.FREE_RANGE && (
             <div>
-              {options.FREE_RANGE.restrictions.min !== null && (
+              {options.restrictions.min && (
                 <div>
                   <strong>
                     <FormattedMessage
@@ -115,7 +137,7 @@ const FREEAnswerOptions = ({
                 </div>
               )}
 
-              {options.FREE_RANGE.restrictions.max !== null && (
+              {options.restrictions.max && (
                 <div>
                   <strong>
                     <FormattedMessage
@@ -133,53 +155,51 @@ const FREEAnswerOptions = ({
       )
     })()}
 
-    <style jsx>
-      {`
-        @import 'src/theme';
+    <style jsx>{`
+      @import 'src/theme';
 
-        .freeAnswerOptions {
-          .slider {
-            .min,
-            .max {
-              font-size: 1rem;
-            }
-
-            .max {
-              float: right;
-            }
+      .freeAnswerOptions {
+        .slider {
+          .min,
+          .max {
+            font-size: 1rem;
           }
 
-          textarea {
-            height: 100%;
-            min-height: 10rem;
-            width: 100%;
-          }
-
-          :global(.rangeslider__fill) {
-            background-color: $color-primary;
-          }
-
-          :global(.rangeslider__handle) {
-            padding: 1rem;
-
-            &:after {
-              display: none;
-            }
-
-            &:focus {
-              outline: none;
-            }
-          }
-
-          :global(.rangeslider__handle-label) {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate3d(-50%, -50%, 0);
+          .max {
+            float: right;
           }
         }
-      `}
-    </style>
+
+        textarea {
+          height: 100%;
+          min-height: 10rem;
+          width: 100%;
+        }
+
+        :global(.rangeslider__fill) {
+          background-color: $color-primary;
+        }
+
+        :global(.rangeslider__handle) {
+          padding: 1rem;
+
+          &:after {
+            display: none;
+          }
+
+          &:focus {
+            outline: none;
+          }
+        }
+
+        :global(.rangeslider__handle-label) {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate3d(-50%, -50%, 0);
+        }
+      }
+    `}</style>
   </div>
 )
 

--- a/src/components/questions/ActionBar.js
+++ b/src/components/questions/ActionBar.js
@@ -55,7 +55,7 @@ function ActionBar({
 
       <div className="creationButtons">
         {creationMode ? (
-          <React.Fragment>
+          <>
             <Button
               icon
               disabled={itemsChecked === 0}
@@ -83,9 +83,9 @@ function ActionBar({
                 values={{ num: +itemsChecked }}
               />
             </Button>
-          </React.Fragment>
+          </>
         ) : (
-          <React.Fragment>
+          <>
             <Button
               icon
               disabled={itemsChecked === 0}
@@ -107,7 +107,7 @@ function ActionBar({
                 />
               )}
             </Button>
-          </React.Fragment>
+          </>
         )}
       </div>
 

--- a/src/components/sessions/Session.js
+++ b/src/components/sessions/Session.js
@@ -6,6 +6,7 @@ import { Button, Icon, Message } from 'semantic-ui-react'
 import { FormattedMessage } from 'react-intl'
 
 import { QuestionBlock } from '../questions'
+import { SESSION_STATUS } from '../../constants'
 
 const propTypes = {
   blocks: PropTypes.array,
@@ -18,6 +19,7 @@ const propTypes = {
   createdAt: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
 }
 
 const defaultProps = {
@@ -25,7 +27,7 @@ const defaultProps = {
 }
 
 const Session = ({
-  button, createdAt, id, name, blocks,
+  button, createdAt, id, name, blocks, status,
 }) => {
   const isFeedbackSession = blocks.length === 0
 
@@ -71,22 +73,28 @@ const Session = ({
           </div>
         ))}
         <div className="actionArea">
-          <Link href={{ pathname: '/questions', query: { editSessionId: id } }}>
-            <Button icon labelPosition="left">
-              <Icon name="edit" />
-              Edit Session
-            </Button>
-          </Link>
-          <a
-            href={`/sessions/evaluation/${id}`}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <Button icon disabled={isFeedbackSession} labelPosition="left">
-              <Icon name="external" />
-              Evaluation
-            </Button>
-          </a>
+          {status === SESSION_STATUS.CREATED && (
+            <Link
+              href={{ pathname: '/questions', query: { editSessionId: id } }}
+            >
+              <Button icon labelPosition="left">
+                <Icon name="edit" />
+                Edit Session
+              </Button>
+            </Link>
+          )}
+          {status !== SESSION_STATUS.CREATED && (
+            <a
+              href={`/sessions/evaluation/${id}`}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <Button icon disabled={isFeedbackSession} labelPosition="left">
+                <Icon name="external" />
+                Evaluation
+              </Button>
+            </a>
+          )}
           {button
             && !button.hidden && (
               <Button

--- a/src/components/sessions/Session.js
+++ b/src/components/sessions/Session.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
+import Link from 'next/link'
 import { Button, Icon, Message } from 'semantic-ui-react'
 import { FormattedMessage } from 'react-intl'
 
@@ -70,6 +71,12 @@ const Session = ({
           </div>
         ))}
         <div className="actionArea">
+          <Link href={{ pathname: '/questions', query: { editSessionId: id } }}>
+            <Button icon labelPosition="left">
+              <Icon name="edit" />
+              Edit Session
+            </Button>
+          </Link>
           <a
             href={`/sessions/evaluation/${id}`}
             rel="noopener noreferrer"

--- a/src/components/sessions/SessionList.js
+++ b/src/components/sessions/SessionList.js
@@ -152,7 +152,7 @@ export const SessionListPres = ({
           )
 
           return (
-            <React.Fragment>
+            <>
               {runningSessions.length + pausedSessions.length > 0 ? (
                 <div className="runningSessions">
                   <h2>
@@ -182,7 +182,7 @@ export const SessionListPres = ({
               )}
 
               {remainingSessions.length > 0 && (
-                <React.Fragment>
+                <>
                   <h2>
                     <FormattedMessage
                       defaultMessage="Planned sessions"
@@ -197,11 +197,11 @@ export const SessionListPres = ({
                       <Session {...session} />
                     </div>
                   ))}
-                </React.Fragment>
+                </>
               )}
 
               {completedSessions.length > 0 && (
-                <React.Fragment>
+                <>
                   <h2>
                     <FormattedMessage
                       defaultMessage="Completed sessions"
@@ -216,9 +216,9 @@ export const SessionListPres = ({
                       <Session {...session} />
                     </div>
                   ))}
-                </React.Fragment>
+                </>
               )}
-            </React.Fragment>
+            </>
           )
         }}
       </Query>

--- a/src/constants.js
+++ b/src/constants.js
@@ -96,6 +96,14 @@ export const SMALL_PIE_THRESHOLD = 0.05
 export const CHANGELOG = {
   new: [
     {
+      items: [
+        'Reworked session creation with possibility to reorder and remove questions within and in-between blocks',
+        'Possibility to edit sessions (i.e., name and questions/blocks) that have not yet been started',
+        'Optional publication of the session evaluation screen to the audience via a separate link (/sessions/public/:id)',
+      ],
+      text: '1.0.0-public.beta.34',
+    },
+    {
       items: ['Pausing sessions'],
       text: '1.0.0-public.beta.22',
     },

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -27,6 +27,7 @@ import SessionEvaluationPublicQuery from './queries/SessionEvaluationPublicQuery
 import SessionListQuery from './queries/SessionListQuery.graphql'
 import QuestionPoolQuery from './queries/QuestionPoolQuery.graphql'
 import TagListQuery from './queries/TagListQuery.graphql'
+import SessionDetailsQuery from './queries/SessionDetailsQuery.graphql'
 
 import ConfusionAddedSubscription from './subscriptions/ConfusionAddedSubscription.graphql'
 import FeedbackAddedSubscription from './subscriptions/FeedbackAddedSubscription.graphql'
@@ -62,6 +63,7 @@ const queries = [
   TagListQuery,
   ConfusionAddedSubscription,
   FeedbackAddedSubscription,
+  SessionDetailsQuery,
 ]
 
 // build a query map from the queries above
@@ -101,5 +103,6 @@ export {
   QuestionListQuery,
   FeedbackAddedSubscription,
   ConfusionAddedSubscription,
+  SessionDetailsQuery,
   queryMap,
 }

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -16,6 +16,7 @@ import StartSessionMutation from './mutations/StartSessionMutation.graphql'
 import UpdateSessionSettingsMutation from './mutations/UpdateSessionSettingsMutation.graphql'
 import ArchiveQuestionsMutation from './mutations/ArchiveQuestionsMutation.graphql'
 import PauseSessionMutation from './mutations/PauseSessionMutation.graphql'
+import ModifySessionMutation from './mutations/ModifySessionMutation.graphql'
 
 import AccountSummaryQuery from './queries/AccountSummaryQuery.graphql'
 import JoinSessionQuery from './queries/JoinSessionQuery.graphql'
@@ -46,6 +47,7 @@ const queries = [
   LoginMutation,
   LogoutMutation,
   ModifyQuestionMutation,
+  ModifySessionMutation,
   RequestPasswordMutation,
   RegistrationMutation,
   StartSessionMutation,
@@ -86,6 +88,7 @@ export {
   LoginMutation,
   LogoutMutation,
   ModifyQuestionMutation,
+  ModifySessionMutation,
   PauseSessionMutation,
   RegistrationMutation,
   StartSessionMutation,

--- a/src/graphql/mutations/ModifySessionMutation.graphql
+++ b/src/graphql/mutations/ModifySessionMutation.graphql
@@ -1,0 +1,18 @@
+mutation ModifySession($sessionId: ID!, $name: String!, $blocks: [Session_QuestionBlockInput!]!) {
+  modifySession(session: { id: $sessionId, name: $name, blocks: $blocks }) {
+    id
+    status
+    blocks {
+      id
+      instances {
+        id
+        version
+        question {
+          id
+          title
+          type
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/mutations/ModifySessionMutation.graphql
+++ b/src/graphql/mutations/ModifySessionMutation.graphql
@@ -1,5 +1,5 @@
-mutation ModifySession($sessionId: ID!, $name: String!, $blocks: [Session_QuestionBlockInput!]!) {
-  modifySession(session: { id: $sessionId, name: $name, blocks: $blocks }) {
+mutation ModifySession($id: ID!, $name: String!, $blocks: [Session_QuestionBlockInput!]!) {
+  modifySession(id: $id, session: { name: $name, blocks: $blocks }) {
     id
     status
     blocks {

--- a/src/graphql/queries/SessionDetailsQuery.graphql
+++ b/src/graphql/queries/SessionDetailsQuery.graphql
@@ -1,0 +1,17 @@
+query SessionDetails($id: ID!) {
+  session(id: $id) {
+    id
+    name
+    blocks {
+      id
+      instances {
+        version
+        question {
+          id
+          title
+          type
+        }
+      }
+    }
+  }
+}

--- a/src/lib/withLogging.js
+++ b/src/lib/withLogging.js
@@ -19,7 +19,7 @@ export default (cfg = {}) =>
   function withLogging(Child) {
     // merge default and passed config
     const config = {
-      chatlio: true,
+      chatlio: false,
       googleAnalytics: true,
       logRocket: true,
       sentry: true,

--- a/src/pages/questions/index.js
+++ b/src/pages/questions/index.js
@@ -301,7 +301,10 @@ export default compose(
     }),
   ),
   withStateHandlers(
-    ({ editSessionDetails: { session } }) => {
+    ({ editSessionDetails }) => {
+      // extract the session from the query response
+      const session = editSessionDetails?.session
+
       // if the session of the session details query is defined, we are in edit mode
       const sessionEditMode = typeof session !== 'undefined'
 

--- a/src/pages/questions/index.js
+++ b/src/pages/questions/index.js
@@ -518,9 +518,12 @@ export default compose(
 
     // handle creating a new session
     handleCreateSession: ({
+      sessionId,
+      sessionEditMode,
       sessionName,
       sessionBlocks,
       createSession,
+      modifySession,
       startSession,
       handleCreationModeToggle,
     }) => type => async (e) => {
@@ -530,17 +533,26 @@ export default compose(
       try {
         // prepare blocks for consumption through the api
         const blocks = sessionBlocks.map(({ questions }) => ({
-          questions: questions.map(({ id, version }) => ({
+          questions: questions.map(({ id, version = 0 }) => ({
             question: id,
             version,
           })),
         }))
 
-        // create a new session
-        const result = await createSession({
-          refetchQueries: [{ query: SessionListQuery }],
-          variables: { blocks, name: sessionName },
-        })
+        let result
+        if (sessionEditMode) {
+          // modify an existing session
+          result = await modifySession({
+            refetchQueries: [{ query: SessionListQuery }],
+            variables: { blocks, id: sessionId, name: sessionName },
+          })
+        } else {
+          // create a new session
+          result = await createSession({
+            refetchQueries: [{ query: SessionListQuery }],
+            variables: { blocks, name: sessionName },
+          })
+        }
 
         // start the session immediately if the respective button was clicked
         if (type === 'start') {

--- a/src/pages/sessions/evaluation.js
+++ b/src/pages/sessions/evaluation.js
@@ -199,19 +199,17 @@ export default compose(
               ].options[activeInstance.question.type].choices.map(
                 (choice, index) => ({
                   correct: choice.correct,
-                  count: activeInstance.results
-                    ? activeInstance.results.CHOICES[index]
-                    : 0,
+                  count: activeInstance.results?.CHOICES[index] || 0,
                   value: choice.name,
                 }),
               ),
-              totalResponses: activeInstance.results.totalParticipants,
+              totalResponses: activeInstance.results?.totalParticipants || 0,
             },
           }
         }
 
         if (QUESTION_GROUPS.FREE.includes(activeInstance.question.type)) {
-          let data = activeInstance.results ? activeInstance.results.FREE : []
+          let data = activeInstance.results?.FREE || []
 
           // values in FREE_RANGE questions need to be numerical
           if (activeInstance.question.type === QUESTION_TYPES.FREE_RANGE) {
@@ -225,7 +223,7 @@ export default compose(
             ...activeInstance,
             results: {
               data,
-              totalResponses: activeInstance.results.totalParticipants,
+              totalResponses: activeInstance.results?.totalParticipants || 0,
             },
           }
         }
@@ -244,7 +242,7 @@ export default compose(
           blockStatus,
           hasSolution: !!solution,
           title: question.title,
-          totalResponses: results.totalResponses,
+          totalResponses: results?.totalResponses || 0,
         }),
       ),
       sessionStatus: session.status,
@@ -329,16 +327,16 @@ export default compose(
 
       const resultsWithPercentages = {
         ...activeInstance.results,
-        data: activeInstance.results.data.map(({ correct, count, value }) => ({
+        data: activeInstance.results?.data.map(({ correct, count, value }) => ({
           correct,
           count,
           percentage: _round(
-            100 * (count / activeInstance.results.totalResponses),
+            100 * (count / activeInstance.results?.totalResponses),
             1,
           ),
           value,
         })),
-        totalResponses: activeInstance.results.totalResponses,
+        totalResponses: activeInstance.results?.totalResponses,
       }
 
       return {

--- a/src/pages/user/login.js
+++ b/src/pages/user/login.js
@@ -31,7 +31,7 @@ const Login = ({ intl }) => (
 
       <Mutation mutation={LoginMutation}>
         {(login, { loading, error }) => (
-          <React.Fragment>
+          <>
             <Message info>
               <Message.Header>Public Beta</Message.Header>
               <Message.Content>
@@ -66,7 +66,7 @@ const Login = ({ intl }) => (
                 )
               </div>
             )}
-          </React.Fragment>
+          </>
         )}
       </Mutation>
 

--- a/src/pages/user/registration.js
+++ b/src/pages/user/registration.js
@@ -52,7 +52,7 @@ const Registration = ({ intl }) => (
           }
 
           return (
-            <React.Fragment>
+            <>
               <Message info>
                 <Message.Header>Public Beta</Message.Header>
                 <Message.Content>
@@ -88,7 +88,7 @@ const Registration = ({ intl }) => (
                   )
                 </div>
               )}
-            </React.Fragment>
+            </>
           )
         }}
       </Mutation>

--- a/src/pages/user/requestPassword.js
+++ b/src/pages/user/requestPassword.js
@@ -46,7 +46,7 @@ const RequestPassword = ({ intl }) => (
           }
 
           return (
-            <React.Fragment>
+            <>
               <PasswordRequestForm
                 intl={intl}
                 loading={loading}
@@ -55,7 +55,7 @@ const RequestPassword = ({ intl }) => (
                 }}
               />
               {error && <Message error>{error.message}</Message>}
-            </React.Fragment>
+            </>
           )
         }}
       </Mutation>

--- a/src/pages/user/resetPassword.js
+++ b/src/pages/user/resetPassword.js
@@ -53,7 +53,7 @@ const ResetPassword = ({ intl, router }) => (
           }
 
           return (
-            <React.Fragment>
+            <>
               <PasswordResetForm
                 intl={intl}
                 loading={loading}
@@ -67,7 +67,7 @@ const ResetPassword = ({ intl, router }) => (
                 }}
               />
               {error && <Message error>{error.message}</Message>}
-            </React.Fragment>
+            </>
           )
         }}
       </Mutation>

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,13 @@
     "@babel/helper-plugin-utils" "7.0.0-beta.42"
     "@babel/plugin-syntax-class-properties" "7.0.0-beta.42"
 
+"@babel/plugin-proposal-do-expressions@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-do-expressions/-/plugin-proposal-do-expressions-7.0.0-beta.51.tgz#f7443be4b5a201cf36d9563ec28055c0a2d5abec"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.51"
+    "@babel/plugin-syntax-do-expressions" "7.0.0-beta.51"
+
 "@babel/plugin-proposal-object-rest-spread@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.42.tgz#56ebd55a8268165cb7cb43a5a232b60f5435a822"


### PR DESCRIPTION
It should be possible to edit sessions that have been created but not yet started.

**DEPENDENCIES**
- Switch from `@babel/plugin-syntax-do-expressions` to `@babel/plugin-proposal-do-expressions`

**GENERAL**
- Add a `SessionDetailsQuery` and `ModifySessionMutation` for session editing purposes
- Implement session editing by query parameter on the question pool page
- Add a button to edit sessions for each session on the session list, rework other buttons
- Add range restriction messages to the join session screen (for FREE_RANGE questions)

**MISC**
- Make use of `eslint-plugin-babel` for fragments and do expressions
- Refactor fragments to shorthand syntax
- Disable chatlio by default (in config)
- (fix) Evaluation of FREE_RANGE without results (optional chaining)
- Slightly optimize padding in the session creation form for easier D&D
