### PR TITLE
fix(apps/frontend-manage): ensure that evaluation does not break in case of missing NR responses

### DIFF
--- a/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
+++ b/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
@@ -4,6 +4,7 @@ import {
   CHART_COLORS,
   STATISTICS_ORDER,
 } from '@klicker-uzh/shared-components/src/constants'
+import { UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -92,7 +93,7 @@ function QuestionEvaluation({
 
                     return (
                       <div key={`${currentInstance.blockIx}-${innerIndex}`}>
-                        <div className="flex flex-row justify-between items-center leading-5">
+                        <div className="flex flex-row items-center justify-between leading-5">
                           <div
                             // TODO: possibly use single color for answer options to highlight correct one? or some other approach to distinguish better
                             style={{
@@ -111,7 +112,7 @@ function QuestionEvaluation({
                           >
                             {String.fromCharCode(65 + innerIndex)}
                           </div>
-                          <div className="whitespace-nowrap text-right">
+                          <div className="text-right whitespace-nowrap">
                             {Math.round(100 * correctFraction)} %
                           </div>
                         </div>
@@ -152,35 +153,41 @@ function QuestionEvaluation({
               <div className="mt-4 font-bold">
                 {t('manage.evaluation.statistics')}:
               </div>
-              {Object.entries(currentInstance.statistics)
-                .slice(1)
-                .sort(
-                  (a, b) =>
-                    STATISTICS_ORDER.indexOf(a[0]) -
-                    STATISTICS_ORDER.indexOf(b[0])
-                )
-                .map((statistic) => {
-                  const statisticName = statistic[0]
-                  return (
-                    <Statistic
-                      key={statisticName}
-                      statisticName={statisticName}
-                      value={statistic[1]}
-                      hasCheckbox={
-                        !(statisticName === 'min' || statisticName === 'max')
-                      }
-                      chartType={chartType}
-                      checked={statisticStates[statisticName]}
-                      onCheck={() => {
-                        setStatisticStates({
-                          ...statisticStates,
-                          [statisticName]: !statisticStates[statisticName],
-                        })
-                      }}
-                      size={textSize.size}
-                    />
+              {currentInstance.statistics ? (
+                Object.entries(currentInstance.statistics)
+                  .slice(1)
+                  .sort(
+                    (a, b) =>
+                      STATISTICS_ORDER.indexOf(a[0]) -
+                      STATISTICS_ORDER.indexOf(b[0])
                   )
-                })}
+                  .map((statistic) => {
+                    const statisticName = statistic[0]
+                    return (
+                      <Statistic
+                        key={statisticName}
+                        statisticName={statisticName}
+                        value={statistic[1]}
+                        hasCheckbox={
+                          !(statisticName === 'min' || statisticName === 'max')
+                        }
+                        chartType={chartType}
+                        checked={statisticStates[statisticName]}
+                        onCheck={() => {
+                          setStatisticStates({
+                            ...statisticStates,
+                            [statisticName]: !statisticStates[statisticName],
+                          })
+                        }}
+                        size={textSize.size}
+                      />
+                    )
+                  })
+              ) : (
+                <UserNotification type="info">
+                  {t('manage.evaluation.noStatistics')}
+                </UserNotification>
+              )}
               {showSolution &&
                 currentInstance.questionData.options.solutionRanges && (
                   <div>

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1065,6 +1065,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       wordCloud: 'Word Cloud',
       histogram: 'Histogramm',
       barChart: 'Balkendiagramm',
+      noStatistics:
+        'Bisher sind aufgrund fehlender Antworten noch keine Statistiken verfügbar.',
     },
     lecturer: {
       noDataAvailable: 'Keine Daten verfügbar...',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1061,6 +1061,8 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       wordCloud: 'Word Cloud',
       histogram: 'Histogram',
       barChart: 'Bar Chart',
+      noStatistics:
+        'Because of missing answers, no statistics are available yet.',
     },
     lecturer: {
       noDataAvailable: 'No data available...',


### PR DESCRIPTION
In case of missing NR responses / statistics, the evaluation did break at the moment. To avoid this, a simple user notification is shown instead.