### PR TITLE
fix(packages/graphql): fix feedback subscriptions on student frontend

### DIFF
--- a/apps/frontend-pwa/src/components/liveSession/FeedbackArea.tsx
+++ b/apps/frontend-pwa/src/components/liveSession/FeedbackArea.tsx
@@ -51,7 +51,9 @@ function Subscriber({ subscribeToMore, sessionId }) {
         const removedItem = subscriptionData.data.feedbackRemoved
         return {
           ...prev,
-          feedbacks: prev.feedbacks?.filter((item) => item.id !== removedItem),
+          feedbacks: prev.feedbacks?.filter(
+            (item) => item.id !== parseInt(removedItem)
+          ),
         }
       },
     })

--- a/packages/graphql/src/services/feedbacks.ts
+++ b/packages/graphql/src/services/feedbacks.ts
@@ -109,6 +109,7 @@ export async function respondToFeedback(
 
   if (!feedback || feedback.session.ownerId !== ctx.user.sub) return null
 
+  const feedbackPublished = feedback.isPublished
   const updatedFeedback = await ctx.prisma.feedback.update({
     where: { id },
     data: {
@@ -127,7 +128,12 @@ export async function respondToFeedback(
     },
   })
 
-  ctx.pubSub.publish('feedbackUpdated', updatedFeedback)
+  if (!feedbackPublished) {
+    ctx.pubSub.publish('feedbackAdded', updatedFeedback)
+    ctx.pubSub.publish('feedbackUpdated', updatedFeedback)
+  } else {
+    ctx.pubSub.publish('feedbackUpdated', updatedFeedback)
+  }
 
   ctx.emitter.emit('invalidate', {
     typename: 'Session',

--- a/packages/graphql/src/services/feedbacks.ts
+++ b/packages/graphql/src/services/feedbacks.ts
@@ -302,10 +302,7 @@ export async function deleteFeedback(
     where: { id },
   })
 
-  ctx.pubSub.publish('feedbackRemoved', {
-    id,
-    sessionId: deletedFeedback.sessionId,
-  })
+  ctx.pubSub.publish('feedbackRemoved', deletedFeedback)
 
   ctx.emitter.emit('invalidate', {
     typename: 'Session',


### PR DESCRIPTION
This pull request fixes the following two feedback subscriptions:
- When unpublished feedbacks (moderation active) are answered, they are automatically published. This now also triggers a visibility change on the student frontend, which did not work before
- When feedbacks are deleted, they also vanish from the student frontend through a correspondingly fixed subscription now.