### PR TITLE
fix(packages/graphql): ensure that execution counter of session block is incremented on session abortion

### DIFF
--- a/packages/graphql/src/services/sessions.ts
+++ b/packages/graphql/src/services/sessions.ts
@@ -1753,7 +1753,9 @@ export async function cancelSession(
             data: {
               status: SessionBlockStatus.SCHEDULED,
               expiresAt: null,
-              execution: 0,
+              execution: {
+                increment: 1,
+              },
             },
           },
         },


### PR DESCRIPTION
Ensure that the execution counter of live session blocks is also incremented when the session is aborted. This ensures that the local storage content on the student applications does not block them from answering questions in a session they have previously answered before the abortion.