### PR TITLE
fix(packages/shared-components): make sure that participant is only shown once on leaderboard

### DIFF
--- a/packages/shared-components/src/Leaderboard.tsx
+++ b/packages/shared-components/src/Leaderboard.tsx
@@ -37,17 +37,17 @@ function Leaderboard({
   className,
   podiumImgSrc,
 }: LeaderboardProps): React.ReactElement {
-  const { top10, inTop10, selfEntry } = useMemo(
+  const { top10AndSelf, inTop10, selfEntry } = useMemo(
     () =>
       leaderboard.reduce<{
-        top10: LeaderboardEntry[]
+        top10AndSelf: LeaderboardEntry[]
         inTop10: boolean
         selfEntry?: LeaderboardEntry
       }>(
         (acc, entry, ix) => {
           if (entry.participantId === participant?.id) {
             return {
-              top10: [...acc.top10, { ...entry, isSelf: true }],
+              top10AndSelf: [...acc.top10AndSelf, { ...entry, isSelf: true }],
               inTop10: ix <= 9,
               selfEntry: entry,
             }
@@ -55,14 +55,14 @@ function Leaderboard({
 
           if (ix <= 9) {
             return {
-              top10: [...acc.top10, entry],
+              top10AndSelf: [...acc.top10AndSelf, entry],
               inTop10: acc.inTop10,
             }
           }
 
           return acc
         },
-        { top10: [], inTop10: false, selfEntry: undefined }
+        { top10AndSelf: [], inTop10: false, selfEntry: undefined }
       ),
     [leaderboard, participant]
   )
@@ -80,41 +80,43 @@ function Leaderboard({
         />
       )}
       <div className={twMerge('space-y-1', className?.list)}>
-        {top10.map((entry: LeaderboardEntry) =>
-          entry.isSelf === true ? (
-            <ParticipantSelf
-              key={entry.id}
-              isActive
-              pseudonym={entry.username}
-              avatar={entry.avatar}
-              withAvatar={!hideAvatars}
-              points={entry.score}
-              rank={entry.rank}
-              onJoinCourse={onJoin}
-              onLeaveCourse={onLeave}
-              onClick={
-                onParticipantClick
-                  ? () => onParticipantClick(entry.participantId, true)
-                  : undefined
-              }
-            />
-          ) : (
-            <ParticipantOther
-              key={entry.id}
-              rank={entry.rank}
-              pseudonym={entry.username}
-              avatar={entry.avatar}
-              withAvatar={!hideAvatars}
-              points={entry.score}
-              onClick={
-                onParticipantClick
-                  ? () => onParticipantClick(entry.participantId, false)
-                  : undefined
-              }
-              className={className?.listItem}
-            />
-          )
-        )}
+        {top10AndSelf
+          .filter((entry: LeaderboardEntry) => entry.rank <= 10)
+          .map((entry: LeaderboardEntry) =>
+            entry.isSelf === true ? (
+              <ParticipantSelf
+                key={entry.id}
+                isActive
+                pseudonym={entry.username}
+                avatar={entry.avatar}
+                withAvatar={!hideAvatars}
+                points={entry.score}
+                rank={entry.rank}
+                onJoinCourse={onJoin}
+                onLeaveCourse={onLeave}
+                onClick={
+                  onParticipantClick
+                    ? () => onParticipantClick(entry.participantId, true)
+                    : undefined
+                }
+              />
+            ) : (
+              <ParticipantOther
+                key={entry.id}
+                rank={entry.rank}
+                pseudonym={entry.username}
+                avatar={entry.avatar}
+                withAvatar={!hideAvatars}
+                points={entry.score}
+                onClick={
+                  onParticipantClick
+                    ? () => onParticipantClick(entry.participantId, false)
+                    : undefined
+                }
+                className={className?.listItem}
+              />
+            )
+          )}
         {!inTop10 && selfEntry && (
           <ParticipantSelf
             key={selfEntry.id}
@@ -124,6 +126,8 @@ function Leaderboard({
             withAvatar={!hideAvatars}
             points={selfEntry.score}
             rank={selfEntry.rank}
+            onJoinCourse={onJoin}
+            onLeaveCourse={onLeave}
           />
         )}
       </div>


### PR DESCRIPTION
As the participant itself was always added to the top10 list, a corresponding entry was shown on the leaderboard in any case. Whenever the participant was not part of the actual top 10, its entry was shown as a duplicate below the leaderboard as well. This issue has been resolve s.t. every participant entry is shown exactly once.