### PR TITLE
enhance(apps/frontend-pwa): create smaller language switcher

### DIFF
--- a/apps/backend-docker/package.json
+++ b/apps/backend-docker/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^18.0.0",
     "@types/passport": "^1.0.10",
     "@types/passport-jwt": "^3.0.6",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "axios": "1.3.2",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/backend-response-processor/package.json
+++ b/apps/backend-response-processor/package.json
@@ -34,7 +34,7 @@
     "@types/md5": "2.3.2",
     "@types/node": "^18.0.0",
     "@types/ramda": "^0.28.15",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",
     "husky": "8.0.3",

--- a/apps/backend-responses/package.json
+++ b/apps/backend-responses/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "^1.0.2",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/node": "^18.0.0",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "cross-env": "7.0.3",
     "husky": "8.0.3",
     "npm-run-all": "4.1.5",

--- a/apps/frontend-control/package.json
+++ b/apps/frontend-control/package.json
@@ -24,7 +24,7 @@
     "@next/font": "13.1.6",
     "@sentry/nextjs": "7.37.2",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "body-parser": "1.20.1",
     "cross-env": "7.0.3",
     "dayjs": "1.11.7",

--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -23,7 +23,7 @@
     "@klicker-uzh/prisma": "^3.0.0-alpha.0",
     "@next/font": "13.1.6",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "d3": "7.8.2",
     "dayjs": "1.11.7",
     "deepmerge": "4.3.0",

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -27,7 +27,7 @@
     "@next/font": "13.1.6",
     "@radix-ui/react-tabs": "1.0.1",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "body-parser": "1.20.1",
     "dayjs": "1.11.7",
     "deepmerge": "4.3.0",

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
 import { faCircleQuestion } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Course, Participant } from '@klicker-uzh/graphql/dist/ops'
-import { Button, H1, H2, ThemeContext } from '@uzh-bf/design-system'
+import { Button, H1, H2, Select, ThemeContext } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -50,40 +50,23 @@ function Header({
       )}
       <div className="flex flex-row items-center gap-4">
         <div className="flex flex-row text-black bg-transparent rounded">
