### PR TITLE
enhance(apps/frontend-pwa): allow to reset local storage on practice quiz manually

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -8,7 +8,7 @@
     "@klicker-uzh/prisma": "workspace:*",
     "@klicker-uzh/shared-components": "workspace:*",
     "@next-auth/prisma-adapter": "1.0.7",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "axios": "1.4.0",
     "bcryptjs": "2.4.3",
     "js-cookie": "3.0.5",

--- a/apps/backend-docker/package.json
+++ b/apps/backend-docker/package.json
@@ -47,7 +47,7 @@
     "@types/passport": "^1.0.10",
     "@types/passport-jwt": "^3.0.6",
     "@types/ramda": "^0.29.3",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "axios": "1.4.0",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,7 +20,7 @@
     "@gabrielcsapo/docusaurus-plugin-matomo": "0.1.2",
     "@mdx-js/react": "2.3.0",
     "@tsconfig/docusaurus": "1.0.5",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "autoprefixer": "10.4.14",
     "cross-env": "7.0.3",
     "nodemon": "3.0.1",

--- a/apps/frontend-control/package.json
+++ b/apps/frontend-control/package.json
@@ -17,7 +17,7 @@
     "@klicker-uzh/shared-components": "workspace:*",
     "@sentry/nextjs": "7.61.1",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "body-parser": "1.20.2",
     "cross-env": "7.0.3",
     "dayjs": "1.11.9",

--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -17,7 +17,7 @@
     "@klicker-uzh/prisma": "workspace:*",
     "@klicker-uzh/shared-components": "workspace:*",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "d3": "7.8.4",
     "dayjs": "1.11.9",
     "deepmerge": "4.3.1",

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -24,7 +24,7 @@
     "@radix-ui/react-tabs": "1.0.3",
     "@socialgouv/matomo-next": "1.6.1",
     "@uidotdev/usehooks": "2.4.1",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "body-parser": "1.20.2",
     "dayjs": "1.11.9",
     "deepmerge": "4.3.1",

--- a/apps/frontend-pwa/src/components/common/LinkButton.tsx
+++ b/apps/frontend-pwa/src/components/common/LinkButton.tsx
@@ -8,10 +8,17 @@ interface LinkButtonProps {
   href: string
   icon?: IconDefinition
   children: string | React.ReactNode
+  onClick?: () => void
   [key: string]: any
 }
 
