### PR TITLE
chore: show notification message on empty leaderboard

### DIFF
--- a/apps/frontend-pwa/src/components/common/SessionLeaderboard.tsx
+++ b/apps/frontend-pwa/src/components/common/SessionLeaderboard.tsx
@@ -3,7 +3,7 @@ import {
   GetSessionLeaderboardDocument,
   SelfDocument,
 } from '@klicker-uzh/graphql/dist/ops'
-import { H2 } from '@uzh-bf/design-system'
+import { H2, UserNotification } from '@uzh-bf/design-system'
 import localforage from 'localforage'
 import { useTranslations } from 'next-intl'
 import React, { useEffect, useState } from 'react'
@@ -92,16 +92,21 @@ function SessionLeaderboard({
         <H2>{t('shared.leaderboard.sessionTitle')}</H2>
         <div>
           {data.sessionLeaderboard?.length &&
-            data.sessionLeaderboard.length > 0 && (
-              <Podium
-                leaderboard={data.sessionLeaderboard?.slice(0, 3)}
-                imgSrc={{
-                  rank1: Rank1Img,
-                  rank2: Rank2Img,
-                  rank3: Rank3Img,
-                }}
-              />
-            )}
+          data.sessionLeaderboard.length > 0 ? (
+            <Podium
+              leaderboard={data.sessionLeaderboard?.slice(0, 3)}
+              imgSrc={{
+                rank1: Rank1Img,
+                rank2: Rank2Img,
+                rank3: Rank3Img,
+              }}
+            />
+          ) : (
+            <UserNotification
+              type="info"
+              message={t('shared.leaderboard.noPointsCollected')}
+            />
+          )}
         </div>
         <div className="space-y-1">
           {data.sessionLeaderboard?.slice(0, 10).map((entry) => (

--- a/packages/shared-components/src/intl-messages/de.json
+++ b/packages/shared-components/src/intl-messages/de.json
@@ -89,7 +89,8 @@
       "pointsCollected": "Punkte (gesammelt)",
       "participantCount": "Anzahl Teilnehmende: {number}",
       "groupCount": "Anzahl Gruppen: {number}",
-      "averagePoints": "Durchschnittliche Punkte: {number}"
+      "averagePoints": "Durchschnittliche Punkte: {number}",
+      "noPointsCollected": "Bisher wurden im Rahmen dieser Session noch keine Punkte gesammelt. Sobald sich dies ändert, werden hier Podium und Rangliste angezeigt."
     },
     "error": {
       "404": "404 Seite nicht gefunden",

--- a/packages/shared-components/src/intl-messages/en.json
+++ b/packages/shared-components/src/intl-messages/en.json
@@ -89,7 +89,8 @@
       "pointsCollected": "Points (collected)",
       "participantCount": "Number of participants: {number}",
       "groupCount": "Number of groups: {number}",
-      "averagePoints": "Average points: {number}"
+      "averagePoints": "Average points: {number}",
+      "noPointsCollected": "No points have been collected in this session so far. As soon as this changes, podium and leaderboard will be displayed here."
     },
     "error": {
       "404": "404 Page not found",


### PR DESCRIPTION
Until now, a strange 0 was shown to the user before any leaderboard entries were available at the beginning of a live session. This was replaced with a nicer user notification.

<img width="502" alt="Screenshot 2023-04-18 at 19 38 25" src="https://user-images.githubusercontent.com/80708107/232861013-ec0f082f-1825-4e86-b907-f67966af6983.png">
<img width="508" alt="Screenshot 2023-04-18 at 19 40 45" src="https://user-images.githubusercontent.com/80708107/232861031-ed213f7e-cf1f-467b-b266-8b578a48abc2.png">
