### PR TITLE
Added functionality to edit Question Options

### DIFF
--- a/src/components/questionTypes/SC/SCCreationOption.js
+++ b/src/components/questionTypes/SC/SCCreationOption.js
@@ -12,9 +12,9 @@ const propTypes = {
   handleCorrectToggle: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
-  toggleEditMode: PropTypes.func.isRequired,
-  saveNewName: PropTypes.func.isRequired,
-  discardNewName: PropTypes.func.isRequired,
+  handleToggleEditMode: PropTypes.func.isRequired,
+  handleSaveNewName: PropTypes.func.isRequired,
+  handleDiscardNewName: PropTypes.func.isRequired,
 }
 
 const defaultProps = {
@@ -27,9 +27,9 @@ const SCCreationOption = ({
   name,
   handleCorrectToggle,
   handleDelete,
-  toggleEditMode,
-  saveNewName,
-  discardNewName,
+  handleToggleEditMode,
+  handleSaveNewName,
+  handleDiscardNewName,
 }) => (
   <div className={classNames('option', { correct })}>
     <button className="leftAction" disabled={disabled} type="button" onClick={handleDelete}>
@@ -46,11 +46,11 @@ const SCCreationOption = ({
     </button>
 
     <SCEditQuestionOption
-      discardNewName={discardNewName}
       editMode={false}
+      handleDiscardNewName={handleDiscardNewName}
+      handleSaveNewName={handleSaveNewName}
+      handleToggleEditMode={handleToggleEditMode}
       name={name}
-      saveNewName={saveNewName}
-      toggleEditMode={toggleEditMode}
     />
 
     <style jsx>{styles}</style>

--- a/src/components/questionTypes/SC/SCCreationOption.js
+++ b/src/components/questionTypes/SC/SCCreationOption.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Icon } from 'semantic-ui-react'
+import SCEditQuestionOption from './SCEditQuestionOption'
 
 import styles from './styles'
 
@@ -11,13 +12,25 @@ const propTypes = {
   handleCorrectToggle: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
+  toggleEditMode: PropTypes.func.isRequired,
+  saveNewName: PropTypes.func.isRequired,
+  discardNewName: PropTypes.func.isRequired,
 }
 
 const defaultProps = {
   disabled: false,
 }
 
-const SCCreationOption = ({ correct, disabled, name, handleCorrectToggle, handleDelete }) => (
+const SCCreationOption = ({
+  correct,
+  disabled,
+  name,
+  handleCorrectToggle,
+  handleDelete,
+  toggleEditMode,
+  saveNewName,
+  discardNewName,
+}) => (
   <div className={classNames('option', { correct })}>
     <button className="leftAction" disabled={disabled} type="button" onClick={handleDelete}>
       <Icon name="trash" />
@@ -32,7 +45,13 @@ const SCCreationOption = ({ correct, disabled, name, handleCorrectToggle, handle
       {correct ? <Icon name="checkmark" /> : <Icon name="remove" />}
     </button>
 
-    <div className="name">{name}</div>
+    <SCEditQuestionOption
+      discardNewName={discardNewName}
+      editMode={false}
+      name={name}
+      saveNewName={saveNewName}
+      toggleEditMode={toggleEditMode}
+    />
 
     <style jsx>{styles}</style>
   </div>

--- a/src/components/questionTypes/SC/SCCreationOptions.js
+++ b/src/components/questionTypes/SC/SCCreationOptions.js
@@ -18,6 +18,7 @@ const propTypes = {
   handleUpdateOrder: PropTypes.func.isRequired,
   invalid: PropTypes.bool.isRequired,
   value: PropTypes.arrayOf(PropTypes.object).isRequired,
+  saveNewName: PropTypes.func.isRequired,
 }
 
 // create the purely functional component
@@ -27,6 +28,7 @@ const SCCreationOptions = ({
   handleDeleteOption,
   handleUpdateOrder,
   handleOptionToggleCorrect,
+  saveNewName,
   value,
   dirty,
   invalid,
@@ -49,14 +51,16 @@ const SCCreationOptions = ({
 
   const Options = ({ sortableOptions, handleCorrectToggle, handleDelete }) => (
     <div className="options">
-      {sortableOptions.map(({ correct, name }, index) => (
+      {sortableOptions.map(({ correct, name, editMode }, index) => (
         <SortableOption
           correct={correct}
+          editMode={editMode}
           handleCorrectToggle={handleCorrectToggle(index)}
           handleDelete={handleDelete(index)}
           index={index}
           key={`sortable-${name}`}
           name={name}
+          saveNewName={saveNewName(index)}
         />
       ))}
     </div>
@@ -88,6 +92,7 @@ const SCCreationOptions = ({
         <SortableOptions
           handleCorrectToggle={handleOptionToggleCorrect}
           handleDelete={handleDeleteOption}
+          saveNewName={saveNewName}
           sortableOptions={value || []}
           onSortEnd={handleUpdateOrder}
         />
@@ -110,7 +115,8 @@ const SCCreationOptions = ({
 SCCreationOptions.propTypes = propTypes
 
 export default compose(
-  mapProps(({ onChange, value, dirty, invalid, disabled }) => ({
+  mapProps(({ onChange, value, dirty, invalid, disabled, name }) => ({
+    name,
     dirty,
     disabled,
     // HACK: mapping as a workaround for the value.choices problem
@@ -131,5 +137,10 @@ export default compose(
 
     handleUpdateOrder: ({ onChange, value }) => ({ oldIndex, newIndex }) =>
       onChange(arrayMove(value, oldIndex, newIndex)),
+
+    saveNewName: ({ value }) => index => ({ newName }) => {
+      const option = value[index]
+      option.name = newName
+    },
   })
 )(SCCreationOptions)

--- a/src/components/questionTypes/SC/SCCreationOptions.js
+++ b/src/components/questionTypes/SC/SCCreationOptions.js
@@ -18,7 +18,7 @@ const propTypes = {
   handleUpdateOrder: PropTypes.func.isRequired,
   invalid: PropTypes.bool.isRequired,
   value: PropTypes.arrayOf(PropTypes.object).isRequired,
-  saveNewName: PropTypes.func.isRequired,
+  handleSaveNewName: PropTypes.func.isRequired,
 }
 
 // create the purely functional component
@@ -28,7 +28,7 @@ const SCCreationOptions = ({
   handleDeleteOption,
   handleUpdateOrder,
   handleOptionToggleCorrect,
-  saveNewName,
+  handleSaveNewName,
   value,
   dirty,
   invalid,
@@ -41,6 +41,10 @@ const SCCreationOptions = ({
           .option {
             cursor: grab;
             margin-bottom: 0.5rem;
+          }
+          .option:hover {
+            box-shadow: 0 0 0.2rem blue;
+            -webkit-transition: all 0.1s;
           }
         `}
       </style>
@@ -57,10 +61,10 @@ const SCCreationOptions = ({
           editMode={editMode}
           handleCorrectToggle={handleCorrectToggle(index)}
           handleDelete={handleDelete(index)}
+          handleSaveNewName={handleSaveNewName(index)}
           index={index}
           key={`sortable-${name}`}
           name={name}
-          saveNewName={saveNewName(index)}
         />
       ))}
     </div>
@@ -92,12 +96,12 @@ const SCCreationOptions = ({
         <SortableOptions
           handleCorrectToggle={handleOptionToggleCorrect}
           handleDelete={handleDeleteOption}
-          saveNewName={saveNewName}
+          handleSaveNewName={handleSaveNewName}
           sortableOptions={value || []}
           onSortEnd={handleUpdateOrder}
         />
 
-        {!disabled && <SCCreationPlaceholder handleSave={handleNewOption} />}
+        {!disabled && <SCCreationPlaceholder handleSave={handleNewOption} handleSaveNewName={handleSaveNewName} />}
       </Form.Field>
 
       <style jsx>
@@ -138,7 +142,7 @@ export default compose(
     handleUpdateOrder: ({ onChange, value }) => ({ oldIndex, newIndex }) =>
       onChange(arrayMove(value, oldIndex, newIndex)),
 
-    saveNewName: ({ value }) => index => ({ newName }) => {
+    handleSaveNewName: ({ value }) => index => ({ newName }) => {
       const option = value[index]
       option.name = newName
     },

--- a/src/components/questionTypes/SC/SCCreationOptions.js
+++ b/src/components/questionTypes/SC/SCCreationOptions.js
@@ -45,6 +45,7 @@ const SCCreationOptions = ({
           .option:hover {
             box-shadow: 0 0 0.2rem blue;
             -webkit-transition: all 0.1s;
+            transition: all 0.1s;
           }
         `}
       </style>

--- a/src/components/questionTypes/SC/SCCreationPlaceholder.js
+++ b/src/components/questionTypes/SC/SCCreationPlaceholder.js
@@ -13,7 +13,11 @@ const propTypes = {
   handleSave: PropTypes.func.isRequired,
   inputMode: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  handleKeyPress: PropTypes.func.isRequired,
 }
+
+// create ref to be assigned to the input field
+const focusField = React.createRef()
 
 // create the purely functional component
 const SCCreationPlaceholder = ({
@@ -24,6 +28,7 @@ const SCCreationPlaceholder = ({
   handleModeToggle,
   handleNameChange,
   handleSave,
+  handleKeyPress,
 }) => (
   <div className={classNames('option', { inputMode })}>
     <button className="leftAction" type="button" onClick={handleModeToggle}>
@@ -34,7 +39,7 @@ const SCCreationPlaceholder = ({
       {correct ? <Icon name="checkmark" /> : <Icon name="remove" />}
     </button>
 
-    <input type="text" value={name} onChange={handleNameChange} />
+    <input ref={focusField} type="text" value={name} onChange={handleNameChange} onKeyDown={handleKeyPress} />
 
     <button className="rightAction" type="button" onClick={handleSave}>
       <Icon name="save" />
@@ -94,7 +99,10 @@ export default compose(
   withHandlers({
     handleCorrectToggle: ({ setCorrect }) => () => setCorrect(correct => !correct),
 
-    handleModeToggle: ({ setInputMode }) => () => setInputMode(inputMode => !inputMode),
+    handleModeToggle: ({ setInputMode }) => () => {
+      setInputMode(inputMode => !inputMode)
+      focusField.current.focus()
+    },
 
     handleNameChange: ({ setName }) => e => setName(e.target.value),
 
@@ -103,6 +111,19 @@ export default compose(
       setInputMode(false)
       setName('')
       handleSave({ correct, name })
+    },
+  }),
+  withHandlers({
+    handleKeyPress: ({ correct, name, handleSave, setCorrect, setInputMode, setName }) => keypress => {
+      if (keypress.key === 'Enter') {
+        keypress.preventDefault()
+        handleSave(correct, name, handleSave, setCorrect, setInputMode, setName)
+        setInputMode(true)
+      } else if (keypress.key === 'Escape') {
+        setCorrect(false)
+        setInputMode(false)
+        setName('')
+      }
     },
   })
 )(SCCreationPlaceholder)

--- a/src/components/questionTypes/SC/SCEditQuestionOption.js
+++ b/src/components/questionTypes/SC/SCEditQuestionOption.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { compose, withHandlers, withState } from 'recompose'
+import { Icon } from 'semantic-ui-react'
+import styles from './styles'
+
+const propTypes = {
+  name: PropTypes.string.isRequired,
+  editMode: PropTypes.bool.isRequired,
+  toggleEditMode: PropTypes.func.isRequired,
+  saveNewName: PropTypes.func.isRequired,
+  discardNewName: PropTypes.func.isRequired,
+  handleNameChange: PropTypes.func.isRequired,
+  handleKeyPress: PropTypes.func.isRequired,
+}
+
+const SCEditQuestionOption = ({
+  name,
+  editMode,
+  toggleEditMode,
+  saveNewName,
+  discardNewName,
+  handleNameChange,
+  handleKeyPress,
+}) => (
+  <div className="optionEditCont">
+    <div className="optionEdit">
+      {editMode ? (
+        <input type="text" value={name} onChange={handleNameChange} onKeyDown={handleKeyPress} />
+      ) : (
+        <div className="name">{name}</div>
+      )}
+    </div>
+
+    <div className="editOptBtnRight">
+      {editMode ? (
+        <button className={classNames('rightAction', { editMode })} type="button" onClick={saveNewName}>
+          <Icon name="save" />
+        </button>
+      ) : null}
+      {editMode ? (
+        <button className={classNames('rightAction', { editMode })} type="button" onClick={discardNewName}>
+          <Icon name="delete" />
+        </button>
+      ) : null}
+      {!editMode ? (
+        <button className={classNames('rightAction', { editMode })} type="button" onClick={toggleEditMode}>
+          <Icon name="edit" />
+        </button>
+      ) : null}
+    </div>
+    <style jsx>{styles}</style>
+  </div>
+)
+
+SCEditQuestionOption.propTypes = propTypes
+
+export default compose(
+  withState('editMode', 'setEditMode', false),
+  withState('name', 'setName', props => {
+    return props.name
+  }),
+  withState('origName', 'setOrigName', props => {
+    return props.name
+  }),
+
+  withHandlers({
+    handleNameChange: ({ setName }) => e => setName(e.target.value),
+    toggleEditMode: ({ setEditMode }) => () => setEditMode(editMode => !editMode),
+
+    saveNewName: ({ name, setEditMode, saveNewName, setOrigName }) => () => {
+      setEditMode(false)
+      setOrigName(name)
+      const newName = name
+      saveNewName({ newName })
+    },
+
+    discardNewName: ({ setEditMode, origName, setName }) => () => {
+      setEditMode(false)
+      setName(origName)
+    },
+
+    handleKeyPress: ({ name, setEditMode, setName, setOrigName, origName, saveNewName }) => keypress => {
+      if (keypress.key === 'Enter') {
+        setEditMode(false)
+        setOrigName(name)
+        const newName = name
+        saveNewName({ newName })
+      } else if (keypress.key === 'Escape') {
+        setEditMode(false)
+        setName(origName)
+      }
+    },
+  })
+)(SCEditQuestionOption)

--- a/src/components/questionTypes/SC/styles.js
+++ b/src/components/questionTypes/SC/styles.js
@@ -16,11 +16,24 @@ export default css`
 
   .option {
     display: flex;
-
     background-color: white;
     border: 1px solid grey;
     position: relative;
     overflow: hidden;
+  }
+
+  .optionEditCont {
+    display: flex;
+    inline-size: -webkit-fill-available;
+  }
+
+  .editOptBtnRight {
+    display: flex;
+  }
+
+  .optionEdit {
+    inline-size: -webkit-fill-available;
+    height: inherit;
   }
 
   .option.correct {


### PR DESCRIPTION
### General

- Added a "Edit" Button to edit Question Options
- Added a "Save" and a "Discard" Button to manage edits
- Pressing "Enter" will save changes in the form
- Pressing "Escape" will discard the changes

## Related Issues
Concernes: "Improved & accessible SC/MC editor"
https://github.com/uzh-bf/klicker-uzh/issues/3
