### PR TITLE
chore: add seed script for flashcards

### DIFF
--- a/packages/graphql/src/services/questions.ts
+++ b/packages/graphql/src/services/questions.ts
@@ -20,6 +20,15 @@ export async function getUserQuestions(ctx: ContextWithUser) {
       questions: {
         where: {
           isDeleted: false,
+          type: {
+            in: [
+              DB.ElementType.SC,
+              DB.ElementType.MC,
+              DB.ElementType.KPRIM,
+              DB.ElementType.FREE_TEXT,
+              DB.ElementType.NUMERICAL,
+            ],
+          },
         },
         orderBy: [
           {

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -8,7 +8,8 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/client": "5.3.1"
+    "@prisma/client": "5.3.1",
+    "xml2js": "0.6.2"
   },
   "devDependencies": {
     "@pothos/plugin-prisma": "3.60.0",
@@ -18,6 +19,7 @@
     "@types/bcryptjs": "^2.4.2",
     "@types/node": "^18.17.4",
     "@types/ramda": "^0.29.3",
+    "@types/xml-js": "^1.0.0",
     "bcryptjs": "2.4.3",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",
@@ -33,6 +35,7 @@
     "size-limit": "8.2.4",
     "ts-node": "10.9.1",
     "tsup": "7.2.0",
+    "turndown": "7.1.2",
     "typescript": "5.1.6",
     "uuidv4": "6.2.13"
   },
@@ -71,6 +74,7 @@
     "prisma:studio:raw": "prisma studio --schema=src/prisma/schema.prisma",
     "seed": "ENV=development doppler run --config dev -- run-s build seed:test",
     "seed:achievements": "ENV=development doppler run --config dev -- ts-node --esm --experimental-specifier-resolution=node src/data/seedAchievements.ts",
+    "seed:flashcards": "ENV=development doppler run --config dev -- ts-node --esm --experimental-specifier-resolution=node src/data/seedFlashcards.ts",
     "seed:importQuestions": "cp ../../legacy/db/exported_questions.json ./src/data/exported_questions.json && ENV=development doppler run --config dev -- ts-node --esm --experimental-specifier-resolution=node src/data/importQuestions.ts",
     "seed:mockExamPoints": "ENV=production doppler run --config prd -- ts-node -r dotenv/config --esm --experimental-specifier-resolution=node src/scripts/parseMockExamPoints.ts",
     "seed:prod": "ENV=production doppler run --config prd -- npm-run-all seed:prod:bf1 seed:prod:ami",

--- a/packages/prisma/src/data/data/FC_Modul_1.xml
+++ b/packages/prisma/src/data/data/FC_Modul_1.xml
@@ -1,0 +1,430 @@
+<?xml version="1.0" encoding="UTF-8"?><box id="340880">
+  <title>23HS Banking and Finance I: Modul 1: Einführung in Corporate Finance</title>
+  <description>Lernkarten zur Assessmentvorlesung Banking and Finance I</description>
+  <private>false</private>
+  <category>category.economy.finance</category>
+  <level>level.university</level>
+  <language>de</language>
+  <cards>
+    <card id="15493928">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Welches sind die drei Aufgaben des Treasurers? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li><strong>Cash-Management / Liquiditätsmanagement: </strong>Umfasst die Planung und Sicherstellung der täglichen Zahlungsbereitschaft (Cash Forecasting), die optimale Bewirtschaftung von Kassenbeständen und der weiteren kurzfristigen Anlagen und Finanzschulden usw.</li><li><strong>Credit-Management:<strong> </strong></strong>Prüfung der Kreditwürdigkeit von Kunden, Festlegung von Zahlungs- und Kreditbedingungen und anschliessende Überwachung der Einhaltung (Mahnwesen).</li><li><strong>Wertpapier Ausgabe: </strong>Regelung aller mit Ausgabe (Emission) von Wertpapieren verbundenen Fragen.</li></ul><p><em>(Skript Kapitel 1.5 Organisation des Finanzwesens)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493929">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Welches sind die fünf Aufgaben des Controllers? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li>Planung (Planning for Control)</li><li>Berichtswesen (Reporting and Interpreting), insbesondere Soll/Ist-Vergleich und Analyse von Abweichungen</li><li>Beratung und Entscheidungsvorbereitung (Evaluation and Consulting)</li><li>Schutz des Unternehmensvermögens (Protection of Assets), d.h. die interne Kontrolle und Revision (Internal Auditing)</li><li>Allgemeines Informationswesen (Economic Appraisal)</li></ul><p><em>(Skript Kapitel 1.5 Organisation des Finanzwesens)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493930">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Welches sind die drei zentralen Aufgaben der Finanzabteilung? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li>Finanzplanung</li><li>Finanzdisposition (Realisierung der Finanzplanung)</li><li>Finanzcontrolling (Überwachung aller finanzieller Geschehnisse)</li></ul><p><em>(Skript Kapitel 1.5 Organisation des Finanzwesens)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493931">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Wie lässt sich der Shareholder Value herleiten? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Der Shareholder Value lässt sich aus den diskontierten, erwarteten Free Cash Flows herleiten oder aus der Börsenkapitalisierung (bei kotierten Unternehmen).</p><p><em>(Skript Kapitel 1.4 Wertmaximierung und Shareholder Value)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493932">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Was sind die Unterschiede bzw. Gemeinsamkeiten des Shareholer Value und des Stakeholder Value ? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Beide Konzepte haben langfristig eine Maximierung des Unternehmenswertes unter Berücksichtigung der Interessen der Shareholder und der Stakeholder zum Ziel. Langfristig stehen die Interessen der Shareholder und Stakeholder also nicht im Widerspruch zueinander.</p><p><em>(Skript Kapitel 1.4 Wertmaximierung und Shareholder Value)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493933">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Erläutere das Konzept des Shareholder Value und des Stakeholder Value? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Die Shareholder Value-Maximierung ist mit der Maximierung des Unternehmenswertes gleichzusetzen. Das Konzept orientiert sich hauptsächlich an den Aktionären (Shareholder), welche die Besitzer des Unternehmens sind und das finanzielle Unternehmensrisiko tragen. Im Gegenzug dafür erhalten sie Eigentümerrechte und das sog. Residuum (übrigbleibenden Reinerfolg nach Erfüllung aller festen Ansprüchen). Die Entscheidungsbefugnis bleibt dabei jedoch weitgehend beim Management, wodurch eine Unternehmensführung verlangt wird, welche den Aktionärsinteressen gerecht wird. Das Stakeholder Value Konzept berücksichtigt neben dem Management und den Aktionären weitere Interessengruppen (Stakeholder) wie zum Beispiel Lieferanten, Kunden und Mitarbeiter.</p><p><em>(Skript Kapitel 1.4 Wertmaximierung und Shareholder Value)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493934">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Beschreibe zwischen welchen Zielen im finanzwirtschaftlichen Dreieck eine Zielharmonie bzw. ein Zielkonflikt besteht. (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li><strong>Zielkonflikt: Liquidität und Rentabilität</strong><br />So lange das Kapital, um die Zahlungsbereitschaft bzw. Liquidität zu gewährleisten, in der Kasse liegt, kann damit auch keine Rendite erzielt werden.</li><li><strong>Zielkonflikt: Rentabilität und Sicherheit</strong><br />Je höher die angestrebte Sicherheit, desto weniger Risiko wird eingegangen, was wiederum die Rentabilität senkt.</li><li><strong>Zielharmonie: Liquidität und Sicherheit</strong><br />Ist genügend Liquidität vorhanden, ist eine Zahlungsunfähigkeit unwahrscheinlicher, somit wird die Sicherheit erhöht.</li></ul><p><em>(Skript Kapitel 1.3 Finanzwirtschaftliches Zieldreieck)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493935">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Erläutere den Begriff <strong>Sicherheit </strong>des Finanzwirtschaftlichen Zieldreiecks (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Das Unternehmen muss berücksichtigen, mit wie viel Sicherheit (bzw. Risiko) die Liquidität und die Rentabilität verbunden sind.</p><p><em>(Skript Kapitel 1.3 Finanzwirtschaftliches Zieldreieck)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493936">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Erläutere den Begriff <strong>Rentabilität </strong>des Finanzwirtschaftlichen Zieldreiecks (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Das Unternehmen sollte auf den eingesetzten Mitteln eine angemessene Rentabilität erwirtschaften, so kann Mehrwert erwirtschaftet werden.</p><p><em>(Skript Kapitel 1.3 Finanzwirtschaftliches Zieldreieck)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493937">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Erläutere den Begriff <strong>Liquidität </strong>des Finanzwirtschaftlichen Zieldreiecks (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Das Unternehmen muss stets so viel Kapital zur Verfügung haben, dass es die bereits bestehenden Zahlungsverpflichtungen jederzeit erfüllen und die geplanten Investitionen realisieren kann.</p><p><em>(Skript Kapitel 1.3 Finanzwirtschaftliches Zieldreieck)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493938">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Welches sind die drei Ziele des finanzwirtschaftlichen Dreiecks? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li><strong>Liquidität</strong></li><li><strong>Rentabilität</strong></li><li><strong>Sicherheit</strong></li></ul><p><em>(Skript Kapitel 1.3 Finanzwirtschaftliches Zieldreieck)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493939">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Was ist das oberste Unternehmensziel einer Unternehmung? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<p>Das oberste Ziel der unternehmerischen Tätigkeit besteht in der langfristigen Maximierung des Unternehmenswertes. Neben diesem Hauptkriterium existiert noch eine Vielzahl weiterer Zielkriterien (siehe z.B. das finanzwirtschaftliche Dreieck).</p><p><em>(Skript Kapitel 1.2 Unternehmenszweck und Ziele des Unternehmens)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493940">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Welche drei Entscheidungen umfasst die Corporate Finance im engeren Sinne? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li>Finanzierungsentscheidung: Wie werden Investitionen finanziert? Finanziert sich das Unternehmen mehr mit EK oder mehr mit FK?</li><li>Dividendenentscheidung: Welcher Anteil des Gewinns wird ausgeschüttet und wie viel wird reinvestiert?</li></ul><p><em>(Skript Kapitel 1.1 Was beinhaltet Corporate Finance?)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+    <card id="15493941">
+      <customId/>
+      <set/>
+      <answerType>text</answerType>
+      <hint/>
+      <question>
+        <text>
+          <![CDATA[<p>Welche vier Komponenten beinhaltet die Corporate Finance im weiteren Sinne? (Theorie)</p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </question>
+      <answer>
+        <text>
+          <![CDATA[<ul><li>Kapitalbeschaffung: Wie finanziert sich das Unternehmen (EK versus FK)?</li><li>Kapitaleinsatz: In welche Projekte soll das Unternehmen investieren?</li><li>Kapitalbewirtschaftung: Wie werden überschüssige flüssige Mittel angelegt?</li><li>Kapitalrückzahlung: Wie werden Kredite zurückgezahlt (FK) und welcher Anteil des Gewinns wird als Dividende ausgeschüttet (EK)?</li></ul><p><em>(Skript Kapitel 1.1 Was beinhaltet Corporate Finance?)</em></p>]]>
+        </text>
+        <additionalInfo/>
+        <phonetics/>
+        <example/>
+        <imageName/>
+        <audioName/>
+        <imageCopyright/>
+        <audioCopyright/>
+      </answer>
+    </card>
+  </cards>
+</box>

--- a/packages/prisma/src/data/data/TEST.ts
+++ b/packages/prisma/src/data/data/TEST.ts
@@ -4,7 +4,7 @@ const { ElementType, SessionStatus, OrderType } = Prisma
 
 export const QUESTIONS = [
   {
-    id: 0,
+    originalId: '0',
     name: 'Testfrage FREE_TEXT',
     content:
       'Beantworte mich korrekt, richtig, oder genau. Ansonsten bekommst du keine Punkte!',
@@ -20,7 +20,7 @@ export const QUESTIONS = [
     },
   },
   {
-    id: 1,
+    originalId: '1',
     name: 'Testfrage MC',
     content: 'Wähle 2 und 3, denn sonst ist es vorbei.',
     explanation: 'MC generische Erklärung, warum diese Frage richtig ist.',
@@ -62,7 +62,7 @@ export const QUESTIONS = [
     ],
   },
   {
-    id: 2,
+    originalId: '2',
     name: 'Testfrage NUMERICAL',
     content: 'Wie viel würdest du in Aktien anlegen? Beni mag 17%.',
     explanation: 'NR generische Erklärung, warum diese Frage richtig ist.',
@@ -91,7 +91,7 @@ export const QUESTIONS = [
     },
   },
   {
-    id: 3,
+    originalId: '3',
     name: 'Multi-Faktor-Modell',
     content: '<br>',
     type: ElementType.KPRIM,
@@ -126,7 +126,7 @@ export const QUESTIONS = [
     ],
   },
   {
-    id: 4,
+    originalId: '4',
     name: 'Modul 4 Business Cycle I',
     content:
       'Aktien von Unternehmen aus zyklischen Industriezweigen haben tendenziell Beta-Werte...',

--- a/packages/prisma/src/data/helpers.ts
+++ b/packages/prisma/src/data/helpers.ts
@@ -232,10 +232,14 @@ export function prepareQuestionInstance({
     }
 
     case Prisma.ElementType.NUMERICAL:
-    case Prisma.ElementType.FREE_TEXT: {
+    case Prisma.ElementType.FREE_TEXT:
+    case Prisma.ElementType.CONTENT:
+    case Prisma.ElementType.FLASHCARD: {
       return {
         ...common,
-        results: {},
+        results: {
+          participants: 0,
+        },
       }
     }
   }
@@ -257,6 +261,120 @@ interface StackData {
 }
 
 export async function prepareLearningElement({
+  stacks,
+  ...args
+}: {
+  id: string
+  name: string
+  displayName: string
+  description?: string
+  pointsMultiplier?: number
+  resetTimeDays?: number
+  orderType?: Prisma.OrderType
+  ownerId: string
+  courseId: string
+  stacks: StackData[]
+  status?: Prisma.LearningElementStatus
+}) {
+  return {
+    where: {
+      id: args.id,
+    },
+    create: {
+      id: args.id,
+      name: args.name,
+      displayName: args.displayName,
+      description: args.description,
+      pointsMultiplier: args.pointsMultiplier,
+      resetTimeDays: args.resetTimeDays,
+      status: args.status,
+      orderType: args.orderType,
+      owner: {
+        connect: {
+          id: args.ownerId,
+        },
+      },
+      course: {
+        connect: {
+          id: args.courseId,
+        },
+      },
+      stacks: {
+        create: await Promise.all(
+          stacks.map(async (stack, ix) => ({
+            type: QuestionStackType.LEARNING_ELEMENT,
+            order: ix,
+            displayName: stack.displayName,
+            description: stack.description,
+            elements: {
+              create: stack.elements.map((element, ixInner) => {
+                if (typeof element === 'string') {
+                  return { order: ixInner, mdContent: element }
+                }
+                return {
+                  order: ixInner,
+                  questionInstance: {
+                    create: prepareQuestionInstance({
+                      order: 0,
+                      question: element,
+                      pointsMultiplier: args.pointsMultiplier
+                        ? args.pointsMultiplier * element.pointsMultiplier
+                        : undefined,
+                      resetTimeDays: args.resetTimeDays,
+                      type: QuestionInstanceType.LEARNING_ELEMENT,
+                    }),
+                  },
+                }
+              }),
+            },
+          }))
+        ),
+      },
+    },
+    update: {
+      name: args.name,
+      displayName: args.displayName,
+      description: args.description,
+      pointsMultiplier: args.pointsMultiplier,
+      resetTimeDays: args.resetTimeDays,
+      status: args.status,
+      orderType: args.orderType,
+      stacks: {
+        create: await Promise.all(
+          stacks.map(async (stack, ix) => ({
+            type: QuestionStackType.LEARNING_ELEMENT,
+            order: ix,
+            displayName: stack.displayName,
+            description: stack.description,
+            elements: {
+              create: stack.elements.map((element, ixInner) => {
+                if (typeof element === 'string') {
+                  return { order: ixInner, mdContent: element }
+                }
+                return {
+                  order: ixInner,
+                  questionInstance: {
+                    create: prepareQuestionInstance({
+                      order: 0,
+                      question: element,
+                      pointsMultiplier: args.pointsMultiplier
+                        ? args.pointsMultiplier * element.pointsMultiplier
+                        : undefined,
+                      resetTimeDays: args.resetTimeDays,
+                      type: QuestionInstanceType.LEARNING_ELEMENT,
+                    }),
+                  },
+                }
+              }),
+            },
+          }))
+        ),
+      },
+    },
+  }
+}
+
+export async function preparePracticeQuiz({
   stacks,
   ...args
 }: {

--- a/packages/prisma/src/data/helpers.ts
+++ b/packages/prisma/src/data/helpers.ts
@@ -119,7 +119,7 @@ export function prepareQuestion({
   options,
   ...args
 }: {
-  id: number
+  originalId: string
   name: string
   content: string
   type: Prisma.ElementType
@@ -151,7 +151,7 @@ export function prepareQuestion({
 
     return {
       where: {
-        id: args.id,
+        originalId: args.originalId,
       },
       create: data,
       update: data,
@@ -166,7 +166,7 @@ export function prepareQuestion({
 
   return {
     where: {
-      id: args.id,
+      originalId: args.originalId,
     },
     create: data,
     update: data,

--- a/packages/prisma/src/data/seedFlashcards.ts
+++ b/packages/prisma/src/data/seedFlashcards.ts
@@ -1,0 +1,123 @@
+import fs from 'fs'
+import Turndown from 'turndown'
+import { parseStringPromise } from 'xml2js'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import Prisma, { ElementType } from '../../dist'
+import { COURSE_ID_TEST, USER_ID_TEST } from './constants.js'
+
+export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+
+  const xmlData = fs.readFileSync(
+    path.join(__dirname, 'data/FC_Modul_1.xml'),
+    'utf-8'
+  )
+
+  const xmlDoc = await parseStringPromise(xmlData)
+
+  console.log(xmlDoc, xmlDoc.box.cards[0])
+
+  const turndown = Turndown()
+
+  function extractQuizInfo(doc: typeof xmlDoc) {
+    return {
+      title: doc.box.title[0],
+      description: doc.box.description[0],
+      elements: doc.box.cards[0].card.map((card) => ({
+        originalId: card['$'].id,
+        name: `FC ${card['$'].id}`,
+        content: turndown.turndown(card.question[0].text[0].trim()),
+        explanation: turndown.turndown(card.answer[0].text[0].trim()),
+        type: ElementType.FLASHCARD,
+        options: null,
+        ownerId: USER_ID_TEST,
+      })),
+      // ... other practice quiz properties
+    }
+  }
+
+  const quizInfo = extractQuizInfo(xmlDoc)
+
+  console.log(quizInfo.elements[0])
+
+  const elementsFC = await Promise.all(
+    quizInfo.elements.map((data) =>
+      prismaClient.element.upsert({
+        where: {
+          originalId: data.originalId,
+        },
+        create: {
+          ...data,
+        },
+        update: {
+          ...data,
+        },
+      })
+    )
+  )
+
+  const practiceQuiz = await prismaClient.practiceQuiz.upsert({
+    where: {
+      id: 'e0c331b1-b66e-4fc2-b352-ba14c22c294c',
+    },
+    create: {
+      id: 'e0c331b1-b66e-4fc2-b352-ba14c22c294c',
+      name: quizInfo.title,
+      displayName: quizInfo.title,
+      description: quizInfo.description,
+      ownerId: USER_ID_TEST,
+      courseId: COURSE_ID_TEST,
+      stacks: {
+        create: elementsFC.map((el, ix) => ({
+          order: ix,
+          elementStackType: 'PRACTICE_QUIZ',
+          options: {},
+          elements: {
+            create: {
+              data: [
+                {
+                  order: ix,
+                  type: 'PRACTICE_QUIZ',
+                  elementId: el.id,
+                  elementType: 'FLASHCARD',
+                  elementData: el,
+                  options: null,
+                  results: {},
+                  owner: {
+                    connect: {
+                      id: USER_ID_TEST,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })),
+      },
+    },
+    update: {},
+  })
+
+  console.log(practiceQuiz)
+
+  // TODO: attach all element instances from the practice quiz directly to the course
+  // TODO: practice interface shows all of the instances attached to the course
+
+  return elementsFC
+}
+
+// if main module, run this
+const prismaClient = new Prisma.PrismaClient()
+seedFlashcards(prismaClient)
+  .then((res) => {
+    console.log('res', res)
+  })
+  .catch((err) => {
+    console.error(err)
+  })
+  .finally(async () => {
+    await prismaClient.$disconnect()
+  })

--- a/packages/prisma/src/data/seedFlashcards.ts
+++ b/packages/prisma/src/data/seedFlashcards.ts
@@ -4,8 +4,11 @@ import { parseStringPromise } from 'xml2js'
 
 import path from 'path'
 import { fileURLToPath } from 'url'
-import Prisma from '../../dist'
-import { ElementInstanceType, ElementStackType, ElementType } from '../client'
+import Prisma, {
+  ElementInstanceType,
+  ElementStackType,
+  ElementType,
+} from '../../dist'
 import { COURSE_ID_TEST, USER_ID_TEST } from './constants.js'
 
 export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
@@ -69,18 +72,17 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
           },
         },
       })
+      // TODO: remove debugging output
       console.log(`id: ${flashcard.id}, originalId: ${flashcard.originalId}`)
       return flashcard
     })
   )
 
+  // TODO: remove debugging content
   console.log('seeded elements', elementsFC)
 
   if (elementsFC.some((el) => el.status === 'rejected')) {
-    throw new Error(
-      'Failed to seed some flashcards and cannot create practice quiz from them'
-    )
-    return null
+    throw new Error('Failed to seed some flashcard elements')
   }
 
   const practiceQuiz = await prismaClient.practiceQuiz.upsert({

--- a/packages/prisma/src/data/seedFlashcards.ts
+++ b/packages/prisma/src/data/seedFlashcards.ts
@@ -4,7 +4,8 @@ import { parseStringPromise } from 'xml2js'
 
 import path from 'path'
 import { fileURLToPath } from 'url'
-import Prisma, { ElementStackType, ElementType } from '../../dist'
+import Prisma from '../../dist'
+import { ElementInstanceType, ElementStackType, ElementType } from '../client'
 import { COURSE_ID_TEST, USER_ID_TEST } from './constants.js'
 
 export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
@@ -68,7 +69,7 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
           },
         },
       })
-
+      console.log(`id: ${flashcard.id}, originalId: ${flashcard.originalId}`)
       return flashcard
     })
   )
@@ -77,7 +78,7 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
 
   if (elementsFC.some((el) => el.status === 'rejected')) {
     throw new Error(
-      'Failed to seed some flashcards flashcards and cannot create practice quiz from them'
+      'Failed to seed some flashcards and cannot create practice quiz from them'
     )
     return null
   }
@@ -96,17 +97,17 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
       stacks: {
         create: elementsFC.map((el, ix) => ({
           order: ix,
-          elementStackType: ElementStackType.PRACTICE_QUIZ,
+          type: ElementStackType.PRACTICE_QUIZ,
           options: {},
           elements: {
             create: {
               data: [
                 {
                   order: ix,
-                  type: ElementStackType.PRACTICE_QUIZ,
+                  type: ElementInstanceType.PRACTICE_QUIZ,
                   elementType: ElementType.FLASHCARD,
                   // TODO: pick only relevant properties of the element
-                  elementData: el,
+                  elementData: el.value,
                   options: null,
                   results: {},
                   owner: {
@@ -116,7 +117,7 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
                   },
                   element: {
                     connect: {
-                      id: el.id,
+                      id: el.value.id,
                     },
                   },
                 },

--- a/packages/prisma/src/data/seedFlashcards.ts
+++ b/packages/prisma/src/data/seedFlashcards.ts
@@ -47,8 +47,6 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
 
   const quizInfo = extractQuizInfo(xmlDoc)
 
-  console.log(quizInfo.elements)
-
   const elementsFC = await Promise.allSettled(
     quizInfo.elements.map(async (data) => {
       const flashcard = await prismaClient.element.upsert({
@@ -72,14 +70,14 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
           },
         },
       })
-      // TODO: remove debugging output
-      console.log(`id: ${flashcard.id}, originalId: ${flashcard.originalId}`)
       return flashcard
     })
   )
 
-  // TODO: remove debugging content
-  console.log('seeded elements', elementsFC)
+  console.log(
+    'created elements with value structure and status value: ',
+    elementsFC[0]
+  )
 
   if (elementsFC.some((el) => el.status === 'rejected')) {
     throw new Error('Failed to seed some flashcard elements')
@@ -102,7 +100,7 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
           type: ElementStackType.PRACTICE_QUIZ,
           options: {},
           elements: {
-            create: {
+            createMany: {
               data: [
                 {
                   order: ix,
@@ -110,18 +108,10 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
                   elementType: ElementType.FLASHCARD,
                   // TODO: pick only relevant properties of the element
                   elementData: el.value,
-                  options: null,
+                  options: {},
                   results: {},
-                  owner: {
-                    connect: {
-                      id: USER_ID,
-                    },
-                  },
-                  element: {
-                    connect: {
-                      id: el.value.id,
-                    },
-                  },
+                  ownerId: el.value.ownerId,
+                  elementId: el.value.id,
                 },
               ],
             },
@@ -131,8 +121,6 @@ export async function seedFlashcards(prismaClient: Prisma.PrismaClient) {
     },
     update: {},
   })
-
-  console.log(practiceQuiz)
 
   // TODO: attach all element instances from the practice quiz directly to the course
   // TODO: practice interface shows all of the instances attached to the course

--- a/packages/prisma/src/data/seedTEST.ts
+++ b/packages/prisma/src/data/seedTEST.ts
@@ -1,4 +1,5 @@
-import Prisma, { Element } from '../../dist'
+import Prisma from '../../dist'
+import { Element } from '../client'
 import {
   COURSE_ID_TEST,
   USER_ID_TEST,
@@ -106,6 +107,9 @@ async function seedTest(prisma: Prisma.PrismaClient) {
     orderBy: { id: 'desc' },
   })
 
+  console.log('questionCount', questionCount?.id)
+
+  // TODO: fix sequence syncing
   await prisma.$executeRawUnsafe(
     `ALTER SEQUENCE "Question_id_seq" RESTART WITH ${
       questionCount?.id ?? -1 + 1

--- a/packages/prisma/src/scripts/2023-10-12_migrate_element_options.ts
+++ b/packages/prisma/src/scripts/2023-10-12_migrate_element_options.ts
@@ -14,9 +14,11 @@ async function migrate() {
         data: {
           options: {
             ...elem.options,
-            displayMode: elem.displayMode,
-            hasSampleSolution: elem.hasSampleSolution,
-            hasAnswerFeedbacks: elem.hasAnswerFeedbacks,
+            displayMode: elem.options?.displayMode ?? elem.displayMode,
+            hasSampleSolution:
+              elem.options?.hasSampleSolution ?? elem.hasSampleSolution,
+            hasAnswerFeedbacks:
+              elem.options?.hasAnswerFeedbacks ?? elem.hasAnswerFeedbacks,
           },
         },
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1881,6 +1881,9 @@ importers:
       '@prisma/client':
         specifier: 5.3.1
         version: 5.3.1(prisma@5.3.1)
+      xml2js:
+        specifier: 0.6.2
+        version: 0.6.2
     devDependencies:
       '@pothos/plugin-prisma':
         specifier: 3.60.0
@@ -1903,6 +1906,9 @@ importers:
       '@types/ramda':
         specifier: ^0.29.3
         version: 0.29.3
+      '@types/xml-js':
+        specifier: ^1.0.0
+        version: 1.0.0
       bcryptjs:
         specifier: 2.4.3
         version: 2.4.3
@@ -1948,6 +1954,9 @@ importers:
       tsup:
         specifier: 7.2.0
         version: 7.2.0(ts-node@10.9.1)(typescript@5.1.6)
+      turndown:
+        specifier: 7.1.2
+        version: 7.1.2
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -2814,6 +2823,7 @@ packages:
   /@azure/identity@3.3.0:
     resolution: {integrity: sha512-gISa/dAAxrWt6F2WiDXZY0y2xY4MLlN2wkNW4cPuq5OgPQKLSkxLc4I2WR04puTfZyQZnpXbAapAMEj1b96fgg==}
     engines: {node: '>=14.0.0'}
+    deprecated: Please upgrade to the latest version of this package to get necessary fixes
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.5.0
@@ -11238,6 +11248,13 @@ packages:
     dependencies:
       '@types/node': 18.17.14
 
+  /@types/xml-js@1.0.0:
+    resolution: {integrity: sha512-tRJYQN/uAD8Br9K+pqqzJNd/htIxQaFy6ppfNEWbwsAoWRK3oAxzROCGA39GHT+E3BHLyuBnSB7XKsnJ0s4w2g==}
+    deprecated: This is a stub types definition for xml-js (https://github.com/nashwaan/xml-js). xml-js provides its own type definitions, so you don't need @types/xml-js installed!
+    dependencies:
+      xml-js: 1.6.11
+    dev: true
+
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
 
@@ -15044,6 +15061,10 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+
+  /domino@2.1.6:
+    resolution: {integrity: sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==}
+    dev: true
 
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -26265,6 +26286,12 @@ packages:
       turbo-windows-arm64: 1.10.14
     dev: true
 
+  /turndown@7.1.2:
+    resolution: {integrity: sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==}
+    dependencies:
+      domino: 2.1.6
+    dev: true
+
   /tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: true
@@ -27643,7 +27670,6 @@ packages:
     hasBin: true
     dependencies:
       sax: 1.2.4
-    dev: false
 
   /xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
@@ -27651,6 +27677,14 @@ packages:
     dependencies:
       sax: 1.2.4
       xmlbuilder: 11.0.1
+
+  /xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: false
 
   /xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}


### PR DESCRIPTION
This pull request includes the following relevant changes:
- Modified approach to test question seeding, which now relies on `originalId` instead of the database id
- Basic seeding for flashcards from an XML-input to a practice quiz with instances of the corresponding elements
- Connections between the created instances and the course, which allow to create nicer repetition structure