### PR TITLE
feat(frontend-control): embed links on controller frontend

### DIFF
--- a/apps/frontend-control/src/components/Layout.tsx
+++ b/apps/frontend-control/src/components/Layout.tsx
@@ -9,10 +9,11 @@ import MobileMenuBar from './layout/MobileMenuBar'
 interface LayoutProps {
   title: string
   children: React.ReactNode
+  sessionId?: string
   className?: string
 }
 
-function Layout({ title, children, className }: LayoutProps) {
+function Layout({ title, children, sessionId, className }: LayoutProps) {
   const router = useRouter()
   const {
     loading: loadingUser,
@@ -48,7 +49,7 @@ function Layout({ title, children, className }: LayoutProps) {
         </div>
 
         <div className="fixed bottom-0 w-full h-12 md:hidden">
-          <MobileMenuBar />
+          <MobileMenuBar sessionId={sessionId} />
         </div>
       </div>
     </div>

--- a/apps/frontend-control/src/components/layout/MenuButton.tsx
+++ b/apps/frontend-control/src/components/layout/MenuButton.tsx
@@ -33,7 +33,9 @@ function MenuButton({
       onClick={onClick}
       disabled={disabled}
     >
-      <Button.Icon className={{ root: className?.icon }}>{icon}</Button.Icon>
+      <Button.Icon className={{ root: twMerge('w-max', className?.icon) }}>
+        {icon}
+      </Button.Icon>
       <Button.Label className={{ root: twMerge('text-xs', className?.label) }}>
         {children}
       </Button.Label>

--- a/apps/frontend-control/src/components/layout/MenuButton.tsx
+++ b/apps/frontend-control/src/components/layout/MenuButton.tsx
@@ -5,6 +5,7 @@ interface MenuButtonProps {
   icon: React.ReactNode
   children: React.ReactNode
   onClick: () => void
+  disabled?: boolean
   className?: {
     root?: string
     icon?: string
@@ -12,16 +13,25 @@ interface MenuButtonProps {
   }
 }
 
-function MenuButton({ icon, children, onClick, className }: MenuButtonProps) {
+function MenuButton({
+  icon,
+  disabled,
+  children,
+  onClick,
+  className,
+}: MenuButtonProps) {
+  console.log(disabled)
   return (
     <Button
       className={{
         root: twMerge(
           'flex justify-center flex-1 my-0.5 flex-col gap-0 bg-grey-60 border-0 shadow-none text-white',
+          disabled && 'cursor-not-allowed text-uzh-grey-100',
           className?.root
         ),
       }}
       onClick={onClick}
+      disabled={disabled}
     >
       <Button.Icon className={{ root: className?.icon }}>{icon}</Button.Icon>
       <Button.Label className={{ root: twMerge('text-xs', className?.label) }}>

--- a/apps/frontend-control/src/components/layout/MobileMenuBar.tsx
+++ b/apps/frontend-control/src/components/layout/MobileMenuBar.tsx
@@ -1,10 +1,21 @@
-import { faArrowLeftLong, faHouse } from '@fortawesome/free-solid-svg-icons'
+import EmbeddingModal from '@components/sessions/EmbeddingModal'
+import {
+  faArrowLeftLong,
+  faHouse,
+  faPersonChalkboard,
+} from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 import MenuButton from './MenuButton'
 
-function MobileMenuBar() {
+interface MobileMenuBarProps {
+  sessionId?: string
+}
+
+function MobileMenuBar({ sessionId }: MobileMenuBarProps) {
   const router = useRouter()
+  const [embedModalOpen, setEmbedModalOpen] = useState<boolean>(false)
 
   return (
     <div className="fixed bottom-0 w-full h-12 bg-slate-800">
@@ -21,7 +32,22 @@ function MobileMenuBar() {
         >
           Home
         </MenuButton>
+        <MenuButton
+          icon={<FontAwesomeIcon icon={faPersonChalkboard} />}
+          onClick={() => setEmbedModalOpen(true)}
+          disabled={!sessionId}
+        >
+          PPT
+        </MenuButton>
       </div>
+
+      {sessionId && (
+        <EmbeddingModal
+          open={embedModalOpen}
+          setOpen={setEmbedModalOpen}
+          sessionId={sessionId}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-control/src/components/sessions/EmbeddingModal.tsx
+++ b/apps/frontend-control/src/components/sessions/EmbeddingModal.tsx
@@ -2,8 +2,8 @@ import { useQuery } from '@apollo/client'
 import { faClipboard } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { GetSingleLiveSessionDocument } from '@klicker-uzh/graphql/dist/ops'
-import { Button, H2, Modal, ThemeContext } from '@uzh-bf/design-system'
-import { useContext, useMemo } from 'react'
+import { Button, H2, Modal } from '@uzh-bf/design-system'
+import { useMemo } from 'react'
 
 interface EmbeddingModalProps {
   open: boolean
@@ -12,7 +12,6 @@ interface EmbeddingModalProps {
 }
 
 function EmbeddingModal({ open, setOpen, sessionId }: EmbeddingModalProps) {
-  const theme = useContext(ThemeContext)
   const { data: dataLiveSession } = useQuery(GetSingleLiveSessionDocument, {
     variables: { sessionId: sessionId || '' },
     skip: !sessionId,

--- a/apps/frontend-control/src/components/sessions/EmbeddingModal.tsx
+++ b/apps/frontend-control/src/components/sessions/EmbeddingModal.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from '@apollo/client'
+import { faClipboard } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { GetSingleLiveSessionDocument } from '@klicker-uzh/graphql/dist/ops'
+import { Button, H2, Modal, ThemeContext } from '@uzh-bf/design-system'
+import { useContext, useMemo } from 'react'
+
+interface EmbeddingModalProps {
+  open: boolean
+  setOpen: (newValue: boolean) => void
+  sessionId: string
+}
+
+function EmbeddingModal({ open, setOpen, sessionId }: EmbeddingModalProps) {
+  const theme = useContext(ThemeContext)
+  const { data: dataLiveSession } = useQuery(GetSingleLiveSessionDocument, {
+    variables: { sessionId: sessionId || '' },
+    skip: !sessionId,
+  })
+
+  const questions = useMemo(
+    () =>
+      dataLiveSession?.liveSession?.blocks?.flatMap(
+        (block) => block.instances
+      ) || [],
+    [dataLiveSession?.liveSession?.blocks]
+  )
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={() => setOpen(!open)}
+      onClose={() => setOpen(false)}
+      onPrimaryAction={
+        <Button onClick={() => setOpen(false)}>Schliessen</Button>
+      }
+      className={{
+        content:
+          'h-max max-h-[calc(100%-5rem)] overflow-y-scroll w-full md:w-max md:min-w-[30rem] my-auto mx-auto',
+      }}
+      hideCloseButton
+    >
+      <H2>PPT-Einbettung Evaluation</H2>
+      <div className="flex flex-col gap-3">
+        {questions?.map((question: any, ix: number) => {
+          return (
+            <div key={question.id}>
+              <div className="w-full font-bold line-clamp-1">{`${ix + 1}. ${
+                question.questionData.name
+              }`}</div>
+              <div className="flex flex-row items-center gap-3 px-1.5 py-0.5 mr-2 border border-solid rounded bg-uzh-grey-40">
+                <FontAwesomeIcon
+                  icon={faClipboard}
+                  className="hover:cursor-pointer"
+                  onClick={() =>
+                    navigator.clipboard.writeText(
+                      `${process.env.NEXT_PUBLIC_MANAGE_URL}/sessions/${sessionId}/evaluation?questionIx=${ix}`
+                    )
+                  }
+                />
+                <div className="text-sm">{`${process.env.NEXT_PUBLIC_MANAGE_URL}/sessions/${sessionId}/evaluation?questionIx=${ix}`}</div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </Modal>
+  )
+}
+
+export default EmbeddingModal

--- a/apps/frontend-control/src/components/sessions/SessionLists.tsx
+++ b/apps/frontend-control/src/components/sessions/SessionLists.tsx
@@ -1,8 +1,14 @@
-import { faCalendar, faPlay } from '@fortawesome/free-solid-svg-icons'
-import { H4 } from '@uzh-bf/design-system'
+import {
+  faCalendar,
+  faPersonChalkboard,
+  faPlay,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Button, H4 } from '@uzh-bf/design-system'
 import { useState } from 'react'
 import ListButton from '../common/ListButton'
 import SessionStartToast from '../toasts/SessionStartToast'
+import EmbeddingModal from './EmbeddingModal'
 import StartModal from './StartModal'
 
 interface SessionListsProps {
@@ -15,6 +21,8 @@ function SessionLists({ runningSessions, plannedSessions }: SessionListsProps) {
   const [errorToast, setErrorToast] = useState(false)
   const [startId, setStartId] = useState('')
   const [startName, setStartName] = useState('')
+  const [embedOpen, setEmbedOpen] = useState(false)
+  const [sessionId, setSessionId] = useState('')
 
   return (
     <>
@@ -22,13 +30,28 @@ function SessionLists({ runningSessions, plannedSessions }: SessionListsProps) {
       {runningSessions.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           {runningSessions.map((session) => (
-            <ListButton
-              key={session.id}
-              link={`/session/${session.id}`}
-              icon={faPlay}
-              label={session.name}
-              className={{ icon: 'mr-1' }}
-            />
+            <div key={session.id} className="flex flex-row items-center gap-2">
+              <ListButton
+                link={`/session/${session.id}`}
+                icon={faPlay}
+                label={session.name}
+                className={{ icon: 'mr-1', root: 'flex-1' }}
+              />
+              <Button
+                onClick={() => {
+                  setEmbedOpen(true)
+                  setSessionId(session.id)
+                }}
+                className={{
+                  root: 'h-full p-2 border border-solid rounded-md bg-uzh-grey-40 border-uzh-grey-100',
+                }}
+              >
+                <Button.Icon className={{ root: 'mr-2' }}>
+                  <FontAwesomeIcon icon={faPersonChalkboard} />
+                </Button.Icon>
+                <Button.Label>PPT</Button.Label>
+              </Button>
+            </div>
           ))}
         </div>
       ) : (
@@ -39,23 +62,44 @@ function SessionLists({ runningSessions, plannedSessions }: SessionListsProps) {
       {plannedSessions.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           {plannedSessions.map((session) => (
-            <ListButton
-              key={session.id}
-              icon={faCalendar}
-              label={session.name}
-              className={{ icon: 'mr-1' }}
-              onClick={() => {
-                setStartModalOpen(true)
-                setStartId(session.id)
-                setStartName(session.name)
-              }}
-            />
+            <div key={session.id} className="flex flex-row items-center gap-2">
+              <ListButton
+                key={session.id}
+                icon={faCalendar}
+                label={session.name}
+                className={{ icon: 'mr-1' }}
+                onClick={() => {
+                  setStartModalOpen(true)
+                  setStartId(session.id)
+                  setStartName(session.name)
+                }}
+              />
+              <Button
+                onClick={() => {
+                  setEmbedOpen(true)
+                  setSessionId(session.id)
+                }}
+                className={{
+                  root: 'h-full p-2 border border-solid rounded-md bg-uzh-grey-40 border-uzh-grey-100',
+                }}
+              >
+                <Button.Icon className={{ root: 'mr-2' }}>
+                  <FontAwesomeIcon icon={faPersonChalkboard} />
+                </Button.Icon>
+                <Button.Label>PPT</Button.Label>
+              </Button>
+            </div>
           ))}
         </div>
       ) : (
         <div>Keine geplanten Sessionen</div>
       )}
 
+      <EmbeddingModal
+        open={embedOpen}
+        setOpen={(newValue: boolean) => setEmbedOpen(newValue)}
+        sessionId={sessionId}
+      />
       <StartModal
         startId={startId}
         startName={startName}

--- a/apps/frontend-control/src/pages/session/[id].tsx
+++ b/apps/frontend-control/src/pages/session/[id].tsx
@@ -94,7 +94,7 @@ function RunningSession() {
   }
 
   return (
-    <Layout title={`Session: ${name}`}>
+    <Layout title={`Session: ${name}`} sessionId={id}>
       <div key={`${currentBlock}-${nextBlock}`}>
         {currentBlock ? (
           <div key={`${currentBlock}-${nextBlock}`}>


### PR DESCRIPTION
This pull request adds another modal to the controller frontend, where the user can once more access the embedding links for the PPT plugin. One can either access them from the session list or through the menu bar on a running session (see images).

<img width="345" alt="Screenshot 2023-01-27 at 03 16 56" src="https://user-images.githubusercontent.com/80708107/214997343-0aa2655b-36fd-4730-911e-076c031f70c2.png">
<img width="345" alt="Screenshot 2023-01-27 at 03 17 05" src="https://user-images.githubusercontent.com/80708107/214997347-314d9ef3-691e-4e52-906e-4b6f266554aa.png">
<img width="405" alt="Screenshot 2023-01-27 at 03 17 21" src="https://user-images.githubusercontent.com/80708107/214997348-57f3dd91-5c63-4359-b1de-33f584e68308.png">
