### PR TITLE
fix(apps/frontend-*): ensure that countdown timer is only shown when timer is set

### DIFF
--- a/apps/frontend-control/src/components/sessions/SessionBlock.tsx
+++ b/apps/frontend-control/src/components/sessions/SessionBlock.tsx
@@ -69,7 +69,7 @@ function SessionBlock({ block, active = false }: SessionBlockProps) {
           {t('control.session.blockN', { number: block.order + 1 })}
         </div>
         <div className="flex flex-row items-center gap-2">
-          {untilExpiration && (
+          {block.expiresAt && untilExpiration && (
             <CycleCountdown
               key={`${block.expiresAt}-${block.status}`}
               overrideSize={15}

--- a/apps/frontend-manage/src/components/sessions/cockpit/SessionBlock.tsx
+++ b/apps/frontend-manage/src/components/sessions/cockpit/SessionBlock.tsx
@@ -70,7 +70,7 @@ function SessionBlock({
           <FontAwesomeIcon icon={ICON_MAP[block.status]} />
         </div>
         <div>{t('manage.cockpit.blockN', { number: block.order! + 1 })}</div>
-        {untilExpiration && (
+        {block.expiresAt && untilExpiration && untilExpiration !== -2 && (
           <CycleCountdown
             key={`${block.expiresAt}-${block.status}`}
             size="sm"


### PR DESCRIPTION
Due to a wrong conditional, the timer with zero duration was shown on all question block in the lecturer cockpit, independent of the specification of a timer or not. This has been fixed such that the timer is only shown, if an expiration time is set.