### PR TITLE
 fix(apps/frontend-manage): ensure that tooltips in creation wizards are always placed above workflow bar

### DIFF
--- a/apps/backend-docker/package.json
+++ b/apps/backend-docker/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^18.0.0",
     "@types/passport": "^1.0.10",
     "@types/passport-jwt": "^3.0.6",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "axios": "1.4.0",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/backend-response-processor/package.json
+++ b/apps/backend-response-processor/package.json
@@ -35,7 +35,7 @@
     "@types/md5": "2.3.2",
     "@types/node": "^18.0.0",
     "@types/ramda": "^0.29.0",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",
     "husky": "8.0.3",

--- a/apps/backend-responses/package.json
+++ b/apps/backend-responses/package.json
@@ -30,7 +30,7 @@
     "@tsconfig/recommended": "^1.0.2",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/node": "^18.0.0",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "cross-env": "7.0.3",
     "husky": "8.0.3",
     "npm-run-all": "4.1.5",

--- a/apps/frontend-control/package.json
+++ b/apps/frontend-control/package.json
@@ -26,7 +26,7 @@
     "@klicker-uzh/prisma": "^3.0.0-alpha.0",
     "@sentry/nextjs": "7.52.1",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "body-parser": "1.20.2",
     "cross-env": "7.0.3",
     "dayjs": "1.11.7",

--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -25,7 +25,7 @@
     "@klicker-uzh/markdown": "^3.0.0-alpha.0",
     "@klicker-uzh/prisma": "^3.0.0-alpha.0",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "d3": "7.8.4",
     "dayjs": "1.11.7",
     "deepmerge": "4.3.1",

