### PR TITLE
enhance(frontend-control): show next block on controller app as well

### DIFF
--- a/apps/frontend-control/src/pages/session/[id].tsx
+++ b/apps/frontend-control/src/pages/session/[id].tsx
@@ -63,6 +63,7 @@ function RunningSession() {
       (block) => block.status === SessionBlockStatus.Scheduled
     )
     setNextBlock(typeof scheduledNext === 'undefined' ? -1 : scheduledNext)
+    console.log(scheduledNext)
   }, [cockpitData?.cockpitSession?.blocks])
 
   if (cockpitLoading) {
@@ -164,6 +165,22 @@ function RunningSession() {
               Session beenden
             </Button>
           </div>
+        )}
+
+        {currentBlock && nextBlock !== -1 && nextBlock !== blocks.length && (
+          <div className="mt-14">
+            <H3>Nächster Block:</H3>
+
+            <SessionBlock
+              block={blocks.find((block) => block.order === nextBlock)}
+            />
+          </div>
+        )}
+        {currentBlock && nextBlock == -1 && (
+          <UserNotification
+            message="Der aktuell laufende Block is der letzte dieser Session. Nach Schliessen dieses Blockes kann die Session beendet werden."
+            className={{ root: 'mt-14' }}
+          />
         )}
       </div>
     </Layout>

--- a/packages/graphql/src/services/sessions.ts
+++ b/packages/graphql/src/services/sessions.ts
@@ -1604,7 +1604,7 @@ export async function cancelSession(
     ctx.prisma.session.update({
       where: { id },
       data: {
-        status: SessionStatus.SCHEDULED,
+        status: SessionStatus.PREPARED,
         startedAt: null,
         pinCode: null,
         activeBlock: {


### PR DESCRIPTION
This pull request adds additional logic to the running session view of the controller frontend and allows the user to already see the next upcoming block before closing the previous one.

<img width="397" alt="Screenshot 2023-01-27 at 10 27 31" src="https://user-images.githubusercontent.com/80708107/215053279-d4841397-e0d7-425b-b643-44de3b6f2f80.png">
<img width="396" alt="Screenshot 2023-01-27 at 10 27 37" src="https://user-images.githubusercontent.com/80708107/215053293-b373b89a-5cce-414e-a40a-1cb6477a869b.png">
