### PR TITLE
style(apps/frontend-pwa): ensure that header text in pwa layout is only small on mobile

### DIFF
--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -39,10 +39,10 @@ function Header({
     >
       {title && course?.displayName && (
         <div>
-          <H1 className={{ root: 'm-0 text-xs text-uzh-grey-60' }}>
+          <H1 className={{ root: 'm-0 text-xs md:text-sm text-uzh-grey-60' }}>
             {course.displayName}
           </H1>
-          <H2 className={{ root: 'm-0 text-sm' }}>{title}</H2>
+          <H2 className={{ root: 'm-0 text-sm md:text-base' }}>{title}</H2>
         </div>
       )}
       {title && !course?.displayName && (

--- a/apps/frontend-pwa/src/components/participant/ParticipantProfileModal.tsx
+++ b/apps/frontend-pwa/src/components/participant/ParticipantProfileModal.tsx
@@ -49,7 +49,7 @@ function ParticipantProfileModal({
       open={isProfileModalOpen}
       onClose={closeProfileModal}
       className={{
-        content: 'w-[500px] my-auto max-h-full overflow-auto',
+        content: 'w-[500px] my-auto h-max max-h-full overflow-auto',
         title: 'text-3xl',
         onNext: 'hidden md:block',
         onPrev: 'hidden md:block',


### PR DESCRIPTION
This pull request fixes two styling problems on the frontend-pwa:
- too small text size in header on desktop view
- height issue with participant modal on medium screen sizes