### PR TITLE
enhance(frontend-manage): add possibility to change text size on evaluation

### DIFF
--- a/apps/frontend-manage/src/components/evaluation/BarChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/BarChart.tsx
@@ -19,9 +19,14 @@ import {
 interface BarChartProps {
   data: InstanceResult
   showSolution: boolean
+  textSize: 'sm' | 'md' | 'lg'
 }
 
-function BarChart({ data, showSolution }: BarChartProps): React.ReactElement {
+function BarChart({
+  data,
+  showSolution,
+  textSize,
+}: BarChartProps): React.ReactElement {
   // add labelIn and labelOut attributes to data, set labelIn to votes if votes/totalResponses > SMALL_BAR_THRESHOLD and set labelOut to votes otherwise
   const dataWithLabels = Object.values(data.results).map((result, idx) => {
     const labelIn =
@@ -59,7 +64,14 @@ function BarChart({ data, showSolution }: BarChartProps): React.ReactElement {
             fill: 'black',
             offset: 30,
             stroke: 'black',
-            style: { fontSize: '2rem' },
+            style: {
+              fontSize:
+                textSize === 'sm'
+                  ? '1.5rem'
+                  : textSize === 'lg'
+                  ? '2.5rem'
+                  : '2rem',
+            },
           }}
         />
         <YAxis
@@ -73,7 +85,19 @@ function BarChart({ data, showSolution }: BarChartProps): React.ReactElement {
               return rounded + 1
             },
           ]}
-          label={{ angle: -90, position: 'insideLeft', value: 'Antworten' }}
+          label={{
+            angle: -90,
+            position: 'insideLeft',
+            value: 'Antworten',
+            style: {
+              fontSize:
+                textSize === 'sm'
+                  ? '1.1rem'
+                  : textSize === 'lg'
+                  ? '1.4rem'
+                  : '1.25rem',
+            },
+          }}
         />
         <CartesianGrid strokeDasharray="3 3" vertical={false} />
         <Bar
@@ -89,14 +113,28 @@ function BarChart({ data, showSolution }: BarChartProps): React.ReactElement {
             position="top"
             stroke="black"
             strokeWidth={1}
-            style={{ fontSize: '1.5rem' }}
+            style={{
+              fontSize:
+                textSize === 'sm'
+                  ? '1.25rem'
+                  : textSize === 'lg'
+                  ? '1.75rem'
+                  : '1.5rem',
+            }}
           />
           <LabelList
             dataKey="labelIn"
             fill="white"
             position="inside"
             stroke="white"
-            style={{ fontSize: '2rem' }}
+            style={{
+              fontSize:
+                textSize === 'sm'
+                  ? '1.75rem'
+                  : textSize === 'lg'
+                  ? '2.75rem'
+                  : '2.25rem',
+            }}
           />
           {QUESTION_GROUPS.CHOICES.includes(data.questionData.type) &&
             data.questionData.options.choices.map(

--- a/apps/frontend-manage/src/components/evaluation/BarChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/BarChart.tsx
@@ -19,7 +19,7 @@ import {
 interface BarChartProps {
   data: InstanceResult
   showSolution: boolean
-  textSize: 'sm' | 'md' | 'lg'
+  textSize: 'sm' | 'md' | 'lg' | 'xl'
 }
 
 function BarChart({
@@ -70,6 +70,8 @@ function BarChart({
                   ? '1.5rem'
                   : textSize === 'lg'
                   ? '2.5rem'
+                  : textSize === 'xl'
+                  ? '3rem'
                   : '2rem',
             },
           }}
@@ -95,6 +97,8 @@ function BarChart({
                   ? '1.1rem'
                   : textSize === 'lg'
                   ? '1.4rem'
+                  : textSize === 'xl'
+                  ? '1.6rem'
                   : '1.25rem',
             },
           }}
@@ -116,10 +120,12 @@ function BarChart({
             style={{
               fontSize:
                 textSize === 'sm'
-                  ? '1.25rem'
-                  : textSize === 'lg'
                   ? '1.75rem'
-                  : '1.5rem',
+                  : textSize === 'lg'
+                  ? '2.75rem'
+                  : textSize === 'xl'
+                  ? '3.25rem'
+                  : '2.25rem',
             }}
           />
           <LabelList
@@ -133,6 +139,8 @@ function BarChart({
                   ? '1.75rem'
                   : textSize === 'lg'
                   ? '2.75rem'
+                  : textSize === 'xl'
+                  ? '3.25rem'
                   : '2.25rem',
             }}
           />

--- a/apps/frontend-manage/src/components/evaluation/BarChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/BarChart.tsx
@@ -19,7 +19,7 @@ import {
 interface BarChartProps {
   data: InstanceResult
   showSolution: boolean
-  textSize: 'sm' | 'md' | 'lg' | 'xl'
+  textSize: Record<string, string>
 }
 
 function BarChart({
@@ -44,8 +44,6 @@ function BarChart({
     return { count: result.count, labelIn, labelOut, xLabel }
   })
 
-  // debugger
-
   // TODO: readd ResponsiveContainer to allow resizing with sizeMe component on level above <ResponsiveContainer><BarChartRecharts>...</BarChartRecharts></ResponsiveContainer>
   return (
     <ResponsiveContainer className="mb-4" height={600} width="99%">
@@ -64,16 +62,7 @@ function BarChart({
             fill: 'black',
             offset: 30,
             stroke: 'black',
-            style: {
-              fontSize:
-                textSize === 'sm'
-                  ? '1.5rem'
-                  : textSize === 'lg'
-                  ? '2.5rem'
-                  : textSize === 'xl'
-                  ? '3rem'
-                  : '2rem',
-            },
+            style: { fontSize: textSize.legend },
           }}
         />
         <YAxis
@@ -91,16 +80,7 @@ function BarChart({
             angle: -90,
             position: 'insideLeft',
             value: 'Antworten',
-            style: {
-              fontSize:
-                textSize === 'sm'
-                  ? '1.1rem'
-                  : textSize === 'lg'
-                  ? '1.4rem'
-                  : textSize === 'xl'
-                  ? '1.6rem'
-                  : '1.25rem',
-            },
+            className: textSize.textXl,
           }}
         />
         <CartesianGrid strokeDasharray="3 3" vertical={false} />
@@ -117,32 +97,14 @@ function BarChart({
             position="top"
             stroke="black"
             strokeWidth={1}
-            style={{
-              fontSize:
-                textSize === 'sm'
-                  ? '1.75rem'
-                  : textSize === 'lg'
-                  ? '2.75rem'
-                  : textSize === 'xl'
-                  ? '3.25rem'
-                  : '2.25rem',
-            }}
+            className={textSize.text3Xl}
           />
           <LabelList
             dataKey="labelIn"
             fill="white"
             position="inside"
             stroke="white"
-            style={{
-              fontSize:
-                textSize === 'sm'
-                  ? '1.75rem'
-                  : textSize === 'lg'
-                  ? '2.75rem'
-                  : textSize === 'xl'
-                  ? '3.25rem'
-                  : '2.25rem',
-            }}
+            className={textSize.text3Xl}
           />
           {QUESTION_GROUPS.CHOICES.includes(data.questionData.type) &&
             data.questionData.options.choices.map(

--- a/apps/frontend-manage/src/components/evaluation/Chart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Chart.tsx
@@ -9,6 +9,7 @@ interface ChartProps {
   chartType: string
   data: InstanceResult
   showSolution: boolean
+  textSize: 'sm' | 'md' | 'lg'
   statisticsShowSolution?: {
     mean?: boolean
     median?: boolean
@@ -22,22 +23,24 @@ function Chart({
   chartType,
   data,
   showSolution,
+  textSize,
   statisticsShowSolution,
 }: ChartProps): React.ReactElement {
   if (chartType === 'table') {
     // TODO: add resizing possibility with sizeMe: <SizeMe refreshRate={250}>{({ size }) => <Component />}</SizeMe>
-    return <TableChart data={data} showSolution={showSolution} />
+    return <TableChart data={data} showSolution={showSolution} textSize={textSize} />
   } else if (chartType === 'histogram') {
     return (
       <Histogram
         data={data}
         showSolution={{ general: showSolution, ...statisticsShowSolution }}
+        textSize={textSize}
       />
     )
   } else if (chartType === 'wordCloud') {
-    return <Wordcloud data={data} showSolution={showSolution} />
+    return <Wordcloud data={data} showSolution={showSolution} textSize={textSize} />
   } else if (chartType === 'barChart') {
-    return <BarChart data={data} showSolution={showSolution} />
+    return <BarChart data={data} showSolution={showSolution} textSize={textSize} />
   } else {
     return <div>There exists no chart for this question type yet</div>
   }

--- a/apps/frontend-manage/src/components/evaluation/Chart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Chart.tsx
@@ -9,7 +9,18 @@ interface ChartProps {
   chartType: string
   data: InstanceResult
   showSolution: boolean
-  textSize: 'sm' | 'md' | 'lg' | 'xl'
+  textSize: {
+    size: string
+    text: string
+    prose: string
+    textLg: string
+    textXl: string
+    text2Xl: string
+    text3Xl: string
+    legend: string
+    min: number
+    max: number
+  }
   statisticsShowSolution?: {
     mean?: boolean
     median?: boolean
@@ -26,21 +37,45 @@ function Chart({
   textSize,
   statisticsShowSolution,
 }: ChartProps): React.ReactElement {
+  console.log('chart', textSize)
   if (chartType === 'table') {
     // TODO: add resizing possibility with sizeMe: <SizeMe refreshRate={250}>{({ size }) => <Component />}</SizeMe>
-    return <TableChart data={data} showSolution={showSolution} textSize={textSize} />
+    return (
+      <TableChart
+        data={data}
+        showSolution={showSolution}
+        textSize={textSize.textLg}
+      />
+    )
   } else if (chartType === 'histogram') {
     return (
       <Histogram
         data={data}
         showSolution={{ general: showSolution, ...statisticsShowSolution }}
-        textSize={textSize}
+        textSize={textSize.text}
       />
     )
   } else if (chartType === 'wordCloud') {
-    return <Wordcloud data={data} showSolution={showSolution} textSize={textSize} />
+    return (
+      <Wordcloud
+        data={data}
+        showSolution={showSolution}
+        textSize={{ min: textSize.min, max: textSize.max }}
+      />
+    )
   } else if (chartType === 'barChart') {
-    return <BarChart data={data} showSolution={showSolution} textSize={textSize} />
+    return (
+      <BarChart
+        data={data}
+        showSolution={showSolution}
+        textSize={{
+          textXl: textSize.textXl,
+          text2Xl: textSize.text2Xl,
+          text3Xl: textSize.text3Xl,
+          legend: textSize.legend,
+        }}
+      />
+    )
   } else {
     return <div>There exists no chart for this question type yet</div>
   }

--- a/apps/frontend-manage/src/components/evaluation/Chart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Chart.tsx
@@ -9,7 +9,7 @@ interface ChartProps {
   chartType: string
   data: InstanceResult
   showSolution: boolean
-  textSize: 'sm' | 'md' | 'lg'
+  textSize: 'sm' | 'md' | 'lg' | 'xl'
   statisticsShowSolution?: {
     mean?: boolean
     median?: boolean

--- a/apps/frontend-manage/src/components/evaluation/Histogram.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Histogram.tsx
@@ -24,7 +24,7 @@ interface HistogramProps {
     q3?: boolean
     sd?: boolean
   }
-  textSize: 'sm' | 'md' | 'lg' | 'xl'
+  textSize: string
 }
 
 const defaultProps = {
@@ -91,13 +91,6 @@ function Histogram({
     return { data: dataArray, domain: { min: min, max: max } }
   }, [data, numBins])
 
-  const computedFontSize =
-    textSize === 'sm'
-      ? '1rem'
-      : textSize === 'lg' || textSize === 'xl'
-      ? '1.6rem'
-      : '1.25rem'
-
   return (
     <div className="mt-1">
       <ResponsiveContainer width="99%" height={500}>
@@ -149,10 +142,10 @@ function Histogram({
               isFront
               label={{
                 fill: 'blue',
-                fontSize: computedFontSize,
                 position: 'top',
                 value: 'MEAN',
               }}
+              className={textSize}
               key={`mean-` + data.statistics.mean}
               stroke="blue"
               x={Math.round(data.statistics.mean || 0)}
@@ -163,10 +156,10 @@ function Histogram({
               isFront
               label={{
                 fill: 'red',
-                fontSize: computedFontSize,
                 position: 'top',
                 value: 'MEDIAN',
               }}
+              className={textSize}
               key={`median-` + data.statistics.median}
               stroke="red"
               x={Math.round(data.statistics.median || 0)}
@@ -177,10 +170,10 @@ function Histogram({
               isFront
               label={{
                 fill: 'black',
-                fontSize: computedFontSize,
                 position: 'top',
                 value: 'Q1',
               }}
+              className={textSize}
               key={`q1-` + data.statistics.q1}
               stroke="black"
               x={Math.round(data.statistics.q1 || 0)}
@@ -191,10 +184,10 @@ function Histogram({
               isFront
               label={{
                 fill: 'black',
-                fontSize: computedFontSize,
                 position: 'top',
                 value: 'Q3',
               }}
+              className={textSize}
               key={`q3-` + data.statistics.q3}
               stroke="black"
               x={Math.round(data.statistics.q3 || 0)}
@@ -215,10 +208,10 @@ function Histogram({
               enableBackground="#FFFFFF"
               label={{
                 fill: 'red',
-                fontSize: computedFontSize,
                 position: 'insideTopRight',
                 value: '+- 1 SD',
               }}
+              className={textSize}
             />
           )}
 
@@ -238,10 +231,10 @@ function Histogram({
                   enableBackground="#FFFFFF"
                   label={{
                     fill: 'green',
-                    fontSize: computedFontSize,
                     position: 'top',
                     value: 'Korrekt',
                   }}
+                  className={textSize}
                 />
               )
             )}

--- a/apps/frontend-manage/src/components/evaluation/Histogram.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Histogram.tsx
@@ -24,7 +24,7 @@ interface HistogramProps {
     q3?: boolean
     sd?: boolean
   }
-  textSize: 'sm' | 'md' | 'lg'
+  textSize: 'sm' | 'md' | 'lg' | 'xl'
 }
 
 const defaultProps = {
@@ -92,7 +92,11 @@ function Histogram({
   }, [data, numBins])
 
   const computedFontSize =
-    textSize === 'sm' ? '1rem' : textSize === 'lg' ? '1.6rem' : '1.25rem'
+    textSize === 'sm'
+      ? '1rem'
+      : textSize === 'lg' || textSize === 'xl'
+      ? '1.6rem'
+      : '1.25rem'
 
   return (
     <div className="mt-1">

--- a/apps/frontend-manage/src/components/evaluation/Histogram.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Histogram.tsx
@@ -24,6 +24,7 @@ interface HistogramProps {
     q3?: boolean
     sd?: boolean
   }
+  textSize: 'sm' | 'md' | 'lg'
 }
 
 const defaultProps = {
@@ -37,7 +38,11 @@ const defaultProps = {
   },
 }
 
-function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
+function Histogram({
+  data,
+  showSolution,
+  textSize,
+}: HistogramProps): React.ReactElement {
   const [numBins, setNumBins] = useState(20)
 
   const processedData = useMemo(() => {
@@ -86,8 +91,11 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
     return { data: dataArray, domain: { min: min, max: max } }
   }, [data, numBins])
 
+  const computedFontSize =
+    textSize === 'sm' ? '1rem' : textSize === 'lg' ? '1.6rem' : '1.25rem'
+
   return (
-    <div>
+    <div className="mt-1">
       <ResponsiveContainer width="99%" height={500}>
         <BarChart
           data={processedData.data}
@@ -137,7 +145,7 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
               isFront
               label={{
                 fill: 'blue',
-                fontSize: '1rem',
+                fontSize: computedFontSize,
                 position: 'top',
                 value: 'MEAN',
               }}
@@ -151,7 +159,7 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
               isFront
               label={{
                 fill: 'red',
-                fontSize: '1rem',
+                fontSize: computedFontSize,
                 position: 'top',
                 value: 'MEDIAN',
               }}
@@ -165,7 +173,7 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
               isFront
               label={{
                 fill: 'black',
-                fontSize: '1rem',
+                fontSize: computedFontSize,
                 position: 'top',
                 value: 'Q1',
               }}
@@ -179,7 +187,7 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
               isFront
               label={{
                 fill: 'black',
-                fontSize: '1rem',
+                fontSize: computedFontSize,
                 position: 'top',
                 value: 'Q3',
               }}
@@ -203,7 +211,7 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
               enableBackground="#FFFFFF"
               label={{
                 fill: 'red',
-                fontSize: '1rem',
+                fontSize: computedFontSize,
                 position: 'insideTopRight',
                 value: '+- 1 SD',
               }}
@@ -226,7 +234,7 @@ function Histogram({ data, showSolution }: HistogramProps): React.ReactElement {
                   enableBackground="#FFFFFF"
                   label={{
                     fill: 'green',
-                    fontSize: '1rem',
+                    fontSize: computedFontSize,
                     position: 'top',
                     value: 'Korrekt',
                   }}

--- a/apps/frontend-manage/src/components/evaluation/TableChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/TableChart.tsx
@@ -6,7 +6,7 @@ import { QUESTION_GROUPS } from 'shared-components/src/constants'
 interface TableChartProps {
   data: InstanceResult
   showSolution: boolean
-  textSize: 'sm' | 'md' | 'lg'
+  textSize: 'sm' | 'md' | 'lg' | 'xl'
 }
 
 function TableChart({
@@ -67,12 +67,16 @@ function TableChart({
             ? 'text-base'
             : textSize === 'lg'
             ? 'text-xl'
+            : textSize === 'xl'
+            ? 'text-2xl'
             : 'text-lg',
         body:
           textSize === 'sm'
             ? 'text-base'
             : textSize === 'lg'
             ? 'text-xl'
+            : textSize === 'xl'
+            ? 'text-2xl'
             : 'text-lg',
       }}
     ></Table>

--- a/apps/frontend-manage/src/components/evaluation/TableChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/TableChart.tsx
@@ -6,7 +6,7 @@ import { QUESTION_GROUPS } from 'shared-components/src/constants'
 interface TableChartProps {
   data: InstanceResult
   showSolution: boolean
-  textSize: 'sm' | 'md' | 'lg' | 'xl'
+  textSize: string
 }
 
 function TableChart({
@@ -62,22 +62,8 @@ function TableChart({
       data={tableData}
       columns={columns}
       className={{
-        tableHeader:
-          textSize === 'sm'
-            ? 'text-base'
-            : textSize === 'lg'
-            ? 'text-xl'
-            : textSize === 'xl'
-            ? 'text-2xl'
-            : 'text-lg',
-        body:
-          textSize === 'sm'
-            ? 'text-base'
-            : textSize === 'lg'
-            ? 'text-xl'
-            : textSize === 'xl'
-            ? 'text-2xl'
-            : 'text-lg',
+        tableHeader: textSize,
+        body: textSize,
       }}
     ></Table>
   )

--- a/apps/frontend-manage/src/components/evaluation/TableChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/TableChart.tsx
@@ -6,11 +6,13 @@ import { QUESTION_GROUPS } from 'shared-components/src/constants'
 interface TableChartProps {
   data: InstanceResult
   showSolution: boolean
+  textSize: 'sm' | 'md' | 'lg'
 }
 
 function TableChart({
   data,
   showSolution,
+  textSize,
 }: TableChartProps): React.ReactElement {
   const tableData = useMemo(() => {
     if (QUESTION_GROUPS.CHOICES.includes(data.questionData.type)) {
@@ -55,7 +57,26 @@ function TableChart({
   if (showSolution)
     // Don't show True/False for numerical questions right now, as it is not implemented in current klicker either
     columns.push({ label: 'T/F', accessor: 'correct', sortable: true })
-  return <Table data={tableData} columns={columns}></Table>
+  return (
+    <Table
+      data={tableData}
+      columns={columns}
+      className={{
+        tableHeader:
+          textSize === 'sm'
+            ? 'text-base'
+            : textSize === 'lg'
+            ? 'text-xl'
+            : 'text-lg',
+        body:
+          textSize === 'sm'
+            ? 'text-base'
+            : textSize === 'lg'
+            ? 'text-xl'
+            : 'text-lg',
+      }}
+    ></Table>
+  )
 }
 
 export default TableChart

--- a/apps/frontend-manage/src/components/evaluation/Wordcloud.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Wordcloud.tsx
@@ -5,7 +5,7 @@ import { TagCloud } from 'react-tagcloud'
 interface WordcloudProps {
   data: InstanceResult
   showSolution: boolean // TODO: not implemented yet
-  textSize: 'sm' | 'md' | 'lg'
+  textSize: 'sm' | 'md' | 'lg' | 'xl'
 }
 
 function Wordcloud({
@@ -25,8 +25,24 @@ function Wordcloud({
     <div className="flex w-full h-full p-4">
       <TagCloud
         colorOptions={{ luminosity: 'dark' }}
-        maxSize={textSize === 'sm' ? 40 : textSize === 'lg' ? 70 : 60}
-        minSize={textSize === 'sm' ? 30 : textSize === 'lg' ? 50 : 40}
+        maxSize={
+          textSize === 'sm'
+            ? 40
+            : textSize === 'lg'
+            ? 70
+            : textSize === 'xl'
+            ? 80
+            : 60
+        }
+        minSize={
+          textSize === 'sm'
+            ? 30
+            : textSize === 'lg'
+            ? 50
+            : textSize === 'xl'
+            ? 60
+            : 40
+        }
         shuffle={false}
         tags={tags}
       />

--- a/apps/frontend-manage/src/components/evaluation/Wordcloud.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Wordcloud.tsx
@@ -5,9 +5,14 @@ import { TagCloud } from 'react-tagcloud'
 interface WordcloudProps {
   data: InstanceResult
   showSolution: boolean // TODO: not implemented yet
+  textSize: 'sm' | 'md' | 'lg'
 }
 
-function Wordcloud({ data }: WordcloudProps): React.ReactElement {
+function Wordcloud({
+  data,
+  showSolution,
+  textSize,
+}: WordcloudProps): React.ReactElement {
   const tags = useMemo(() => {
     return Object.values(data.results).map((result) => {
       return {
@@ -20,8 +25,8 @@ function Wordcloud({ data }: WordcloudProps): React.ReactElement {
     <div className="flex w-full h-full p-4">
       <TagCloud
         colorOptions={{ luminosity: 'dark' }}
-        maxSize={60}
-        minSize={18}
+        maxSize={textSize === 'sm' ? 40 : textSize === 'lg' ? 70 : 60}
+        minSize={textSize === 'sm' ? 30 : textSize === 'lg' ? 50 : 40}
         shuffle={false}
         tags={tags}
       />

--- a/apps/frontend-manage/src/components/evaluation/Wordcloud.tsx
+++ b/apps/frontend-manage/src/components/evaluation/Wordcloud.tsx
@@ -5,7 +5,7 @@ import { TagCloud } from 'react-tagcloud'
 interface WordcloudProps {
   data: InstanceResult
   showSolution: boolean // TODO: not implemented yet
-  textSize: 'sm' | 'md' | 'lg' | 'xl'
+  textSize: Record<string, number>
 }
 
 function Wordcloud({
@@ -25,24 +25,8 @@ function Wordcloud({
     <div className="flex w-full h-full p-4">
       <TagCloud
         colorOptions={{ luminosity: 'dark' }}
-        maxSize={
-          textSize === 'sm'
-            ? 40
-            : textSize === 'lg'
-            ? 70
-            : textSize === 'xl'
-            ? 80
-            : 60
-        }
-        minSize={
-          textSize === 'sm'
-            ? 30
-            : textSize === 'lg'
-            ? 50
-            : textSize === 'xl'
-            ? 60
-            : 40
-        }
+        maxSize={textSize.max}
+        minSize={textSize.min}
         shuffle={false}
         tags={tags}
       />

--- a/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
@@ -37,7 +37,7 @@ import {
   UserNotification,
 } from '@uzh-bf/design-system'
 import { useRouter } from 'next/router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useReducer, useState } from 'react'
 import {
   ACTIVE_CHART_TYPES,
   CHART_COLORS,
@@ -60,11 +60,11 @@ const INSTANCE_STATUS_ICON: Record<string, IconDefinition> = {
 function Collapsed({
   selectedInstance,
   currentInstance,
-  size,
+  proseSize,
 }: {
   selectedInstance: string
   currentInstance: Partial<InstanceResult>
-  size: string
+  proseSize: string
 }) {
   const [questionElem, setQuestionElem] = useState<HTMLDivElement | null>(null)
 
@@ -99,17 +99,12 @@ function Collapsed({
 
   return (
     <div className="border-b-[0.1rem] border-solid border-uzh-grey-80">
-      <div
-        ref={(ref) => setQuestionElem(ref)}
-        className={twMerge(computedClassName)}
-      >
+      <div ref={(ref) => setQuestionElem(ref)} className={computedClassName}>
         <Prose
           className={{
             root: twMerge(
               'flex-initial max-w-full prose-p:m-0 leading-8 prose-lg',
-              size === 'sm' && '!text-base',
-              size === 'lg' && '!text-xl !leading-9',
-              size === 'xl' && '!text-2xl !leading-10'
+              proseSize
             ),
           }}
         >
@@ -207,24 +202,165 @@ function Evaluation() {
     statistics: {},
     status: SessionBlockStatus.Executed,
   })
-  const [textSize, setTextSize] = useState<'sm' | 'md' | 'lg' | 'xl'>('md')
 
-  const increaseTextSize = () => {
-    if (textSize === 'xl') return
-    setTextSize((prev) => {
-      if (prev === 'sm') return 'md'
-      if (prev === 'md') return 'lg'
-      return 'xl'
-    })
+  const sizeReducer = (
+    state: { size: string; text: string },
+    action: { type: string }
+  ) => {
+    switch (action.type) {
+      case 'increase':
+        switch (state.size) {
+          case 'xl':
+            return {
+              size: 'xl',
+              text: 'text-xl',
+              prose: 'prose-2xl',
+              textLg: 'text-2xl',
+              textXl: 'text-3xl',
+              text2Xl: 'text-4xl',
+              text3Xl: 'text-5xl',
+              legend: '3rem',
+              min: 60,
+              max: 80,
+            }
+          case 'lg':
+            return {
+              size: 'xl',
+              text: 'text-xl',
+              prose: 'prose-2xl',
+              textLg: 'text-2xl',
+              textXl: 'text-3xl',
+              text2Xl: 'text-4xl',
+              text3Xl: 'text-5xl',
+              legend: '3rem',
+              min: 60,
+              max: 80,
+            }
+          case 'md':
+            return {
+              size: 'lg',
+              text: 'text-lg',
+              prose: 'prose-xl',
+              textLg: 'text-xl',
+              textXl: 'text-2xl',
+              text2Xl: 'text-3xl',
+              text3Xl: 'text-4xl',
+              legend: '2.5rem',
+              min: 50,
+              max: 70,
+            }
+          case 'sm':
+            return {
+              size: 'md',
+              text: 'text-base',
+              prose: 'prose-lg',
+              textLg: 'text-lg',
+              textXl: 'text-xl',
+              text2Xl: 'text-2xl',
+              text3Xl: 'text-3xl',
+              legend: '2rem',
+              min: 40,
+              max: 60,
+            }
+          default:
+            return {
+              size: 'md',
+              text: 'text-base',
+              prose: 'prose-lg',
+              textLg: 'text-lg',
+              textXl: 'text-xl',
+              text2Xl: 'text-2xl',
+              text3Xl: 'text-3xl',
+              legend: '2rem',
+              min: 40,
+              max: 60,
+            }
+        }
+      case 'decrease':
+        switch (state.size) {
+          case 'xl':
+            return {
+              size: 'lg',
+              text: 'text-lg',
+              prose: 'prose-xl',
+              textLg: 'text-xl',
+              textXl: 'text-2xl',
+              text2Xl: 'text-3xl',
+              text3Xl: 'text-4xl',
+              legend: '2.5rem',
+              min: 50,
+              max: 70,
+            }
+          case 'lg':
+            return {
+              size: 'md',
+              text: 'text-base',
+              prose: 'prose-lg',
+              textLg: 'text-lg',
+              textXl: 'text-xl',
+              text2Xl: 'text-2xl',
+              text3Xl: 'text-3xl',
+              legend: '2rem',
+              min: 40,
+              max: 60,
+            }
+          case 'md':
+            return {
+              size: 'sm',
+              text: 'text-sm',
+              prose: 'prose-base',
+              textLg: 'text-base',
+              textXl: 'text-lg',
+              text2Xl: 'text-xl',
+              text3Xl: 'text-2xl',
+              legend: '1.5rem',
+              min: 30,
+              max: 40,
+            }
+          case 'sm':
+            return {
+              size: 'sm',
+              text: 'text-sm',
+              prose: 'prose-base',
+              textLg: 'text-base',
+              textXl: 'text-lg',
+              text2Xl: 'text-xl',
+              text3Xl: 'text-2xl',
+              legend: '1.5rem',
+              min: 30,
+              max: 40,
+            }
+          default:
+            return {
+              size: 'md',
+              text: 'text-base',
+              prose: 'prose-lg',
+              textLg: 'text-lg',
+              textXl: 'text-xl',
+              text2Xl: 'text-2xl',
+              text3Xl: 'text-3xl',
+              legend: '2rem',
+              min: 40,
+              max: 60,
+            }
+        }
+      default:
+        throw new Error()
+    }
   }
-  const decreaseTextSize = () => {
-    if (textSize === 'sm') return
-    setTextSize((prev) => {
-      if (prev === 'lg') return 'md'
-      if (prev === 'xl') return 'lg'
-      return 'sm'
-    })
-  }
+
+  const [textSize, settextSize] = useReducer(sizeReducer, {
+    size: 'md',
+    text: 'text-base',
+    prose: 'prose-lg',
+    textLg: 'text-lg',
+    textXl: 'text-xl',
+    text2Xl: 'text-2xl',
+    text3Xl: 'text-3xl',
+    legend: '2rem',
+    min: 40,
+    max: 60,
+  })
 
   const {
     data,
@@ -572,7 +708,7 @@ function Evaluation() {
               <Collapsed
                 currentInstance={currentInstance}
                 selectedInstance={selectedInstance}
-                size={textSize}
+                proseSize={textSize.prose}
               />
 
               <div className="flex flex-col flex-1 md:flex-row">
@@ -593,12 +729,7 @@ function Evaluation() {
                 </div>
                 <div className="flex-initial order-1 w-64 p-4 border-l md:order-2">
                   <div
-                    className={twMerge(
-                      'flex flex-col gap-2',
-                      textSize === 'sm' && 'text-sm',
-                      textSize === 'lg' && 'text-lg',
-                      textSize === 'xl' && 'text-xl'
-                    )}
+                    className={twMerge('flex flex-col gap-2', textSize.text)}
                   >
                     <div className="font-bold">Diagramm Typ:</div>
                     <Select
@@ -812,12 +943,22 @@ function Evaluation() {
                 onCheckedChange={(newValue) => setShowSolution(newValue)}
               />
               <div className="flex flex-row items-center gap-2 ml-2">
-                <Button onClick={decreaseTextSize} disabled={textSize === 'sm'}>
+                <Button
+                  onClick={() => {
+                    settextSize({ type: 'decrease' })
+                  }}
+                  disabled={textSize.size === 'sm'}
+                >
                   <Button.Icon>
                     <FontAwesomeIcon icon={faMinus} />
                   </Button.Icon>
                 </Button>
-                <Button onClick={increaseTextSize} disabled={textSize === 'xl'}>
+                <Button
+                  onClick={() => {
+                    settextSize({ type: 'increase' })
+                  }}
+                  disabled={textSize.size === 'xl'}
+                >
                   <Button.Icon>
                     <FontAwesomeIcon icon={faPlus} />
                   </Button.Icon>

--- a/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
@@ -592,7 +592,14 @@ function Evaluation() {
                   />
                 </div>
                 <div className="flex-initial order-1 w-64 p-4 border-l md:order-2">
-                  <div className="flex flex-col gap-2">
+                  <div
+                    className={twMerge(
+                      'flex flex-col gap-2',
+                      textSize === 'sm' && 'text-sm',
+                      textSize === 'lg' && 'text-lg',
+                      textSize === 'xl' && 'text-xl'
+                    )}
+                  >
                     <div className="font-bold">Diagramm Typ:</div>
                     <Select
                       className={{ root: '-mt-1 mb-1' }}

--- a/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
@@ -203,6 +203,57 @@ function Evaluation() {
     status: SessionBlockStatus.Executed,
   })
 
+  const TextSizes = {
+    xl: {
+      size: 'xl',
+      text: 'text-xl',
+      prose: 'prose-2xl',
+      textLg: 'text-2xl',
+      textXl: 'text-3xl',
+      text2Xl: 'text-4xl',
+      text3Xl: 'text-5xl',
+      legend: '3rem',
+      min: 60,
+      max: 80,
+    },
+    lg: {
+      size: 'lg',
+      text: 'text-lg',
+      prose: 'prose-xl',
+      textLg: 'text-xl',
+      textXl: 'text-2xl',
+      text2Xl: 'text-3xl',
+      text3Xl: 'text-4xl',
+      legend: '2.5rem',
+      min: 50,
+      max: 70,
+    },
+    md: {
+      size: 'md',
+      text: 'text-base',
+      prose: 'prose-lg',
+      textLg: 'text-lg',
+      textXl: 'text-xl',
+      text2Xl: 'text-2xl',
+      text3Xl: 'text-3xl',
+      legend: '2rem',
+      min: 40,
+      max: 60,
+    },
+    sm: {
+      size: 'sm',
+      text: 'text-sm',
+      prose: 'prose-base',
+      textLg: 'text-base',
+      textXl: 'text-lg',
+      text2Xl: 'text-xl',
+      text3Xl: 'text-2xl',
+      legend: '1.5rem',
+      min: 30,
+      max: 40,
+    },
+  }
+
   const sizeReducer = (
     state: { size: string; text: string },
     action: { type: string }
@@ -211,138 +262,28 @@ function Evaluation() {
       case 'increase':
         switch (state.size) {
           case 'xl':
-            return {
-              size: 'xl',
-              text: 'text-xl',
-              prose: 'prose-2xl',
-              textLg: 'text-2xl',
-              textXl: 'text-3xl',
-              text2Xl: 'text-4xl',
-              text3Xl: 'text-5xl',
-              legend: '3rem',
-              min: 60,
-              max: 80,
-            }
+            return TextSizes.xl
           case 'lg':
-            return {
-              size: 'xl',
-              text: 'text-xl',
-              prose: 'prose-2xl',
-              textLg: 'text-2xl',
-              textXl: 'text-3xl',
-              text2Xl: 'text-4xl',
-              text3Xl: 'text-5xl',
-              legend: '3rem',
-              min: 60,
-              max: 80,
-            }
+            return TextSizes.xl
           case 'md':
-            return {
-              size: 'lg',
-              text: 'text-lg',
-              prose: 'prose-xl',
-              textLg: 'text-xl',
-              textXl: 'text-2xl',
-              text2Xl: 'text-3xl',
-              text3Xl: 'text-4xl',
-              legend: '2.5rem',
-              min: 50,
-              max: 70,
-            }
+            return TextSizes.lg
           case 'sm':
-            return {
-              size: 'md',
-              text: 'text-base',
-              prose: 'prose-lg',
-              textLg: 'text-lg',
-              textXl: 'text-xl',
-              text2Xl: 'text-2xl',
-              text3Xl: 'text-3xl',
-              legend: '2rem',
-              min: 40,
-              max: 60,
-            }
+            return TextSizes.md
           default:
-            return {
-              size: 'md',
-              text: 'text-base',
-              prose: 'prose-lg',
-              textLg: 'text-lg',
-              textXl: 'text-xl',
-              text2Xl: 'text-2xl',
-              text3Xl: 'text-3xl',
-              legend: '2rem',
-              min: 40,
-              max: 60,
-            }
+            return TextSizes.md
         }
       case 'decrease':
         switch (state.size) {
           case 'xl':
-            return {
-              size: 'lg',
-              text: 'text-lg',
-              prose: 'prose-xl',
-              textLg: 'text-xl',
-              textXl: 'text-2xl',
-              text2Xl: 'text-3xl',
-              text3Xl: 'text-4xl',
-              legend: '2.5rem',
-              min: 50,
-              max: 70,
-            }
+            return TextSizes.lg
           case 'lg':
-            return {
-              size: 'md',
-              text: 'text-base',
-              prose: 'prose-lg',
-              textLg: 'text-lg',
-              textXl: 'text-xl',
-              text2Xl: 'text-2xl',
-              text3Xl: 'text-3xl',
-              legend: '2rem',
-              min: 40,
-              max: 60,
-            }
+            return TextSizes.md
           case 'md':
-            return {
-              size: 'sm',
-              text: 'text-sm',
-              prose: 'prose-base',
-              textLg: 'text-base',
-              textXl: 'text-lg',
-              text2Xl: 'text-xl',
-              text3Xl: 'text-2xl',
-              legend: '1.5rem',
-              min: 30,
-              max: 40,
-            }
+            return TextSizes.sm
           case 'sm':
-            return {
-              size: 'sm',
-              text: 'text-sm',
-              prose: 'prose-base',
-              textLg: 'text-base',
-              textXl: 'text-lg',
-              text2Xl: 'text-xl',
-              text3Xl: 'text-2xl',
-              legend: '1.5rem',
-              min: 30,
-              max: 40,
-            }
+            return TextSizes.sm
           default:
-            return {
-              size: 'md',
-              text: 'text-base',
-              prose: 'prose-lg',
-              textLg: 'text-lg',
-              textXl: 'text-xl',
-              text2Xl: 'text-2xl',
-              text3Xl: 'text-3xl',
-              legend: '2rem',
-              min: 40,
-              max: 60,
-            }
+            return TextSizes.md
         }
       default:
         throw new Error()

--- a/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
@@ -871,7 +871,12 @@ function Evaluation() {
         </RadixTab.Content>
       </div>
 
-      <Footer className="relative flex-none h-14">
+      <Footer
+        className={twMerge(
+          'relative flex-none h-14',
+          (feedbacks || confusion || leaderboard) && 'h-18'
+        )}
+      >
         {currentInstance && !feedbacks && !confusion && !leaderboard && (
           <div className="flex flex-row items-center justify-between px-4 py-2.5 pr-8 m-0">
             <div className="text-lg">

--- a/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
@@ -9,7 +9,10 @@ import {
   faChevronUp,
   faComment,
   faFaceSmile,
+  faFont,
   faGamepad,
+  faMinus,
+  faPlus,
   faSync,
   IconDefinition,
 } from '@fortawesome/free-solid-svg-icons'
@@ -57,9 +60,11 @@ const INSTANCE_STATUS_ICON: Record<string, IconDefinition> = {
 function Collapsed({
   selectedInstance,
   currentInstance,
+  size,
 }: {
   selectedInstance: string
   currentInstance: Partial<InstanceResult>
+  size: string
 }) {
   const [questionElem, setQuestionElem] = useState<HTMLDivElement | null>(null)
 
@@ -83,22 +88,28 @@ function Collapsed({
     return () => setQuestionElem(null)
   }, [questionCollapsed, questionElem, selectedInstance])
 
+  const computedClassName = twMerge(
+    questionCollapsed ? 'md:max-h-[7rem]' : 'md:max-h-content',
+    !showExtensibleButton && 'border-solid border-b-only border-primary',
+    showExtensibleButton &&
+      questionCollapsed &&
+      'md:bg-clip-text md:bg-gradient-to-b md:from-black md:via-black md:to-white md:text-transparent',
+    'w-full md:overflow-y-hidden md:self-start flex-[0_0_auto] p-4 text-left'
+  )
+
   return (
-    <div className={`border-b-[0.1rem] border-solid border-uzh-grey-80`}>
+    <div className="border-b-[0.1rem] border-solid border-uzh-grey-80">
       <div
         ref={(ref) => setQuestionElem(ref)}
-        className={twMerge(
-          questionCollapsed ? 'md:max-h-[7rem]' : 'md:max-h-content',
-          !showExtensibleButton && 'border-solid border-b-only border-primary',
-          showExtensibleButton &&
-            questionCollapsed &&
-            'md:bg-clip-text md:bg-gradient-to-b md:from-black md:via-black md:to-white md:text-transparent',
-          'w-full md:overflow-y-hidden md:self-start flex-[0_0_auto] p-4 text-left'
-        )}
+        className={twMerge(computedClassName)}
       >
         <Prose
           className={{
-            root: 'flex-initial max-w-full leading-8 prose-lg prose-p:m-0',
+            root: twMerge(
+              'flex-initial max-w-full prose-p:m-0 leading-8 prose-lg',
+              size === 'sm' && '!text-base',
+              size === 'lg' && '!text-xl !leading-9'
+            ),
           }}
         >
           <Markdown
@@ -195,6 +206,22 @@ function Evaluation() {
     statistics: {},
     status: SessionBlockStatus.Executed,
   })
+  const [textSize, setTextSize] = useState<'sm' | 'md' | 'lg'>('md')
+
+  const increaseTextSize = () => {
+    if (textSize === 'lg') return
+    setTextSize((prev) => {
+      if (prev === 'sm') return 'md'
+      return 'lg'
+    })
+  }
+  const decreaseTextSize = () => {
+    if (textSize === 'sm') return
+    setTextSize((prev) => {
+      if (prev === 'lg') return 'md'
+      return 'sm'
+    })
+  }
 
   const {
     data,
@@ -542,6 +569,7 @@ function Evaluation() {
               <Collapsed
                 currentInstance={currentInstance}
                 selectedInstance={selectedInstance}
+                size={textSize}
               />
 
               <div className="flex flex-col flex-1 md:flex-row">
@@ -550,6 +578,7 @@ function Evaluation() {
                     chartType={chartType}
                     data={currentInstance}
                     showSolution={showSolution}
+                    textSize={textSize}
                     statisticsShowSolution={{
                       mean: statisticStates.mean,
                       median: statisticStates.median,
@@ -760,17 +789,33 @@ function Evaluation() {
         </RadixTab.Content>
       </div>
 
-      <Footer className="relative flex-none h-18">
+      <Footer className="relative flex-none h-14">
         {currentInstance && !feedbacks && !confusion && !leaderboard && (
-          <div className="flex flex-row justify-between p-4 pr-8 m-0">
-            <div className="text-xl">
+          <div className="flex flex-row items-center justify-between px-4 py-2.5 pr-8 m-0">
+            <div className="text-lg">
               Total Teilnehmende: {currentInstance.participants}
             </div>
-            <Switch
-              checked={showSolution}
-              label="Lösung anzeigen"
-              onCheckedChange={(newValue) => setShowSolution(newValue)}
-            />
+            <div className="flex flex-row items-center gap-5">
+              <Switch
+                checked={showSolution}
+                label="Lösung anzeigen"
+                onCheckedChange={(newValue) => setShowSolution(newValue)}
+              />
+              <div className="flex flex-row items-center gap-2 ml-2">
+                <Button onClick={decreaseTextSize} disabled={textSize === 'sm'}>
+                  <Button.Icon>
+                    <FontAwesomeIcon icon={faMinus} />
+                  </Button.Icon>
+                </Button>
+                <Button onClick={increaseTextSize} disabled={textSize === 'lg'}>
+                  <Button.Icon>
+                    <FontAwesomeIcon icon={faPlus} />
+                  </Button.Icon>
+                </Button>
+                <FontAwesomeIcon icon={faFont} size="lg" />
+                Schriftgrösse
+              </div>
+            </div>
           </div>
         )}
       </Footer>

--- a/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/evaluation.tsx
@@ -108,7 +108,8 @@ function Collapsed({
             root: twMerge(
               'flex-initial max-w-full prose-p:m-0 leading-8 prose-lg',
               size === 'sm' && '!text-base',
-              size === 'lg' && '!text-xl !leading-9'
+              size === 'lg' && '!text-xl !leading-9',
+              size === 'xl' && '!text-2xl !leading-10'
             ),
           }}
         >
@@ -206,19 +207,21 @@ function Evaluation() {
     statistics: {},
     status: SessionBlockStatus.Executed,
   })
-  const [textSize, setTextSize] = useState<'sm' | 'md' | 'lg'>('md')
+  const [textSize, setTextSize] = useState<'sm' | 'md' | 'lg' | 'xl'>('md')
 
   const increaseTextSize = () => {
-    if (textSize === 'lg') return
+    if (textSize === 'xl') return
     setTextSize((prev) => {
       if (prev === 'sm') return 'md'
-      return 'lg'
+      if (prev === 'md') return 'lg'
+      return 'xl'
     })
   }
   const decreaseTextSize = () => {
     if (textSize === 'sm') return
     setTextSize((prev) => {
       if (prev === 'lg') return 'md'
+      if (prev === 'xl') return 'lg'
       return 'sm'
     })
   }
@@ -807,7 +810,7 @@ function Evaluation() {
                     <FontAwesomeIcon icon={faMinus} />
                   </Button.Icon>
                 </Button>
-                <Button onClick={increaseTextSize} disabled={textSize === 'lg'}>
+                <Button onClick={increaseTextSize} disabled={textSize === 'xl'}>
                   <Button.Icon>
                     <FontAwesomeIcon icon={faPlus} />
                   </Button.Icon>


### PR DESCRIPTION
This pull request adds a button and corresponding style attributes that are required to change the font size on the evaluation page within some pre-defined limits. Note that only the parts relevant to students get rescaled as the rescaling is meant for presentation mode.

<img width="1565" alt="Screenshot 2022-12-11 at 14 09 56" src="https://user-images.githubusercontent.com/80708107/206905621-6c9c4fc1-96a6-45f1-8ea7-b70dd4eb5a99.png">
<img width="1565" alt="Screenshot 2022-12-11 at 14 10 00" src="https://user-images.githubusercontent.com/80708107/206905633-4a59a976-f2e8-4d37-afac-65b8408358b1.png">
<img width="1565" alt="Screenshot 2022-12-11 at 14 10 06" src="https://user-images.githubusercontent.com/80708107/206905637-9913ee08-0c50-43be-b975-bd9d26910a57.png">
<img width="1565" alt="Screenshot 2022-12-11 at 14 10 11" src="https://user-images.githubusercontent.com/80708107/206905639-e25a6c54-0299-4a83-a546-a889ba232b68.png">