-function LinkButton({ href, children, icon, ...props }: LinkButtonProps) {
+function LinkButton({
+  href,
+  children,
+  icon,
+  onClick,
+  ...props
+}: LinkButtonProps) {
   return (
     <Link href={href} className="w-full">
       <Button
@@ -23,6 +30,7 @@ function LinkButton({ href, children, icon, ...props }: LinkButtonProps) {
             props.className?.root
           ),
         }}
+        onClick={onClick}
       >
         {icon && (
           <Button.Icon>

--- a/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
+++ b/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
@@ -37,8 +37,9 @@ function StepProgressWithScoring({
   return (
     <div className="flex flex-row w-full gap-1 md:gap-2">
       <StepProgress
-        displayOffset={(items.length ?? 0) > 7 ? 3 : undefined}
-        value={currentIx}
+        displayOffsetLeft={(items.length ?? 0) > 5 ? 3 : undefined}
+        displayOffsetRight={(items.length ?? 0) > 5 ? 1 : undefined}
+        value={currentIx === -1 ? 0 : currentIx}
         items={items}
         onItemClick={(ix: number) => setCurrentIx(ix)}
         data={{ cy: 'learning-element-progress' }}

--- a/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
+++ b/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
@@ -10,6 +10,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, StepItem, StepProgress } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
+import { twMerge } from 'tailwind-merge'
 
 const ICON_MAP: Record<string, IconDefinition> = {
   correct: faCheckDouble,
@@ -53,14 +54,25 @@ function StepProgressWithScoring({
             return {
               className,
               element: (
-                <div className="flex flex-row items-center justify-between w-full px-2">
-                  <div>{ix + 1}</div>
+                <div className="flex flex-row justify-center w-full px-0.5 md:px-2">
+                  <div className="flex flex-row justify-between items-center md:w-full">
+                    <div
+                      className={twMerge(element.score && 'hidden md:block')}
+                    >
+                      {ix + 1}
+                    </div>
 
-                  <ProgressPoints
-                    score={element.score}
-                    status={element.status}
-                  />
-                  <FontAwesomeIcon icon={ICON_MAP[element.status]} />
+                    {element.score && (
+                      <ProgressPoints
+                        score={element.score}
+                        status={element.status}
+                      />
+                    )}
+                    <FontAwesomeIcon
+                      icon={ICON_MAP[element.status]}
+                      className="hidden md:block"
+                    />
+                  </div>
                 </div>
               ),
             }

--- a/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
+++ b/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
@@ -56,7 +56,7 @@ function StepProgressWithScoring({
               className,
               element: (
                 <div className="flex flex-row justify-center w-full px-0.5 md:px-2">
-                  <div className="flex flex-row justify-between items-center md:w-full">
+                  <div className="flex flex-row items-center justify-between md:w-full">
                     <div
                       className={twMerge(element.score && 'hidden md:block')}
                     >

--- a/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
+++ b/apps/frontend-pwa/src/components/common/StepProgressWithScoring.tsx
@@ -4,10 +4,12 @@ import {
   faCheck,
   faCheckDouble,
   faInbox,
+  faRepeat,
   faX,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { StepItem, StepProgress } from '@uzh-bf/design-system'
+import { Button, StepItem, StepProgress } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
 
 const ICON_MAP: Record<string, IconDefinition> = {
   correct: faCheckDouble,
@@ -20,68 +22,91 @@ interface StepProgressWithScoringProps {
   items: StepItem[]
   currentIx: number
   setCurrentIx: (ix: number) => void
+  resetLocalStorage?: () => void
 }
 
 function StepProgressWithScoring({
   items,
   currentIx,
   setCurrentIx,
+  resetLocalStorage,
 }: StepProgressWithScoringProps) {
+  const t = useTranslations()
+
   return (
-    <StepProgress
-      displayOffset={(items.length ?? 0) > 7 ? 3 : undefined}
-      value={currentIx}
-      items={items}
-      onItemClick={(ix: number) => setCurrentIx(ix)}
-      data={{ cy: 'learning-element-progress' }}
-      formatter={({ element, ix }) => {
-        function render({
-          className,
-          element,
-        }: {
-          className: string
-          element: StepItem
-        }) {
-          return {
+    <div className="flex flex-row w-full gap-1 md:gap-2">
+      <StepProgress
+        displayOffset={(items.length ?? 0) > 7 ? 3 : undefined}
+        value={currentIx}
+        items={items}
+        onItemClick={(ix: number) => setCurrentIx(ix)}
+        data={{ cy: 'learning-element-progress' }}
+        className={{ root: 'w-full' }}
+        formatter={({ element, ix }) => {
+          function render({
             className,
-            element: (
-              <div className="flex flex-row items-center justify-between w-full px-2">
-                <div>{ix + 1}</div>
+            element,
+          }: {
+            className: string
+            element: StepItem
+          }) {
+            return {
+              className,
+              element: (
+                <div className="flex flex-row items-center justify-between w-full px-2">
+                  <div>{ix + 1}</div>
 
-                <ProgressPoints score={element.score} status={element.status} />
-                <FontAwesomeIcon icon={ICON_MAP[element.status]} />
-              </div>
-            ),
+                  <ProgressPoints
+                    score={element.score}
+                    status={element.status}
+                  />
+                  <FontAwesomeIcon icon={ICON_MAP[element.status]} />
+                </div>
+              ),
+            }
           }
-        }
 
-        if (element.status === 'correct') {
+          if (element.status === 'correct') {
+            return render({
+              element,
+              className: 'bg-green-600 bg-opacity-60 text-white',
+            })
+          }
+
+          if (element.status === 'incorrect') {
+            return render({
+              element,
+              className: 'bg-red-600 bg-opacity-60 text-white',
+            })
+          }
+
+          if (element.status === 'partial') {
+            return render({
+              element,
+              className: 'bg-uzh-red-100 bg-opacity-60 text-white',
+            })
+          }
+
           return render({
             element,
-            className: 'bg-green-600 bg-opacity-60 text-white',
+            className: '',
           })
-        }
-
-        if (element.status === 'incorrect') {
-          return render({
-            element,
-            className: 'bg-red-600 bg-opacity-60 text-white',
-          })
-        }
-
-        if (element.status === 'partial') {
-          return render({
-            element,
-            className: 'bg-uzh-red-100 bg-opacity-60 text-white',
-          })
-        }
-
-        return render({
-          element,
-          className: '',
-        })
-      }}
-    />
+        }}
+      />
+      {resetLocalStorage && (
+        <Button
+          className={{ root: 'text-sm h-7 flex flex-row' }}
+          onClick={() => {
+            resetLocalStorage()
+          }}
+        >
+          <FontAwesomeIcon icon={faRepeat} />
+          <div className="hidden w-max md:block">
+            {t('pwa.practiceQuiz.resetAnswers')}
+          </div>
+        </Button>
+      )}
+    </div>
   )
 }
 

--- a/apps/frontend-pwa/src/components/common/StepProgressWithScoringOld.tsx
+++ b/apps/frontend-pwa/src/components/common/StepProgressWithScoringOld.tsx
@@ -31,7 +31,8 @@ function StepProgressWithScoring({
 }: StepProgressWithScoringProps) {
   return (
     <StepProgress
-      displayOffset={(items.length ?? 0) > 7 ? 3 : undefined}
+      displayOffsetLeft={(items.length ?? 0) > 7 ? 3 : undefined}
+      displayOffsetRight={(items.length ?? 0) > 7 ? 3 : undefined}
       value={currentIx}
       items={items}
       onItemClick={(ix: number) => setCurrentIx(ix)}

--- a/apps/frontend-pwa/src/components/practiceQuiz/CourseCollapsible.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/CourseCollapsible.tsx
@@ -10,6 +10,7 @@ import * as RadixCollapsible from '@radix-ui/react-collapsible'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { resetPracticeQuizLocalStorage } from './PracticeQuiz'
 
 export enum RepetitionElementType {
   LEARNING_ELEMENT,
@@ -55,6 +56,9 @@ function CourseCollapsible({ courseName, elements }: CourseCollapsibleProps) {
                     : `/course/${element.course!.id}/quiz/${element.id}`
                 }
                 data={{ cy: 'practice-quiz' }}
+                onClick={() => {
+                  resetPracticeQuizLocalStorage(element.id)
+                }}
               >
                 {element.displayName}
               </LinkButton>

--- a/apps/frontend-pwa/src/components/practiceQuiz/CourseCollapsible.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/CourseCollapsible.tsx
@@ -1,4 +1,3 @@
-import LinkButton from '@components/common/LinkButton'
 import {
   faBookOpenReader,
   faChevronDown,
@@ -10,6 +9,7 @@ import * as RadixCollapsible from '@radix-ui/react-collapsible'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import LinkButton from '../common/LinkButton'
 import { resetPracticeQuizLocalStorage } from './PracticeQuiz'
 
 export enum RepetitionElementType {

--- a/apps/frontend-pwa/src/components/practiceQuiz/Flashcard.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/Flashcard.tsx
@@ -1,4 +1,3 @@
-import DynamicMarkdown from '@components/learningElements/DynamicMarkdown'
 import {
   IconDefinition,
   faHandPointer,
@@ -9,6 +8,7 @@ import { Button } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import DynamicMarkdown from '../learningElements/DynamicMarkdown'
 import { FlashcardResponseValues } from './ElementStack'
 
 interface FlashcardProps {
@@ -51,7 +51,7 @@ function Flashcard({
             existingResponse={existingResponse}
           />
         ) : (
-          <div className="self-end text-sm text-gray-500 flex flex-row items-center gap-2">
+          <div className="flex flex-row items-center self-end gap-2 text-sm text-gray-500">
             <FontAwesomeIcon icon={faHandPointer} />
             {t('pwa.practiceQuiz.flashcardClick')}
           </div>
@@ -99,15 +99,15 @@ function FlashcardBack({
   const t = useTranslations()
 
   return (
-    <div className="flex flex-col w-full flex-1 transform-rotateY-180 backface-hidden">
+    <div className="flex flex-col flex-1 w-full transform-rotateY-180 backface-hidden">
       <div className="flex flex-1">
         <DynamicMarkdown content={explanation} withProse />
       </div>
-      <div className="flex flex-col items-center justify-center gap-1 flex-shrink-0 w-full pt-4 border-t border-gray-300">
+      <div className="flex flex-col items-center justify-center flex-shrink-0 w-full gap-1 pt-4 border-t border-gray-300">
         <p className="font-bold">
           {t('pwa.practiceQuiz.studentFlashcardResponse')}
         </p>
-        <div className="flex flex-row justify-evenly w-full mt-2 space-x-2">
+        <div className="flex flex-row w-full mt-2 space-x-2 justify-evenly">
           <FlashcardButton
             active={
               response === 'incorrect' || existingResponse === 'incorrect'

--- a/apps/frontend-pwa/src/components/practiceQuiz/PracticeQuiz.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/PracticeQuiz.tsx
@@ -5,11 +5,21 @@ import StepProgressWithScoring from '../common/StepProgressWithScoring'
 import ElementOverview from '../learningElements/ElementOverview'
 import ElementStack, { InstanceStatus } from './ElementStack'
 
+export function resetPracticeQuizLocalStorage(id: string) {
+  const localStorageKeys = Object.keys(localStorage)
+  localStorageKeys.forEach((key) => {
+    if (key.includes(id)) {
+      localStorage.removeItem(key)
+    }
+  })
+}
+
 interface PracticeQuizProps {
   quiz: PracticeQuiz
   currentIx: number
   setCurrentIx: (ix: number) => void
   handleNextElement: () => void
+  showResetLocalStorage?: boolean
 }
 
 function PracticeQuiz({
@@ -17,6 +27,7 @@ function PracticeQuiz({
   currentIx,
   setCurrentIx,
   handleNextElement,
+  showResetLocalStorage = false,
 }: PracticeQuizProps) {
   const currentStack = quiz.stacks?.[currentIx]
 
@@ -56,6 +67,14 @@ function PracticeQuiz({
         }
         currentIx={currentIx}
         setCurrentIx={setCurrentIx}
+        resetLocalStorage={
+          showResetLocalStorage
+            ? () => {
+                resetPracticeQuizLocalStorage(quiz.id)
+                window.location.reload()
+              }
+            : undefined
+        }
       />
 
       {currentIx === -1 && (
@@ -75,7 +94,7 @@ function PracticeQuiz({
       {currentStack && (
         <ElementStack
           parentId={quiz.id}
-          courseId={quiz.course.id}
+          courseId={quiz.course!.id}
           stack={currentStack}
           currentStep={currentIx + 1}
           totalSteps={quiz.stacks?.length ?? 0}

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client'
-import PracticeQuiz from '@components/practiceQuiz/PracticeQuiz'
 import { GetCoursePracticeQuizDocument } from '@klicker-uzh/graphql/dist/ops'
 import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { addApolloState, initializeApollo } from '@lib/apollo'
@@ -8,8 +7,9 @@ import { UserNotification } from '@uzh-bf/design-system'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
-import Layout from 'src/components/Layout'
-import Footer from 'src/components/common/Footer'
+import Layout from '../../../components/Layout'
+import Footer from '../../../components/common/Footer'
+import PracticeQuiz from '../../../components/practiceQuiz/PracticeQuiz'
 
 interface Props {
   courseId: string

--- a/apps/frontend-pwa/src/pages/course/[courseId]/quiz/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/quiz/[id].tsx
@@ -64,6 +64,7 @@ function PracticeQuizPage({ courseId, id }: Props) {
         currentIx={currentIx}
         setCurrentIx={setCurrentIx}
         handleNextElement={handleNextQuestion}
+        showResetLocalStorage
       />
       <Footer
         browserLink={`${process.env.NEXT_PUBLIC_PWA_URL}/course/${courseId}/element/${id}`}

--- a/apps/frontend-pwa/src/pages/course/[courseId]/quiz/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/quiz/[id].tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client'
-import PracticeQuiz from '@components/practiceQuiz/PracticeQuiz'
 import {
   GetPracticeQuizDocument,
   PracticeQuiz as PracticeQuizType,
@@ -13,6 +12,7 @@ import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import Layout from '../../../../components/Layout'
 import Footer from '../../../../components/common/Footer'
+import PracticeQuiz from '../../../../components/practiceQuiz/PracticeQuiz'
 
 interface Props {
   courseId: string

--- a/apps/frontend-pwa/src/pages/editProfile.tsx
+++ b/apps/frontend-pwa/src/pages/editProfile.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from '@apollo/client'
 import { BigHead } from '@bigheads/core'
-import DebouncedUsernameField from '@components/forms/DebouncedUsernameField'
 import { faSave } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
@@ -31,6 +30,7 @@ import { pick } from 'ramda'
 import { useEffect, useState } from 'react'
 import * as yup from 'yup'
 import Layout from '../components/Layout'
+import DebouncedUsernameField from '../components/forms/DebouncedUsernameField'
 
 function EditProfile() {
   const t = useTranslations()
@@ -194,14 +194,14 @@ function EditProfile() {
         {({ values, isSubmitting, isValid, validateField }) => {
           return (
             <Form>
-              <div className="flex flex-col md:w-full md:max-w-5xl md:mx-auto gap-4">
-                <div className="flex flex-col w-full md:flex-row gap-4">
-                  <div className="flex flex-col justify-between flex-1 order-2 gap-3 md:order-1 md:bg-slate-50 md:p-4 rounded">
+              <div className="flex flex-col gap-4 md:w-full md:max-w-5xl md:mx-auto">
+                <div className="flex flex-col w-full gap-4 md:flex-row">
+                  <div className="flex flex-col justify-between flex-1 order-2 gap-3 rounded md:order-1 md:bg-slate-50 md:p-4">
                     <div>
                       <H3 className={{ root: 'border-b mb-0' }}>
                         {t('shared.generic.profile')}
                       </H3>
-                      <div className="space-y-3 mb-2">
+                      <div className="mb-2 space-y-3">
                         <FormikTextField
                           // TODO: as soon as verification mechanism for email is implemented, add check for "isEmailValid" in DB for disabled field as emails with typos cannot be changed currently
                           disabled={
@@ -244,7 +244,7 @@ function EditProfile() {
                           <div className="font-bold">
                             {t('pwa.profile.publicProfile')}
                           </div>
-                          <div className="flex flex-row space-between gap-4">
+                          <div className="flex flex-row gap-4 space-between">
                             <div className="flex flex-col items-center gap-1">
                               <FormikSwitchField name="isProfilePublic" />
                               {values.isProfilePublic
@@ -273,7 +273,7 @@ function EditProfile() {
                     </Button>
                   </div>
 
-                  <div className="flex-1 order-1 md:order-2 md:bg-slate-50 md:p-4 rounded justify-between flex flex-col space-y-4">
+                  <div className="flex flex-col justify-between flex-1 order-1 space-y-4 rounded md:order-2 md:bg-slate-50 md:p-4">
                     <div className="flex-initial space-y-2">
                       <H3 className={{ root: 'border-b mb-0' }}>
                         {t('pwa.profile.deleteProfile')}
@@ -323,13 +323,13 @@ function EditProfile() {
                   </div>
                 </div>
 
-                <div className="md:bg-slate-50 md:p-4 rounded space-y-2">
+                <div className="space-y-2 rounded md:bg-slate-50 md:p-4">
                   <H3 className={{ root: 'border-b' }}>Avatar</H3>
-                  <div className="flex flex-col md:flex-row gap-4 md:gap-8">
+                  <div className="flex flex-col gap-4 md:flex-row md:gap-8">
                     <div className="flex-1">
                       <BigHead
                         // @ts-ignore
-                        className="border-b-4 md:h-48 border-primary-80 w-full"
+                        className="w-full border-b-4 md:h-48 border-primary-80"
                         eyebrows="raised"
                         faceMask={false}
                         lashes={false}
@@ -348,7 +348,7 @@ function EditProfile() {
                         facialHair={values.facialHair}
                       />
                     </div>
-                    <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-xs md:text-sm">
+                    <div className="grid grid-cols-2 gap-2 text-xs md:grid-cols-3 md:text-sm">
                       {Object.keys(AVATAR_OPTIONS).map((key) => (
                         <FormikSelectField
                           className={{

--- a/apps/frontend-pwa/src/pages/practice.tsx
+++ b/apps/frontend-pwa/src/pages/practice.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client'
+import { resetPracticeQuizLocalStorage } from '@components/practiceQuiz/PracticeQuiz'
 import { faBookOpenReader } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ParticipationsDocument } from '@klicker-uzh/graphql/dist/ops'
@@ -42,12 +43,7 @@ function Practice() {
                 data={{ cy: 'practice-quiz' }}
                 onClick={() => {
                   // check the localstorage and delete all elements, which contain practiceQuiz.id
-                  const localStorageKeys = Object.keys(localStorage)
-                  localStorageKeys.forEach((key) => {
-                    if (key.includes(participation.course!.id)) {
-                      localStorage.removeItem(key)
-                    }
-                  })
+                  resetPracticeQuizLocalStorage(participation.course!.id)
                 }}
               >
                 <Button.Icon>

--- a/apps/frontend-pwa/src/pages/practice.tsx
+++ b/apps/frontend-pwa/src/pages/practice.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client'
-import { resetPracticeQuizLocalStorage } from '@components/practiceQuiz/PracticeQuiz'
 import { faBookOpenReader } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ParticipationsDocument } from '@klicker-uzh/graphql/dist/ops'
@@ -9,6 +8,7 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { twMerge } from 'tailwind-merge'
 import Layout from '../components/Layout'
+import { resetPracticeQuizLocalStorage } from '../components/practiceQuiz/PracticeQuiz'
 
 function Practice() {
   const t = useTranslations()

--- a/apps/frontend-pwa/src/pages/repetition.tsx
+++ b/apps/frontend-pwa/src/pages/repetition.tsx
@@ -66,61 +66,7 @@ function Repetition() {
               elements={elements}
             />
           ))}
-        {/* {learningElementsData?.learningElements?.map((element) => (
-          <Link
-            key={element.id}
-            href={`/course/${element.course!.id}/element/${element.id}`}
-            legacyBehavior
-          >
-            <Button
-              className={{
-                root: twMerge(
-                  'gap-6 px-4 py-2 text-lg shadow bg-uzh-grey-20 sm:hover:bg-uzh-grey-40'
-                ),
-              }}
-              data={{ cy: 'practice-quiz' }}
-            >
-              <Button.Icon>
-                <FontAwesomeIcon icon={faBookOpenReader} />
-              </Button.Icon>
-              <Button.Label className={{ root: 'flex-1 text-left' }}>
-                <div>{element.displayName}</div>
-              </Button.Label>
-            </Button>
-          </Link>
-        ))}
-        {practiceQuizzesData?.practiceQuizzes?.map((practiceQuiz) => (
-          <Link
-            key={practiceQuiz.id}
-            href={`/course/${practiceQuiz.course!.id}/quiz/${practiceQuiz.id}`}
-            legacyBehavior
-          >
-            <Button
-              className={{
-                root: twMerge(
-                  'gap-6 px-4 py-2 text-lg shadow bg-uzh-grey-20 sm:hover:bg-uzh-grey-40'
-                ),
-              }}
-              data={{ cy: 'practice-quiz' }}
-              onClick={() => {
-                // check the localstorage and delete all elements, which contain practiceQuiz.id
-                const localStorageKeys = Object.keys(localStorage)
-                localStorageKeys.forEach((key) => {
-                  if (key.includes(practiceQuiz.id)) {
-                    localStorage.removeItem(key)
-                  }
-                })
-              }}
-            >
-              <Button.Icon>
-                <FontAwesomeIcon icon={faBookOpenReader} />
-              </Button.Icon>
-              <Button.Label className={{ root: 'flex-1 text-left' }}>
-                <div>{practiceQuiz.displayName}</div>
-              </Button.Label>
-            </Button>
-          </Link>
-        ))} */}
+
         {(!learningElementsData?.learningElements ||
           learningElementsData?.learningElements?.length === 0) &&
           (!practiceQuizzesData?.practiceQuizzes ||

--- a/apps/func-incoming-responses/package.json
+++ b/apps/func-incoming-responses/package.json
@@ -18,7 +18,7 @@
     "@tsconfig/recommended": "^1.0.2",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^18.17.4",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "azure-functions-core-tools": "4.0.5390",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/func-response-processor/package.json
+++ b/apps/func-response-processor/package.json
@@ -23,7 +23,7 @@
     "@types/md5": "2.3.2",
     "@types/node": "^18.17.4",
     "@types/ramda": "^0.29.3",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "azure-functions-core-tools": "4.0.5390",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/office-addin/package.json
+++ b/apps/office-addin/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0-beta.1",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "core-js": "3.30.2",
     "es6-promise": "4.2.8",
     "formik": "2.4.3",

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -459,6 +459,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       flashcardNoResponse: 'Nein',
       flashcardPartialResponse: 'Teilweise',
       flashcardYesResponse: 'Ja',
+      resetAnswers: 'Antworten zurücksetzen',
     },
     microSession: {
       notFound:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -460,6 +460,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       flashcardNoResponse: 'No',
       flashcardPartialResponse: 'Partially',
       flashcardYesResponse: 'Yes',
+      resetAnswers: 'Reset answers',
     },
     microSession: {
       notFound:

--- a/packages/lti/package.json
+++ b/packages/lti/package.json
@@ -24,7 +24,7 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "next": "13.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "6.4.2",
     "@fortawesome/free-solid-svg-icons": "6.4.2",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "next": "13.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/prisma/src/data/seedFlashcards.ts
+++ b/packages/prisma/src/data/seedFlashcards.ts
@@ -11,8 +11,8 @@ import Prisma, {
   ElementType,
   PublicationStatus,
 } from '../../dist'
-import { COURSE_ID_BF1_HS23, USER_ID_BF1_HS23 } from './constants'
-// import { COURSE_ID_TEST, USER_ID_TEST } from './constants.js'
+// import { COURSE_ID_BF1_HS23, USER_ID_BF1_HS23 } from './constants'
+import { COURSE_ID_TEST, USER_ID_TEST } from './constants.js'
 
 const turndown = Turndown()
 
@@ -40,10 +40,10 @@ async function seedFlashcardSet(
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)
 
-  // const USER_ID = USER_ID_TEST
-  // const COURSE_ID = COURSE_ID_TEST
-  const USER_ID = USER_ID_BF1_HS23
-  const COURSE_ID = COURSE_ID_BF1_HS23
+  const USER_ID = USER_ID_TEST
+  const COURSE_ID = COURSE_ID_TEST
+  // const USER_ID = USER_ID_BF1_HS23
+  // const COURSE_ID = COURSE_ID_BF1_HS23
 
   const xmlData = fs.readFileSync(path.join(__dirname, fileName), 'utf-8')
 

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -31,7 +31,7 @@
     "@fortawesome/free-regular-svg-icons": "6.4.2",
     "@fortawesome/free-solid-svg-icons": "6.4.2",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@uzh-bf/design-system": "2.1.12",
+    "@uzh-bf/design-system": "2.1.13",
     "formik": "2.4.3",
     "next": "13.5.6",
     "next-intl": "2.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(@prisma/client@5.3.1)(next-auth@4.22.3)
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       axios:
         specifier: 1.4.0
         version: 1.4.0
@@ -260,8 +260,8 @@ importers:
         specifier: ^0.29.3
         version: 0.29.3
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       axios:
         specifier: 1.4.0
         version: 1.4.0
@@ -353,8 +353,8 @@ importers:
         specifier: 1.0.5
         version: 1.0.5
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.27)
@@ -453,8 +453,8 @@ importers:
         specifier: 1.6.1
         version: 1.6.1(next@13.5.6)
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -628,8 +628,8 @@ importers:
         specifier: 1.6.1
         version: 1.6.1(next@13.5.6)
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       d3:
         specifier: 7.8.4
         version: 7.8.4
@@ -875,8 +875,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1(react-dom@18.2.0)(react@18.2.0)
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -1054,8 +1054,8 @@ importers:
         specifier: ^18.17.4
         version: 18.17.4
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       azure-functions-core-tools:
         specifier: 4.0.5390
         version: 4.0.5390
@@ -1246,8 +1246,8 @@ importers:
         specifier: ^0.29.3
         version: 0.29.3
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       azure-functions-core-tools:
         specifier: 4.0.5390
         version: 4.0.5390
@@ -1279,8 +1279,8 @@ importers:
   apps/office-addin:
     dependencies:
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       core-js:
         specifier: 3.30.2
         version: 3.30.2
@@ -1709,8 +1709,8 @@ importers:
   packages/lti:
     dependencies:
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -1773,8 +1773,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.2.0)
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       next:
         specifier: 13.5.6
         version: 13.5.6(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
@@ -1985,8 +1985,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.2.0)
       '@uzh-bf/design-system':
-        specifier: 2.1.12
-        version: 2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.1.13
+        version: 2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       formik:
         specifier: 2.4.3
         version: 2.4.3(react@18.2.0)
@@ -11400,8 +11400,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@uzh-bf/design-system@2.1.12(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0):
-    resolution: {integrity: sha512-QlCTslaEM4AWSVmF4WFGl/zeqgtlrtvTAg2KyODIse7ULekSp7Gv9r6EcnMz3xU0Ax5kWl8RRY5x08V6hBvHIw==}
+  /@uzh-bf/design-system@2.1.13(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.7)(@types/react@18.2.18)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0):
+    resolution: {integrity: sha512-arcVKoSTOobF1drAmFTSNGu+MEcAPjqQJftxEs5yAMjQIL23OXwG47lYjo9YJkMq7JhL+W8YI3vej6JDjUTZSA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ^6.3.0


### PR DESCRIPTION
This pull request introduced:
- Bugfix: reset element status properly when re-entering the component through the menu
- Enhancement: allow users to reset the element manually through a corresponding button -> used when integrated into LMS
- Enhancement: asymmetric step progress offsets can now be chosen, allowing a more compact representation of what is really relevant - especially important on mobile devices


<img width="1266" alt="Screenshot 2023-10-26 at 21 19 56" src="https://github.com/uzh-bf/klicker-uzh/assets/80708107/6e32e7b4-6f52-443d-b442-4aa4402ff734">
<img width="416" alt="Screenshot 2023-10-26 at 22 01 53" src="https://github.com/uzh-bf/klicker-uzh/assets/80708107/f1596020-333b-4c2b-a01b-f46abe215def">