--- a/apps/frontend-manage/src/components/sessions/creation/BlockField.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/BlockField.tsx
@@ -18,7 +18,7 @@ function BlockField({ fieldName }: BlockFieldProps) {
           label="Fragen:"
           className={{
             root: 'font-bold',
-            tooltip: 'font-normal text-sm !w-1/2',
+            tooltip: 'font-normal text-sm !w-1/2 z-20',
           }}
           tooltip="Fügen Sie mittels Drag&Drop Fragen zu Ihrer Micro-Session hinzu."
           showTooltipSymbol={true}

--- a/apps/frontend-manage/src/components/sessions/creation/LearningElementWizard.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LearningElementWizard.tsx
@@ -258,7 +258,7 @@ function StepOne(_: StepProps) {
           name="name"
           label="Name"
           tooltip="Der Name soll Ihnen ermöglichen, dieses Lernelement von anderen zu unterscheiden. Er wird den Teilnehmenden nicht angezeigt, verwenden Sie hierfür bitte den Anzeigenamen im nächsten Feld."
-          className={{ root: 'mb-1 w-full md:w-1/2' }}
+          className={{ root: 'mb-1 w-full md:w-1/2', tooltip: 'z-20' }}
           data-cy="insert-learning-element-name"
         />
         <FormikTextField
@@ -267,7 +267,7 @@ function StepOne(_: StepProps) {
           name="displayName"
           label="Anzeigename"
           tooltip="Der Anzeigename wird den Teilnehmenden bei der Durchführung angezeigt."
-          className={{ root: 'mb-1 w-full md:w-1/2' }}
+          className={{ root: 'mb-1 w-full md:w-1/2', tooltip: 'z-20' }}
           data-cy="insert-learning-element-display-name"
         />
       </div>
@@ -302,6 +302,7 @@ function StepTwo(props: StepProps) {
           tooltip="Für die Erstellung einer Micro-Session ist die Auswahl des zugehörigen Kurses erforderlich."
           label="Kurs"
           data={{ cy: 'select-course' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="courseId"
@@ -324,6 +325,7 @@ function StepTwo(props: StepProps) {
             { label: 'Vierfach (4x)', value: '4' },
           ]}
           data={{ cy: 'select-multiplier' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="multiplier"
@@ -339,6 +341,7 @@ function StepTwo(props: StepProps) {
           tooltip="Wählen Sie einen Zeitraum nach welchem die Studierenden die Micro-Session wiederholen können."
           className={{
             input: 'w-20',
+            tooltip: 'z-20',
           }}
           required
           hideError={true}
@@ -362,6 +365,7 @@ function StepTwo(props: StepProps) {
           })}
           required
           data={{ cy: 'select-order' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="order"

--- a/apps/frontend-manage/src/components/sessions/creation/LiveSessionWizard.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LiveSessionWizard.tsx
@@ -248,7 +248,7 @@ function StepOne(_: StepProps) {
           name="name"
           label="Name"
           tooltip="Der Name soll Ihnen ermöglichen, diese Session von anderen zu unterscheiden. Er wird den Teilnehmenden nicht angezeigt, verwenden Sie hierfür bitte den Anzeigenamen im nächsten Feld."
-          className={{ root: 'mb-1 w-full md:w-1/2' }}
+          className={{ root: 'mb-1 w-full md:w-1/2', tooltip: 'z-20' }}
           data-cy="insert-live-session-name"
           shouldValidate={() => true}
         />
@@ -258,14 +258,14 @@ function StepOne(_: StepProps) {
           name="displayName"
           label="Anzeigename"
           tooltip="Der Anzeigename wird den Teilnehmenden bei der Durchführung angezeigt."
-          className={{ root: 'mb-1 w-full md:w-1/2' }}
+          className={{ root: 'mb-1 w-full md:w-1/2', tooltip: 'z-20' }}
           data-cy="insert-live-display-name"
         />
       </div>
       <EditorField
         // key={fieldName.value}
         label="Beschreibung"
-        tooltip="// TODO CONTENT TOOLTIP"
+        tooltip="Hier können Sie eine optionale Beschreibung der Live-Session eingeben. Diese wird in den Studierenden zu Beginn der Session angezeigt."
         fieldName="description"
         showToolbarOnFocus={false}
       />
@@ -294,6 +294,7 @@ function StepTwo(props: StepProps) {
             items={[{ label: 'Kein Kurs', value: '' }, ...props.courses]}
             hideError
             data={{ cy: 'select-course' }}
+            className={{ tooltip: 'z-20' }}
           />
           <ErrorMessage
             name="courseId"
@@ -316,6 +317,7 @@ function StepTwo(props: StepProps) {
           ]}
           required
           data={{ cy: 'select-multiplier' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="multiplier"
@@ -331,6 +333,7 @@ function StepTwo(props: StepProps) {
           required
           standardLabel
           data={{ cy: 'set-gamification' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="isGamificationEnabled"

--- a/apps/frontend-manage/src/components/sessions/creation/MicroSessionWizard.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/MicroSessionWizard.tsx
@@ -243,7 +243,7 @@ function StepOne(_: StepProps) {
           name="name"
           label="Name"
           tooltip="Der Name soll Ihnen ermöglichen, diese Micro-Session von anderen zu unterscheiden. Er wird den Teilnehmenden nicht angezeigt, verwenden Sie hierfür bitte den Anzeigenamen im nächsten Feld."
-          className={{ root: 'mb-1 w-full md:w-1/2' }}
+          className={{ root: 'mb-1 w-full md:w-1/2', tooltip: 'z-20' }}
           data-cy="insert-micro-session-name"
         />
         <FormikTextField
@@ -252,7 +252,7 @@ function StepOne(_: StepProps) {
           name="displayName"
           label="Anzeigename"
           tooltip="Der Anzeigename wird den Teilnehmenden bei der Durchführung angezeigt."
-          className={{ root: 'mb-1 w-full md:w-1/2' }}
+          className={{ root: 'mb-1 w-full md:w-1/2', tooltip: 'z-20' }}
           data-cy="insert-micro-session-display-name"
         />
       </div>
@@ -287,6 +287,7 @@ function StepTwo(props: StepProps) {
           tooltip="Für die Erstellung einer Micro-Session ist die Auswahl des zugehörigen Kurses erforderlich."
           label="Kurs"
           data={{ cy: 'select-course' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="courseId"
@@ -302,6 +303,7 @@ function StepTwo(props: StepProps) {
         className={{
           root: 'w-[24rem]',
           input: 'bg-uzh-grey-20',
+          tooltip: 'z-20',
         }}
         data={{ cy: 'select-start-date' }}
       />
@@ -313,6 +315,7 @@ function StepTwo(props: StepProps) {
         className={{
           root: 'w-[24rem]',
           input: 'bg-uzh-grey-20',
+          tooltip: 'z-20',
         }}
         data={{ cy: 'select-end-date' }}
       />
@@ -330,6 +333,7 @@ function StepTwo(props: StepProps) {
             { label: 'Vierfach (4x)', value: '4' },
           ]}
           data={{ cy: 'select-multiplier' }}
+          className={{ tooltip: 'z-20' }}
         />
         <ErrorMessage
           name="multiplier"

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -29,7 +29,7 @@
     "@klicker-uzh/prisma": "^3.0.0-alpha.0",
     "@radix-ui/react-tabs": "1.0.3",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "body-parser": "1.20.2",
     "dayjs": "1.11.7",
     "deepmerge": "4.3.1",

--- a/apps/office-addin/package.json
+++ b/apps/office-addin/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react": "8.109.5",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "core-js": "3.30.2",
     "es6-promise": "4.2.8",
     "formik": "2.2.9",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -24,7 +24,7 @@
         "@headlessui/react": "1.5.0",
         "@heroicons/react": "1.0.6",
         "@tsconfig/docusaurus": "1.0.5",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "autoprefixer": "10.4.14",
         "cross-env": "7.0.3",
         "nodemon": "3.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "@headlessui/react": "1.5.0",
     "@heroicons/react": "1.0.6",
     "@tsconfig/docusaurus": "1.0.5",
-    "@uzh-bf/design-system": "2.0.2",
+    "@uzh-bf/design-system": "2.0.6",
     "autoprefixer": "10.4.14",
     "cross-env": "7.0.3",
     "nodemon": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       }
     },
     "apps/backend-docker": {
+      "name": "@klicker-uzh/backend-docker",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -73,7 +74,7 @@
         "@types/node": "^18.0.0",
         "@types/passport": "^1.0.10",
         "@types/passport-jwt": "^3.0.6",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "axios": "1.4.0",
         "cross-env": "7.0.3",
         "dotenv": "16.0.3",
@@ -104,6 +105,7 @@
       }
     },
     "apps/backend-response-processor": {
+      "name": "@klicker-uzh/backend-response-processor",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -122,7 +124,7 @@
         "@types/md5": "2.3.2",
         "@types/node": "^18.0.0",
         "@types/ramda": "^0.29.0",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "cross-env": "7.0.3",
         "dotenv": "16.0.3",
         "husky": "8.0.3",
@@ -149,6 +151,7 @@
       }
     },
     "apps/backend-responses": {
+      "name": "@klicker-uzh/backend-responses",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -162,7 +165,7 @@
         "@tsconfig/recommended": "^1.0.2",
         "@types/jsonwebtoken": "^9.0.1",
         "@types/node": "^18.0.0",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "cross-env": "7.0.3",
         "husky": "8.0.3",
         "npm-run-all": "4.1.5",
@@ -188,6 +191,7 @@
       }
     },
     "apps/frontend-control": {
+      "name": "@klicker-uzh/frontend-control",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -201,7 +205,7 @@
         "@klicker-uzh/prisma": "^3.0.0-alpha.0",
         "@sentry/nextjs": "7.52.1",
         "@socialgouv/matomo-next": "1.6.1",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "body-parser": "1.20.2",
         "cross-env": "7.0.3",
         "dayjs": "1.11.7",
@@ -319,6 +323,7 @@
       }
     },
     "apps/frontend-manage": {
+      "name": "@klicker-uzh/frontend-manage",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -331,7 +336,7 @@
         "@klicker-uzh/markdown": "^3.0.0-alpha.0",
         "@klicker-uzh/prisma": "^3.0.0-alpha.0",
         "@socialgouv/matomo-next": "1.6.1",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "d3": "7.8.4",
         "dayjs": "1.11.7",
         "deepmerge": "4.3.1",
@@ -461,6 +466,7 @@
       }
     },
     "apps/frontend-pwa": {
+      "name": "@klicker-uzh/frontend-pwa",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -475,7 +481,7 @@
         "@klicker-uzh/prisma": "^3.0.0-alpha.0",
         "@radix-ui/react-tabs": "1.0.3",
         "@socialgouv/matomo-next": "1.6.1",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "body-parser": "1.20.2",
         "dayjs": "1.11.7",
         "deepmerge": "4.3.1",
@@ -596,11 +602,12 @@
       }
     },
     "apps/office-addin": {
+      "name": "@klicker-uzh/office-addin",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fluentui/react": "8.109.5",
-        "@uzh-bf/design-system": "2.0.2",
+        "@uzh-bf/design-system": "2.0.6",
         "core-js": "3.30.2",
         "es6-promise": "4.2.8",
         "formik": "2.2.9",
@@ -14306,9 +14313,9 @@
       }
     },
     "node_modules/@uzh-bf/design-system": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@uzh-bf/design-system/-/design-system-2.0.2.tgz",
-      "integrity": "sha512-mL6cInrPHXRFo0XujTjkKrP0RVstQcfkLbU1R/qqkMNZ3PoJC/S9wONBaxnkUsG6/xS2jKKsMPeoKyygxu14+Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@uzh-bf/design-system/-/design-system-2.0.6.tgz",
+      "integrity": "sha512-K4TTlhB2hn3e33w/Yejq+ozRo0lWb9IsIICKGkJSdg2UN65GWpbT0N1AQv4zORQu1TN1qdQZO6NeqRULiTNdsw==",
       "dependencies": {
         "@radix-ui/react-checkbox": "1.0.4",
         "@radix-ui/react-collapsible": "1.0.3",
@@ -14341,8 +14348,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "tailwind-merge": "^1.8.1",
-        "tailwindcss": "3.3.2",
-        "tailwindcss-radix": "2.8.0",
+        "tailwindcss": "^3.3.0",
+        "tailwindcss-radix": "^2.8.0",
         "yup": "^1.0.0"
       }
     },
@@ -40172,6 +40179,7 @@
       }
     },
     "packages/grading": {
+      "name": "@klicker-uzh/grading",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -40207,6 +40215,7 @@
       }
     },
     "packages/graphql": {
+      "name": "@klicker-uzh/graphql",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -40285,6 +40294,7 @@
       }
     },
     "packages/lti": {
+      "name": "@klicker-uzh/lti",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -40319,6 +40329,7 @@
       }
     },
     "packages/markdown": {
+      "name": "@klicker-uzh/markdown",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -40369,6 +40380,7 @@
       }
     },
     "packages/prisma": {
+      "name": "@klicker-uzh/prisma",
       "version": "3.0.0-beta.4",
       "license": "AGPL-3.0",
       "dependencies": {


### PR DESCRIPTION
This pull request fixes a layout issue where the tooltips inside the session wizards (for all three session types) were placed below certain parts of the workflow component, because of too small z-indices.