### PR TITLE
style(frontend-manage): refactor shortening logic of choices on evaluation view

### DIFF
--- a/apps/frontend-manage/src/components/common/Ellipsis.tsx
+++ b/apps/frontend-manage/src/components/common/Ellipsis.tsx
@@ -1,5 +1,5 @@
 import Markdown from '@klicker-uzh/markdown'
-import { Tooltip } from '@uzh-bf/design-system'
+import { Prose, Tooltip } from '@uzh-bf/design-system'
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
 
@@ -41,7 +41,15 @@ function Ellipsis({
   if (maxLines) {
     return (
       <Tooltip
-        tooltip={parsedContent}
+        tooltip={
+          <Prose
+            className={{
+              root: 'flex-initial max-w-full leading-6 prose-p:m-0 prose-invert text-white hover:text-white',
+            }}
+          >
+            {parsedContent}
+          </Prose>
+        }
         className={{
           tooltip: twMerge(
             'text-sm max-w-[50%] md:max-w-[60%]',
@@ -51,14 +59,13 @@ function Ellipsis({
         withIndicator={false}
       >
         <div className={twMerge(`line-clamp-${maxLines}`, className?.root)}>
-          <Markdown
-            content={
-              children
-                ? children.toString().replace(/^(- |[0-9]+\. |\* |\+ )/g, '')
-                : 'No content'
-            }
-            className={className?.markdown}
-          />
+          <Prose
+            className={{
+              root: 'flex-initial max-w-full leading-6 prose-p:m-0 text-black hover:text-black',
+            }}
+          >
+            {parsedContent}
+          </Prose>
         </div>
       </Tooltip>
     )
@@ -91,25 +98,27 @@ function Ellipsis({
 
   // compute shortened output based on either maxLength or endIndex
   const shortenedParsedContent = (
-    <Markdown
-      content={
-        children
-          ? `${children
-              .toString()
-              .substr(0, endIndex || maxLength)
-              .replace(/^(- |[0-9]+\. |\* |\+ )/g, '')} **...**`
-          : 'no content'
-      }
-      className={className?.markdown}
-    />
+    <Prose
+      className={{
+        root: 'flex-initial max-w-full leading-6 prose-p:m-0 text-black hover:text-black',
+      }}
+    >
+      <Markdown
+        content={`${children
+          .toString()
+          .substr(0, endIndex || maxLength)
+          .replace(/^(- |[0-9]+\. |\* |\+ )/g, '')} **...**`}
+        className={className?.markdown}
+      />
+    </Prose>
   )
 
   // return full content if it was shorter than the set maxLength or if endIndex = children.length
   // (whole string is included in shortened version)
   if (
-    children?.length <= maxLength ||
+    children.length <= maxLength ||
     typeof children !== 'string' ||
-    children?.length === endIndex
+    children.length === endIndex
   ) {
     return parsedContent
   }

--- a/apps/frontend-manage/src/components/common/Ellipsis.tsx
+++ b/apps/frontend-manage/src/components/common/Ellipsis.tsx
@@ -3,9 +3,10 @@ import { Tooltip } from '@uzh-bf/design-system'
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
 
-interface Props {
+interface EllipsisProps {
   children: string
-  maxLength: number
+  maxLength?: number
+  maxLines?: number
   withoutPopup?: boolean
   className?: {
     root?: string
@@ -14,22 +15,58 @@ interface Props {
   }
 }
 
+interface EllipsisPropsMaxLength extends EllipsisProps {
+  maxLength: number
+  maxLines?: never
+}
+interface EllipsisPropsMaxLines extends EllipsisProps {
+  maxLength?: never
+  maxLines: number
+}
+
 function Ellipsis({
   children,
   maxLength,
+  maxLines,
   withoutPopup,
   className,
-}: Props): React.ReactElement {
+}: EllipsisPropsMaxLength | EllipsisPropsMaxLines): React.ReactElement {
   const parsedContent = (
     <Markdown
-      content={
-        children
-          ? children.toString().replace(/^(- |[0-9]+\. |\* |\+ )/g, '')
-          : 'no content'
-      }
+      content={children.toString().replace(/^(- |[0-9]+\. |\* |\+ )/g, '')}
       className={className?.markdown}
     />
   )
+
+  if (maxLines) {
+    return (
+      <Tooltip
+        tooltip={parsedContent}
+        className={{
+          tooltip: twMerge(
+            'text-sm max-w-[50%] md:max-w-[60%]',
+            className?.tooltip
+          ),
+        }}
+        withIndicator={false}
+      >
+        <div className={twMerge(`line-clamp-${maxLines}`, className?.root)}>
+          <Markdown
+            content={
+              children
+                ? children.toString().replace(/^(- |[0-9]+\. |\* |\+ )/g, '')
+                : 'No content'
+            }
+            className={className?.markdown}
+          />
+        </div>
+      </Tooltip>
+    )
+  }
+
+  if (!maxLength) {
+    return <div>No content</div>
+  }
 
   const formulaRegex = RegExp(/(\${2})[^]*?[^\\]\1/gm)
   let endIndex = null

--- a/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
+++ b/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
@@ -102,10 +102,13 @@ function QuestionEvaluation({
                           {String.fromCharCode(65 + innerIndex)}
                         </div>
 
-                        <div className="w-[calc(100%-3rem)]">
+                        <div className="w-[calc(100%-3rem)] line-clamp-3">
                           <Ellipsis
-                            maxLength={60}
-                            className={{ tooltip: 'z-20 float-right' }}
+                            maxLines={3}
+                            className={{
+                              tooltip:
+                                'z-20 float-right !text-white min-w-[25rem]',
+                            }}
                           >
                             {choice.value}
                           </Ellipsis>


### PR DESCRIPTION
This pull request enhances the implementation of the ellipsis component so that it is now possible to either shorten the content to a maximum length of characters or a maximum number of lines. This shortening to a maximum number of lines is better suited for the choices on the evaluation page, as the markdown content can quickly contain many lines without a lot of characters and introduce layout issues.
<img width="1641" alt="Screenshot 2023-01-06 at 11 19 15" src="https://user-images.githubusercontent.com/80708107/210983814-7b6c0081-e0f9-4971-a2dd-0246afe58191.png">
