### PR TITLE
enhance(packages/grading): update grading logic and test suite

### DIFF
--- a/.github/workflows/test-grading.yml
+++ b/.github/workflows/test-grading.yml
@@ -22,5 +22,4 @@ jobs:
           run_install: true
       - name: Test functions
         shell: bash
-        run: |
-          pnpm run test
+        run: jest

--- a/.github/workflows/test-grading.yml
+++ b/.github/workflows/test-grading.yml
@@ -22,4 +22,6 @@ jobs:
           run_install: true
       - name: Test functions
         shell: bash
-        run: jest
+        run: |
+          cd packages/grading
+          pnpm run test

--- a/.github/workflows/test-grading.yml
+++ b/.github/workflows/test-grading.yml
@@ -1,0 +1,26 @@
+name: Test grading package functionalities
+
+on:
+  push:
+    branches: ["v3"]
+  pull_request:
+    branches: ["v3"]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.12
+          run_install: true
+      - name: Test functions
+        shell: bash
+        run: |
+          pnpm run test

--- a/apps/func-response-processor/src/index.ts
+++ b/apps/func-response-processor/src/index.ts
@@ -188,7 +188,6 @@ const serviceBusTrigger = async function (
           })
           xpAwarded = computeAwardedXp({
             pointsPercentage,
-            multiplier: parseFloat(pointsMultiplier),
           })
 
           if (
@@ -252,7 +251,6 @@ const serviceBusTrigger = async function (
           })
           xpAwarded = computeAwardedXp({
             pointsPercentage: answerCorrect ?? 0,
-            multiplier: parseFloat(pointsMultiplier),
           })
 
           if (parsedSolutions && answerCorrect && !firstResponseReceivedAt) {
@@ -312,7 +310,6 @@ const serviceBusTrigger = async function (
           })
           xpAwarded = computeAwardedXp({
             pointsPercentage: answerCorrect ?? 0,
-            multiplier: parseFloat(pointsMultiplier),
           })
 
           if (answerCorrect && !firstResponseReceivedAt) {

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -193,7 +193,7 @@ export function computeSimpleAwardedPoints({
   pointsMultiplier,
 }: ComputeSimpleAwardedPointsArgs): number {
   if (pointsPercentage !== null && typeof pointsPercentage !== 'undefined') {
-    return points * pointsPercentage * (pointsMultiplier ?? 1)
+    return Math.round(points * pointsPercentage * (pointsMultiplier ?? 1))
   }
   return 0
 }

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -151,7 +151,7 @@ export function computeAwardedPoints({
   const slope = maxBonus / (timeToZeroBonus ?? 20)
 
   // default number of points each student gets independent of the correctness of the answer
-  let awardedPoints = defaultPoints ?? 0
+  let awardedPoints = 0
 
   // time between the first response and the current response
   let responseTiming =
@@ -175,6 +175,8 @@ export function computeAwardedPoints({
   if (typeof pointsMultiplier !== 'undefined') {
     awardedPoints *= Number(pointsMultiplier)
   }
+
+  awardedPoints += defaultPoints || 0
 
   return Math.round(awardedPoints)
 }

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -200,13 +200,9 @@ export function computeSimpleAwardedPoints({
 
 interface ComputeAwardedXpArgs {
   pointsPercentage: number | null
-  multiplier: number
 }
 
-export function computeAwardedXp({
-  pointsPercentage,
-  multiplier,
-}: ComputeAwardedXpArgs) {
+export function computeAwardedXp({ pointsPercentage }: ComputeAwardedXpArgs) {
   if (pointsPercentage !== null && pointsPercentage === 1) {
     return 10
   }

--- a/packages/grading/test/index.test.ts
+++ b/packages/grading/test/index.test.ts
@@ -1,5 +1,6 @@
 import {
   computeAwardedPoints,
+  computeAwardedXp,
   computeSimpleAwardedPoints,
   gradeQuestionFreeText,
   gradeQuestionKPRIM,
@@ -462,5 +463,22 @@ describe('@klicker-uzh/grading', () => {
       pointsMultiplier: 2,
     })
     expect(points3Multiplier).toEqual(9)
+  })
+
+  it('should compute the rewarded XP correctly', () => {
+    const xp = computeAwardedXp({
+      pointsPercentage: 1,
+    })
+    expect(xp).toEqual(10)
+
+    const xp2 = computeAwardedXp({
+      pointsPercentage: 0.5,
+    })
+    expect(xp2).toEqual(0)
+
+    const xp3 = computeAwardedXp({
+      pointsPercentage: 0,
+    })
+    expect(xp3).toEqual(0)
   })
 })

--- a/packages/grading/test/index.test.ts
+++ b/packages/grading/test/index.test.ts
@@ -1,5 +1,6 @@
 import {
   computeAwardedPoints,
+  computeSimpleAwardedPoints,
   gradeQuestionFreeText,
   gradeQuestionKPRIM,
   gradeQuestionMC,
@@ -183,7 +184,7 @@ describe('@klicker-uzh/grading', () => {
     expect(points4).toEqual(0)
   })
 
-  it('should compute the awarded points correctly', () => {
+  it('should compute the awarded points correctly for live sessions', () => {
     const points = computeAwardedPoints({
       firstResponseReceivedAt: null,
       responseTimestamp: 2000,
@@ -195,6 +196,19 @@ describe('@klicker-uzh/grading', () => {
       pointsPercentage: 1,
     })
     expect(points).toEqual(45)
+
+    const pointsMultiplier = computeAwardedPoints({
+      firstResponseReceivedAt: null,
+      responseTimestamp: 2000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 1,
+      pointsMultiplier: 2,
+    })
+    expect(pointsMultiplier).toEqual(80)
 
     const points2 = computeAwardedPoints({
       firstResponseReceivedAt: null,
@@ -208,6 +222,19 @@ describe('@klicker-uzh/grading', () => {
     })
     expect(points2).toEqual(45)
 
+    const points2Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: null,
+      responseTimestamp: 2000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: true,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: null,
+      pointsMultiplier: 3,
+    })
+    expect(points2Multiplier).toEqual(115)
+
     const points3 = computeAwardedPoints({
       firstResponseReceivedAt: null,
       responseTimestamp: 2000,
@@ -220,6 +247,19 @@ describe('@klicker-uzh/grading', () => {
     })
     expect(points3).toEqual(28)
 
+    const points3Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: null,
+      responseTimestamp: 2000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 0.5,
+      pointsMultiplier: 2,
+    })
+    expect(points3Multiplier).toEqual(45)
+
     const points4 = computeAwardedPoints({
       firstResponseReceivedAt: '1000',
       responseTimestamp: 11000,
@@ -231,6 +271,19 @@ describe('@klicker-uzh/grading', () => {
       pointsPercentage: 1,
     })
     expect(points4).toEqual(30)
+
+    const points4Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: '1000',
+      responseTimestamp: 11000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 1,
+      pointsMultiplier: 2,
+    })
+    expect(points4Multiplier).toEqual(50)
 
     const points5 = computeAwardedPoints({
       firstResponseReceivedAt: '1000',
@@ -256,6 +309,19 @@ describe('@klicker-uzh/grading', () => {
     })
     expect(points6).toEqual(30)
 
+    const points6Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: '1000',
+      responseTimestamp: 11000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: true,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: null,
+      pointsMultiplier: 2,
+    })
+    expect(points6Multiplier).toEqual(50)
+
     const points7 = computeAwardedPoints({
       firstResponseReceivedAt: '1000',
       responseTimestamp: 11000,
@@ -267,6 +333,19 @@ describe('@klicker-uzh/grading', () => {
       pointsPercentage: 0,
     })
     expect(points7).toEqual(10)
+
+    const points7Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: '1000',
+      responseTimestamp: 11000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 0,
+      pointsMultiplier: 3,
+    })
+    expect(points7Multiplier).toEqual(10)
 
     const points8 = computeAwardedPoints({
       firstResponseReceivedAt: '1000',
@@ -280,6 +359,19 @@ describe('@klicker-uzh/grading', () => {
     })
     expect(points8).toEqual(15)
 
+    const points8Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: '1000',
+      responseTimestamp: 21000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 1,
+      pointsMultiplier: 2,
+    })
+    expect(points8Multiplier).toEqual(20)
+
     const points9 = computeAwardedPoints({
       firstResponseReceivedAt: '1000',
       responseTimestamp: 21000,
@@ -292,6 +384,19 @@ describe('@klicker-uzh/grading', () => {
     })
     expect(points9).toEqual(10)
 
+    const points9Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: '1000',
+      responseTimestamp: 21000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 0,
+      pointsMultiplier: 2,
+    })
+    expect(points9Multiplier).toEqual(10)
+
     const points10 = computeAwardedPoints({
       firstResponseReceivedAt: '1000',
       responseTimestamp: 21000,
@@ -303,5 +408,59 @@ describe('@klicker-uzh/grading', () => {
       pointsPercentage: 0.5,
     })
     expect(points10).toEqual(13)
+
+    const points10Multiplier = computeAwardedPoints({
+      firstResponseReceivedAt: '1000',
+      responseTimestamp: 21000,
+      maxBonus: 30,
+      timeToZeroBonus: 20,
+      getsMaxPoints: false,
+      defaultPoints: 10,
+      defaultCorrectPoints: 5,
+      pointsPercentage: 0.5,
+      pointsMultiplier: 2,
+    })
+    expect(points10Multiplier).toEqual(15)
+  })
+
+  it('should compute the awarded points correctly for learning elements and micro sessions', () => {
+    const points = computeSimpleAwardedPoints({
+      points: 10,
+      pointsPercentage: 1,
+    })
+    expect(points).toEqual(10)
+
+    const pointsMultiplier = computeSimpleAwardedPoints({
+      points: 10,
+      pointsPercentage: 1,
+      pointsMultiplier: 2,
+    })
+    expect(pointsMultiplier).toEqual(20)
+
+    const points2 = computeSimpleAwardedPoints({
+      points: 10,
+      pointsPercentage: 0.5,
+    })
+    expect(points2).toEqual(5)
+
+    const points2Multiplier = computeSimpleAwardedPoints({
+      points: 10,
+      pointsPercentage: 0.5,
+      pointsMultiplier: 2,
+    })
+    expect(points2Multiplier).toEqual(10)
+
+    const points3 = computeSimpleAwardedPoints({
+      points: 10,
+      pointsPercentage: 0.45,
+    })
+    expect(points3).toEqual(5)
+
+    const points3Multiplier = computeSimpleAwardedPoints({
+      points: 10,
+      pointsPercentage: 0.45,
+      pointsMultiplier: 2,
+    })
+    expect(points3Multiplier).toEqual(9)
   })
 })

--- a/packages/graphql/src/services/learningElements.ts
+++ b/packages/graphql/src/services/learningElements.ts
@@ -74,7 +74,6 @@ function evaluateQuestionResponse(
           }),
           xp: computeAwardedXp({
             pointsPercentage,
-            multiplier: multiplier ?? 1,
           }),
           percentile: pointsPercentage ?? 0,
         }
@@ -94,7 +93,6 @@ function evaluateQuestionResponse(
           }),
           xp: computeAwardedXp({
             pointsPercentage,
-            multiplier: multiplier ?? 1,
           }),
           percentile: pointsPercentage ?? 0,
         }
@@ -114,7 +112,6 @@ function evaluateQuestionResponse(
           }),
           xp: computeAwardedXp({
             pointsPercentage,
-            multiplier: multiplier ?? 1,
           }),
           percentile: pointsPercentage ?? 0,
         }
@@ -137,7 +134,6 @@ function evaluateQuestionResponse(
         score: correct ? correct * 10 * (multiplier ?? 1) : 0,
         xp: computeAwardedXp({
           pointsPercentage: correct,
-          multiplier: multiplier ?? 1,
         }),
         percentile: correct ?? 0,
       }
@@ -158,7 +154,6 @@ function evaluateQuestionResponse(
         score: correct ? correct * 10 * (multiplier ?? 1) : 0,
         xp: computeAwardedXp({
           pointsPercentage: correct,
-          multiplier: multiplier ?? 1,
         }),
         percentile: correct ?? 0,
       }


### PR DESCRIPTION
This pull request contains the following updates in the grading package:
- The default points, which are awarded for participating in a live session should not be multiplied by either the question multiplier nor the element multiplier, as wrong answers can lead to a lot of points otherwise
- The test suite is extended with different point combination functions
- The function to compute experience points is updated not to take a multiplier anymore, as it is not considered afterwards anyways
- The grading test suite is now also run as a part of the CI actions