### PR TITLE
fix(apps/frontend-pwa): ensure that unit fields do not contain line breaks

### DIFF
--- a/packages/shared-components/dist/utilities.css
+++ b/packages/shared-components/dist/utilities.css
@@ -152,6 +152,11 @@
   width: 100%
 }
 
+.min-w-max {
+  min-width: -moz-max-content;
+  min-width: max-content
+}
+
 .max-w-none {
   max-width: none
 }

--- a/packages/shared-components/src/questions/NUMERICALAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/NUMERICALAnswerOptions.tsx
@@ -68,7 +68,7 @@ export function NUMERICALAnswerOptions({
           }}
         />
         {unit && (
-          <div className="flex flex-col items-center justify-center px-4 text-white rounded-r bg-slate-600">
+          <div className="flex flex-col items-center justify-center px-4 text-white rounded-r bg-slate-600 min-w-max">
             {unit}
           </div>
         )}


### PR DESCRIPTION
<img width="412" alt="Screenshot 2023-11-07 at 23 22 48" src="https://github.com/uzh-bf/klicker-uzh/assets/80708107/dd0cc1ce-34bd-4df4-974f-6d5bbd0cbb49">
<img width="210" alt="Screenshot 2023-11-08 at 00 47 01" src="https://github.com/uzh-bf/klicker-uzh/assets/80708107/7bfd6f1e-3d9d-4d61-bc08-96d75981c5e1">
