### PR TITLE
enhance(frontend-manage): add reordering possiblities for session creation forms

### DIFF
--- a/apps/frontend-manage/src/components/sessions/creation/LearningElementCreationForm.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LearningElementCreationForm.tsx
@@ -191,7 +191,7 @@ function LearningElementCreationForm({
                       showTooltipSymbol={true}
                     />
                     <FieldArray name="questions">
-                      {({ push, remove }: FieldArrayRenderProps) => (
+                      {({ push, remove, move }: FieldArrayRenderProps) => (
                         <div className="flex flex-row gap-1 overflow-scroll">
                           {values.questions.map(
                             (question: any, index: number) => (
@@ -199,7 +199,9 @@ function LearningElementCreationForm({
                                 key={`${question.id}`}
                                 index={index}
                                 question={question}
+                                numOfBlocks={values.questions.length}
                                 remove={remove}
+                                move={move}
                               />
                             )
                           )}

--- a/apps/frontend-manage/src/components/sessions/creation/LearningElementCreationForm.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LearningElementCreationForm.tsx
@@ -196,7 +196,7 @@ function LearningElementCreationForm({
                           {values.questions.map(
                             (question: any, index: number) => (
                               <QuestionBlock
-                                key={`${question.id}`}
+                                key={`${question.id}-${index}`}
                                 index={index}
                                 question={question}
                                 numOfBlocks={values.questions.length}

--- a/apps/frontend-manage/src/components/sessions/creation/LiveSessionCreationForm.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LiveSessionCreationForm.tsx
@@ -31,7 +31,7 @@ import { twMerge } from 'tailwind-merge'
 import * as yup from 'yup'
 import AddBlockButton from './AddBlockButton'
 import EditorField from './EditorField'
-import SessionBlock from './SessionBlock'
+import SessionCreationBlock from './SessionCreationBlock'
 
 interface LiveSessionCreationFormProps {
   courses?: {
@@ -244,15 +244,17 @@ function LiveSessionCreationForm({
                     showTooltipSymbol={true}
                   />
                   <FieldArray name="blocks">
-                    {({ push, remove }: FieldArrayRenderProps) => (
+                    {({ push, remove, move }: FieldArrayRenderProps) => (
                       <div className="flex flex-row gap-1 overflow-scroll">
                         {values.blocks.map((block: any, index: number) => (
-                          <SessionBlock
+                          <SessionCreationBlock
                             key={`${index}-${block.questionIds.join('')}`}
                             index={index}
                             block={block}
+                            numOfBlocks={values.blocks.length}
                             setFieldValue={setFieldValue}
                             remove={remove}
+                            move={move}
                           />
                         ))}
                         <AddBlockButton push={push} />

--- a/apps/frontend-manage/src/components/sessions/creation/MicroSessionCreationForm.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/MicroSessionCreationForm.tsx
@@ -229,7 +229,7 @@ function MicroSessionCreationForm({
                     showTooltipSymbol={true}
                   />
                   <FieldArray name="questions">
-                    {({ push, remove }: FieldArrayRenderProps) => (
+                    {({ push, remove, move }: FieldArrayRenderProps) => (
                       <div className="flex flex-row gap-1 overflow-scroll">
                         {values.questions.map(
                           (question: any, index: number) => (
@@ -237,7 +237,9 @@ function MicroSessionCreationForm({
                               key={`${question.id}-${index}`}
                               index={index}
                               question={question}
+                              numOfBlocks={values.questions.length}
                               remove={remove}
+                              move={move}
                             />
                           )
                         )}

--- a/apps/frontend-manage/src/components/sessions/creation/QuestionBlock.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/QuestionBlock.tsx
@@ -3,17 +3,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, ThemeContext } from '@uzh-bf/design-system'
 import { useContext } from 'react'
 
-interface SessionBlockProps {
+interface QuestionBlockProps {
   index: number
   question: { id: number; title: string }
   remove: (index: number) => void
 }
 
-function SessionBlock({
+function QuestionBlock({
   index,
   question,
   remove,
-}: SessionBlockProps): React.ReactElement {
+}: QuestionBlockProps): React.ReactElement {
   const theme = useContext(ThemeContext)
 
   return (
@@ -39,4 +39,4 @@ function SessionBlock({
   )
 }
 
-export default SessionBlock
+export default QuestionBlock

--- a/apps/frontend-manage/src/components/sessions/creation/QuestionBlock.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/QuestionBlock.tsx
@@ -1,4 +1,8 @@
-import { faTrash } from '@fortawesome/free-solid-svg-icons'
+import {
+  faArrowLeft,
+  faArrowRight,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, ThemeContext } from '@uzh-bf/design-system'
 import { useContext } from 'react'
@@ -6,13 +10,17 @@ import { useContext } from 'react'
 interface QuestionBlockProps {
   index: number
   question: { id: number; title: string }
+  numOfBlocks: number
   remove: (index: number) => void
+  move: (from: number, to: number) => void
 }
 
 function QuestionBlock({
   index,
   question,
+  numOfBlocks,
   remove,
+  move,
 }: QuestionBlockProps): React.ReactElement {
   const theme = useContext(ThemeContext)
 
@@ -24,6 +32,26 @@ function QuestionBlock({
       <div className="flex flex-row items-center justify-between">
         <div className="font-bold">Frage {index + 1}</div>
         <div className="flex flex-row gap-1 ml-2">
+          <Button
+            basic
+            className={{ root: 'mx-1' }}
+            onClick={() => move(index, index !== 0 ? index - 1 : index)}
+          >
+            <Button.Icon>
+              <FontAwesomeIcon icon={faArrowLeft} />
+            </Button.Icon>
+          </Button>
+          <Button
+            basic
+            className={{ root: 'ml-1 mr-2' }}
+            onClick={() =>
+              move(index, index !== numOfBlocks ? index + 1 : index)
+            }
+          >
+            <Button.Icon>
+              <FontAwesomeIcon icon={faArrowRight} />
+            </Button.Icon>
+          </Button>
           <Button
             onClick={() => remove(index)}
             className={{

--- a/apps/frontend-manage/src/components/sessions/creation/SessionCreationBlock.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/SessionCreationBlock.tsx
@@ -1,4 +1,10 @@
-import { faGears, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
+import {
+  faArrowLeft,
+  faArrowRight,
+  faGears,
+  faPlus,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   Button,
@@ -10,19 +16,23 @@ import { useContext, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import { twMerge } from 'tailwind-merge'
 
-interface SessionBlockProps {
+interface SessionCreationBlockProps {
   index: number
   block: { questionIds: number[]; titles: string[]; timeLimit: string }
+  numOfBlocks: number
   setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void
   remove: (index: number) => void
+  move: (from: number, to: number) => void
 }
 
-function SessionBlock({
+function SessionCreationBlock({
   index,
   block,
+  numOfBlocks,
   setFieldValue,
   remove,
-}: SessionBlockProps): React.ReactElement {
+  move,
+}: SessionCreationBlockProps): React.ReactElement {
   const theme = useContext(ThemeContext)
   const [openSettings, setOpenSettings] = useState(false)
 
@@ -59,6 +69,26 @@ function SessionBlock({
           Block {index + 1}
         </div>
         <div className="flex flex-row gap-1 ml-2">
+          <Button
+            basic
+            className={{ root: 'mx-1' }}
+            onClick={() => move(index, index !== 0 ? index - 1 : index)}
+          >
+            <Button.Icon>
+              <FontAwesomeIcon icon={faArrowLeft} />
+            </Button.Icon>
+          </Button>
+          <Button
+            basic
+            className={{ root: 'ml-1 mr-2' }}
+            onClick={() =>
+              move(index, index !== numOfBlocks ? index + 1 : index)
+            }
+          >
+            <Button.Icon>
+              <FontAwesomeIcon icon={faArrowRight} />
+            </Button.Icon>
+          </Button>
           <Button
             onClick={() => remove(index)}
             className={{
@@ -136,4 +166,4 @@ function SessionBlock({
   )
 }
 
-export default SessionBlock
+export default SessionCreationBlock

--- a/apps/frontend-manage/src/components/sessions/creation/SessionCreationBlock.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/SessionCreationBlock.tsx
@@ -1,6 +1,8 @@
 import {
+  faArrowDown,
   faArrowLeft,
   faArrowRight,
+  faArrowUp,
   faGears,
   faPlus,
   faTrash,
@@ -115,6 +117,81 @@ function SessionCreationBlock({
             className="flex flex-row border border-solid rounded bg-uzh-grey-20 border-uzh-grey-100"
           >
             <div className="p-0.5 flex-1">{title}</div>
+            <div className="h-full">
+              <Button
+                basic
+                className={{
+                  root: twMerge(
+                    'flex flex-col justify-center h-1/2 px-2',
+                    theme.primaryBgHover
+                  ),
+                }}
+                onClick={() => {
+                  if (!(questionIdx === 0 || block.questionIds.length === 1)) {
+                    const tempId = block.questionIds[questionIdx]
+                    const tempTitle = block.titles[questionIdx]
+
+                    setFieldValue(
+                      `blocks[${index}][questionIds][${questionIdx}]`,
+                      block.questionIds[questionIdx - 1]
+                    )
+                    setFieldValue(
+                      `blocks[${index}][titles][${questionIdx}]`,
+                      block.titles[questionIdx - 1]
+                    )
+                    setFieldValue(
+                      `blocks[${index}][questionIds][${questionIdx - 1}]`,
+                      tempId
+                    )
+                    setFieldValue(
+                      `blocks[${index}][titles][${questionIdx - 1}]`,
+                      tempTitle
+                    )
+                  }
+                }}
+              >
+                <FontAwesomeIcon icon={faArrowUp} />
+              </Button>
+              <Button
+                basic
+                className={{
+                  root: twMerge(
+                    'flex flex-col justify-center h-1/2 px-2',
+                    theme.primaryBgHover
+                  ),
+                }}
+                onClick={() => {
+                  if (
+                    !(
+                      block.questionIds.length === questionIdx - 1 ||
+                      block.questionIds.length === 1
+                    )
+                  ) {
+                    const tempId = block.questionIds[questionIdx]
+                    const tempTitle = block.titles[questionIdx]
+
+                    setFieldValue(
+                      `blocks[${index}][questionIds][${questionIdx}]`,
+                      block.questionIds[questionIdx + 1]
+                    )
+                    setFieldValue(
+                      `blocks[${index}][titles][${questionIdx}]`,
+                      block.titles[questionIdx + 1]
+                    )
+                    setFieldValue(
+                      `blocks[${index}][questionIds][${questionIdx + 1}]`,
+                      tempId
+                    )
+                    setFieldValue(
+                      `blocks[${index}][titles][${questionIdx + 1}]`,
+                      tempTitle
+                    )
+                  }
+                }}
+              >
+                <FontAwesomeIcon icon={faArrowDown} />
+              </Button>
+            </div>
             <div
               className={`flex items-center px-2 text-white ${theme.primaryTextHover} bg-red-500 hover:bg-red-600 rounded-r`}
               onClick={() => {


### PR DESCRIPTION
This pull request introduces the possibility to reorder blocks and question blocks on session creation forms for live sessions, micro sessions and learning elements as well as reordering possibilities for questions inside live session blocks.
<img width="1362" alt="Screenshot 2023-01-06 at 11 11 29" src="https://user-images.githubusercontent.com/80708107/210983980-64c9f7a7-4ed2-4644-8fd0-88cac8134c5b.png">
<img width="1368" alt="Screenshot 2023-01-06 at 11 11 12" src="https://user-images.githubusercontent.com/80708107/210983992-c405c1be-0def-42bd-a3e2-c0c742c867c1.png">
<img width="1371" alt="Screenshot 2023-01-06 at 11 10 59" src="https://user-images.githubusercontent.com/80708107/210983996-1d88d74d-1f68-4cc0-b1b4-37ea03556008.png">
