### PR TITLE
fix(frontend-manage): ensure that empty explanations are saved as null

### DIFF
--- a/apps/frontend-manage/src/components/questions/QuestionEditModal.tsx
+++ b/apps/frontend-manage/src/components/questions/QuestionEditModal.tsx
@@ -335,7 +335,11 @@ function QuestionEditModal({
           id: questionId,
           name: values.name,
           content: values.content,
-          explanation: values.explanation,
+          explanation:
+            !values.explanation?.match(/^(<br>(\n)*)$/g) &&
+            values.explanation !== ''
+              ? values.explanation
+              : null,
           hasSampleSolution: values.hasSampleSolution,
           hasAnswerFeedbacks: values.hasAnswerFeedbacks,
           tags: values.tags,


### PR DESCRIPTION
This pull request ensures that empty explanation fields on the manage frontends, which might contain a break and newlines in markdown syntax are checked correctly and then saved as null in case of an empty editor. This also ensures that the students will no longer observe empty explanation boxes