-          <Button
-            basic
-            onClick={() =>
+          <Select
+            value={router.locale}
+            items={[
+              { value: 'de', label: 'DE' },
+              { value: 'en', label: 'EN' },
+            ]}
+            onChange={(newValue: string) =>
               router.push({ pathname, query }, asPath, {
-                locale: 'de',
+                locale: newValue,
               })
             }
             className={{
-              root: twMerge(
-                'py-1 px-2 rounded-l bg-white',
-                router.locale === 'de' &&
-                  `font-bold text-white ${theme.primaryBgDark}`
-              ),
+              trigger:
+                'text-white border-b border-solid p-0.5 pb-0 rounded-none hover:bg-transparent hover:text-white',
             }}
-          >
-            DE
-          </Button>
-          <Button
             basic
-            onClick={() =>
-              router.push({ pathname, query }, asPath, {
-                locale: 'en',
-              })
-            }
-            className={{
-              root: twMerge(
-                'py-1 px-2 rounded-r bg-white',
-                router.locale === 'en' &&
-                  `font-bold text-white ${theme.primaryBgDark}`
-              ),
-            }}
-          >
-            EN
-          </Button>
+          />
         </div>
         {course?.id && (
           <Link href={`/course/${course.id}/docs`}>

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -48,7 +48,7 @@ function Header({
       {title && !course?.displayName && (
         <H1 className={{ root: 'mb-0 text-xl' }}>{title}</H1>
       )}
-      <div className="flex flex-row items-center gap-4">
+      <div className="flex flex-row items-center gap-2 sm:gap-4">
         <div className="flex flex-row text-black bg-transparent rounded">
           <Select
             value={router.locale}
@@ -72,8 +72,13 @@ function Header({
           <Link href={`/course/${course.id}/docs`}>
             <Button
               className={{
-                root: 'bg-slate-800 peer-disabled: md:block border-slate-800',
+                root: twMerge(
+                  'block px-1 md:px-2 py-1 rounded',
+                  theme.primaryBgHover,
+                  theme.primaryTextHover
+                ),
               }}
+              basic
             >
               <FontAwesomeIcon className="fa-xl" icon={faCircleQuestion} />
             </Button>

--- a/apps/office-addin/package.json
+++ b/apps/office-addin/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui/react": "8.105.7",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "core-js": "3.27.2",
     "es6-promise": "4.2.8",
     "formik": "2.2.9",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19,7 +19,7 @@
         "@headlessui/react": "1.5.0",
         "@heroicons/react": "1.0.6",
         "@tsconfig/docusaurus": "1.0.5",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "autoprefixer": "10.4.8",
         "cross-env": "7.0.3",
         "nodemon": "2.0.15",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "@headlessui/react": "1.5.0",
     "@heroicons/react": "1.0.6",
     "@tsconfig/docusaurus": "1.0.5",
-    "@uzh-bf/design-system": "1.4.2",
+    "@uzh-bf/design-system": "1.4.3",
     "autoprefixer": "10.4.8",
     "cross-env": "7.0.3",
     "nodemon": "2.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "apps/backend-docker": {
       "name": "@klicker-uzh/backend-docker",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@envelop/response-cache-redis": "2.0.5",
@@ -70,7 +70,7 @@
         "@types/node": "^18.0.0",
         "@types/passport": "^1.0.10",
         "@types/passport-jwt": "^3.0.6",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "axios": "1.3.2",
         "cross-env": "7.0.3",
         "dotenv": "16.0.3",
@@ -95,7 +95,7 @@
     },
     "apps/backend-response-processor": {
       "name": "@klicker-uzh/backend-response-processor",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@klicker-uzh/grading": "^3.0.0-alpha.0",
@@ -113,7 +113,7 @@
         "@types/md5": "2.3.2",
         "@types/node": "^18.0.0",
         "@types/ramda": "^0.28.15",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "cross-env": "7.0.3",
         "dotenv": "16.0.3",
         "husky": "8.0.3",
@@ -134,7 +134,7 @@
     },
     "apps/backend-responses": {
       "name": "@klicker-uzh/backend-responses",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@azure/service-bus": "7.8.0",
@@ -147,7 +147,7 @@
         "@tsconfig/recommended": "^1.0.2",
         "@types/jsonwebtoken": "^9.0.1",
         "@types/node": "^18.0.0",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "cross-env": "7.0.3",
         "husky": "8.0.3",
         "npm-run-all": "4.1.5",
@@ -167,7 +167,7 @@
     },
     "apps/frontend-control": {
       "name": "@klicker-uzh/frontend-control",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apollo/client": "3.7.7",
@@ -181,7 +181,7 @@
         "@next/font": "13.1.6",
         "@sentry/nextjs": "7.37.2",
         "@socialgouv/matomo-next": "1.6.1",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "body-parser": "1.20.1",
         "cross-env": "7.0.3",
         "dayjs": "1.11.7",
@@ -238,7 +238,7 @@
     },
     "apps/frontend-manage": {
       "name": "@klicker-uzh/frontend-manage",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apollo/client": "3.7.7",
@@ -251,7 +251,7 @@
         "@klicker-uzh/prisma": "^3.0.0-alpha.0",
         "@next/font": "13.1.6",
         "@socialgouv/matomo-next": "1.6.1",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "d3": "7.8.2",
         "dayjs": "1.11.7",
         "deepmerge": "4.3.0",
@@ -347,7 +347,7 @@
     },
     "apps/frontend-pwa": {
       "name": "@klicker-uzh/frontend-pwa",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apollo/client": "3.7.7",
@@ -362,7 +362,7 @@
         "@next/font": "13.1.6",
         "@radix-ui/react-tabs": "1.0.1",
         "@socialgouv/matomo-next": "1.6.1",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "body-parser": "1.20.1",
         "dayjs": "1.11.7",
         "deepmerge": "4.3.0",
@@ -447,11 +447,11 @@
     },
     "apps/office-addin": {
       "name": "@klicker-uzh/office-addin",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fluentui/react": "8.105.7",
-        "@uzh-bf/design-system": "1.4.2",
+        "@uzh-bf/design-system": "1.4.3",
         "core-js": "3.27.2",
         "es6-promise": "4.2.8",
         "formik": "2.2.9",
@@ -11113,9 +11113,9 @@
       }
     },
     "node_modules/@uzh-bf/design-system": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@uzh-bf/design-system/-/design-system-1.4.2.tgz",
-      "integrity": "sha512-85wZYstKGVl54Q3ismJdxJ+jx+bq8LKnX+2s9ZUE/IL9X/Vi48Cu6bBmEdVLguatLjFkB8JKOr/42ZmRSK4iKg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@uzh-bf/design-system/-/design-system-1.4.3.tgz",
+      "integrity": "sha512-lVtOCaEt+k3Dmb9Cb1pAeEA0ehg2zOaTKeyfRfl+udO8HI3gxpUJjc7w0+fjOdhogLAaqv939/ewUZgIHR9Fdg==",
       "dependencies": {
         "@radix-ui/react-checkbox": "1.0.1",
         "@radix-ui/react-collapsible": "1.0.1",
@@ -35362,7 +35362,7 @@
     },
     "packages/grading": {
       "name": "@klicker-uzh/grading",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "ramda": "0.28.0"
@@ -35385,7 +35385,7 @@
     },
     "packages/graphql": {
       "name": "@klicker-uzh/graphql",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@pothos/core": "3.25.0",
@@ -35446,7 +35446,7 @@
     },
     "packages/lti": {
       "name": "@klicker-uzh/lti",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "body-parser": "1.20.1"
@@ -35468,7 +35468,7 @@
     },
     "packages/markdown": {
       "name": "@klicker-uzh/markdown",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "rehype-external-links": "2.0.1",
@@ -35560,7 +35560,7 @@
     },
     "packages/prisma": {
       "name": "@klicker-uzh/prisma",
-      "version": "3.0.0-alpha.58",
+      "version": "3.0.0-alpha.60",
       "license": "AGPL-3.0",
       "dependencies": {
         "@prisma/client": "4.8.1"


### PR DESCRIPTION
This pull requests adds an improved header layout for language switching, taking up less space especially on mobile devices (which are probably the biggest user group for the student frontend)

<img width="388" alt="Screenshot 2023-02-23 at 02 12 02" src="https://user-images.githubusercontent.com/80708107/220800225-ce19898b-33ce-4bba-8367-24fddcd96938.png">
<img width="384" alt="Screenshot 2023-02-23 at 02 12 09" src="https://user-images.githubusercontent.com/80708107/220800227-ee965f68-22a9-423e-8fac-90801223b920.png">
