### PR TITLE
enhance(apps/frontend-manage): add support modal to header on lecturer frontend

### DIFF
--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -7,6 +7,7 @@
     "@apollo/client": "3.8.3",
     "@azure/storage-blob": "12.15.0",
     "@fortawesome/fontawesome-svg-core": "6.4.2",
+    "@fortawesome/free-brands-svg-icons": "6.4.2",
     "@fortawesome/free-regular-svg-icons": "6.4.2",
     "@fortawesome/free-solid-svg-icons": "6.4.2",
     "@fortawesome/react-fontawesome": "0.2.0",

--- a/apps/frontend-manage/src/components/common/Header.tsx
+++ b/apps/frontend-manage/src/components/common/Header.tsx
@@ -1,5 +1,9 @@
 import { useQuery } from '@apollo/client'
-import { faPlayCircle, faUserCircle } from '@fortawesome/free-regular-svg-icons'
+import {
+  faPlayCircle,
+  faQuestionCircle,
+  faUserCircle,
+} from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   GetUserRunningSessionsDocument,
@@ -8,7 +12,9 @@ import {
 import { Navigation } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import SupportModal from './SupportModal'
 
 interface HeaderProps {
   user?: User | null
@@ -17,6 +23,7 @@ interface HeaderProps {
 function Header({ user }: HeaderProps): React.ReactElement {
   const router = useRouter()
   const t = useTranslations()
+  const [showSupportModal, setShowSupportModal] = useState(false)
 
   const { data } = useQuery(GetUserRunningSessionsDocument)
 
@@ -118,6 +125,14 @@ function Header({ user }: HeaderProps): React.ReactElement {
             )}
           </Navigation.TriggerItem>
         </div>
+        <Navigation.ButtonItem
+          onClick={() => setShowSupportModal(true)}
+          label=""
+          icon={<FontAwesomeIcon icon={faQuestionCircle} className="h-7" />}
+          className={{
+            root: 'hidden md:block h-7 sm:group-hover:text-white bg-transparent hover:bg-transparent text-white hover:text-uzh-blue-40 -mt-1',
+          }}
+        />
         <Navigation.TriggerItem
           icon={<FontAwesomeIcon icon={faUserCircle} className="h-5" />}
           label={user?.shortname}
@@ -130,11 +145,6 @@ function Header({ user }: HeaderProps): React.ReactElement {
           }}
           data={{ cy: 'user-menu' }}
         >
-          {/* <Navigation.DropdownItem
-            title="Support"
-            onClick={() => router.push("/support")}
-            className={{ title: 'text-base font-bold', root: 'p-2' }}
-          /> */}
           <Navigation.DropdownItem
             title={t('shared.generic.settings')}
             onClick={() => router.push('/user/settings')}
@@ -157,6 +167,11 @@ function Header({ user }: HeaderProps): React.ReactElement {
           />
         </Navigation.TriggerItem>
       </Navigation>
+      <SupportModal
+        open={showSupportModal}
+        setOpen={setShowSupportModal}
+        user={user}
+      />
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/common/Header.tsx
+++ b/apps/frontend-manage/src/components/common/Header.tsx
@@ -96,7 +96,7 @@ function Header({ user }: HeaderProps): React.ReactElement {
             }
             dropdownWidth="w-[12rem]"
             className={{
-              root: 'h-10 w-10 group',
+              root: 'h-10 w-2 group',
               icon: twMerge(
                 'text-uzh-grey-80',
                 data?.userRunningSessions?.length !== 0 && 'text-green-600'

--- a/apps/frontend-manage/src/components/common/SupportEntry.tsx
+++ b/apps/frontend-manage/src/components/common/SupportEntry.tsx
@@ -1,0 +1,40 @@
+import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Link from 'next/link'
+
+interface Props {
+  title: string
+  subtitle?: string
+  href: string
+  icon?: IconDefinition
+  data: {
+    cy?: string
+    test?: string
+  }
+}
+
+function SupportEntry({ title, subtitle, href, icon, data }: Props) {
+  return (
+    <Link passHref legacyBehavior href={href}>
+      <a
+        rel="noopener noreferrer"
+        target="_blank"
+        data-cy={data?.cy}
+        data-test={data?.test}
+        className="flex flex-row items-center w-full gap-4 px-3 py-1 text-black border border-solid rounded-lg hover:bg-gray-200 hover:cursor-pointer"
+      >
+        {icon && (
+          <div className="flex items-center justify-center w-6">
+            <FontAwesomeIcon icon={icon} size="lg" />
+          </div>
+        )}
+        <div>
+          <div className="-mb-0.5 text-lg font-bold">{title}</div>
+          {subtitle && <div className="font-normal">{subtitle}</div>}
+        </div>
+      </a>
+    </Link>
+  )
+}
+
+export default SupportEntry

--- a/apps/frontend-manage/src/components/common/SupportModal.tsx
+++ b/apps/frontend-manage/src/components/common/SupportModal.tsx
@@ -15,6 +15,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { User } from '@klicker-uzh/graphql/dist/ops'
 import { H2, Modal } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import SupportEntry from './SupportEntry'
 
@@ -25,9 +26,11 @@ interface SupportModalProps {
 }
 
 function SupportModal({ open, setOpen, user }: SupportModalProps) {
+  const t = useTranslations()
+
   return (
     <Modal
-      title="Support KlickerUZH"
+      title={t('manage.support.modalTitle')}
       open={open}
       onClose={() => setOpen(false)}
       className={{
@@ -39,31 +42,29 @@ function SupportModal({ open, setOpen, user }: SupportModalProps) {
       <div className="flex flex-col flex-wrap gap-8 md:gap-16 md:flex-row">
         <div className="flex flex-col justify-between flex-1">
           <div className="order-2 md:order-1">
-            <H2>Your Feedback</H2>
-            <p className="mb-2 prose prose-lg">
-              Do you have any feedback for us? Are you experiencing issues when
-              using the KlickerUZH? Please provide us with your feedback so we
-              can continue to improve the KlickerUZH for you.
+            <H2>{t('manage.support.yourFeedback')}</H2>
+            <p className="mb-4 leading-6 prose">
+              {t('manage.support.feedbackText')}
             </p>
             <div className="flex flex-col gap-2">
               <SupportEntry
                 href="https://klicker-uzh.feedbear.com/boards/feature-requests"
-                subtitle="I would like to request a new feature."
-                title="Feature Request"
+                title={t('manage.support.featureRequest')}
+                subtitle={t('manage.support.featureRequestDesc')}
                 icon={faLightbulb}
                 data={{ cy: 'support-feature-request' }}
               />
               <SupportEntry
                 href="https://klicker-uzh.feedbear.com/boards/bug-reports"
-                subtitle="I would like to report a bug or issue."
-                title="Bug Report"
+                title={t('manage.support.bugReport')}
+                subtitle={t('manage.support.bugReportDesc')}
                 icon={faBug}
                 data={{ cy: 'support-bug-report' }}
               />
               <SupportEntry
                 href="https://klicker-uzh.feedbear.com/boards/self-hosting"
-                subtitle="I have problems when self-hosting the KlickerUZH."
-                title="Self-Hosting"
+                title={t('manage.support.selfHosting')}
+                subtitle={t('manage.support.selfHostingDesc')}
                 icon={faServer}
                 data={{ cy: 'support-self-hosting' }}
               />
@@ -84,67 +85,75 @@ function SupportModal({ open, setOpen, user }: SupportModalProps) {
 
         <div className="flex flex-col justify-between flex-1">
           <div className="flex flex-col gap-2">
-            <H2>Further Resources</H2>
-            <div className="text-gray-600">Documentation</div>
+            <H2>{t('manage.support.furtherResources')}</H2>
+            <div className="text-gray-600">
+              {t('shared.generic.documentation')}
+            </div>
             <SupportEntry
               href="https://www.klicker.uzh.ch/getting_started/welcome"
+              title={t('shared.generic.documentation')}
+              subtitle={t('manage.support.documentationDesc')}
               icon={faBook}
-              subtitle="Tutorials, feature documentation, and release notes"
-              title="Documentation"
               data={{ cy: 'support-documentation' }}
             />
             <SupportEntry
               href="https://www.klicker.uzh.ch/faq"
+              title={t('manage.support.faq')}
+              subtitle={t('manage.support.faqDesc')}
               icon={faQuestion}
-              subtitle="Frequently asked questions"
-              title="FAQ"
               data={{ cy: 'support-faq' }}
             />
-            <div className="mt-4 text-gray-600">Connect with Us</div>
+            <div className="mt-4 text-gray-600">
+              {t('manage.support.connect')}
+            </div>
             <SupportEntry
               href="https://www.klicker.uzh.ch/community"
+              title={t('manage.support.community')}
+              subtitle={t('manage.support.communityDesc')}
               icon={faComments}
-              subtitle="A place for discussions and questions regarding the KlickerUZH"
-              title="Community"
               data={{ cy: 'support-community' }}
             />
             {user?.catalyst ? (
               <SupportEntry
                 href="mailto:klicker.support@uzh.ch"
+                title={t('manage.support.email')}
+                subtitle={t('manage.support.emailDesc')}
                 icon={faEnvelope}
-                subtitle="Contact us at klicker.support@uzh.ch"
-                title="Email"
                 data={{ cy: 'support-email' }}
               />
             ) : null}
-            <div className="mt-4 text-gray-600">About the Project</div>
+            <div className="mt-4 text-gray-600">
+              {t('manage.support.aboutProject')}
+            </div>
             <SupportEntry
               href="https://community.klicker.uzh.ch/tag/project-update"
+              title={t('manage.support.projectUpdates')}
+              subtitle={t('manage.support.projectUpdatesDesc')}
               icon={faInfo}
-              subtitle="Regular updates regarding the progress of our project"
-              title="Project Updates"
               data={{ cy: 'support-project-updates' }}
             />
             <SupportEntry
               href="https://www.klicker.uzh.ch/development"
+              title={t('manage.support.roadmap')}
+              subtitle={t('manage.support.roadmapDesc')}
               icon={faBullseye}
-              subtitle="Our current priorities and plans for the future"
-              title="Roadmap"
               data={{ cy: 'support-roadmap' }}
             />
             <SupportEntry
               href="https://community.klicker.uzh.ch/tag/release"
+              title={t('manage.support.releaseNotes')}
+              subtitle={t('manage.support.releaseNotesDesc')}
               icon={faList}
-              subtitle="Overview of changes in our latest releases"
-              title="Release Notes"
               data={{ cy: 'support-release-notes' }}
             />
-            <div className="mt-4 text-gray-600">Open-Source</div>
+            <div className="mt-4 text-gray-600">
+              {t('manage.support.openSource')}
+            </div>
             <SupportEntry
               href="https://github.com/uzh-bf/klicker-uzh"
+              title={t('manage.support.githubRepository')}
+              subtitle={t('manage.support.githubRepositoryDesc')}
               icon={faGithub}
-              subtitle="Source code of the open-source project"
-              title="Github Repository"
               data={{ cy: 'support-github-repository' }}
             />
           </div>

--- a/apps/frontend-manage/src/components/common/SupportModal.tsx
+++ b/apps/frontend-manage/src/components/common/SupportModal.tsx
@@ -1,0 +1,157 @@
+import { faGithub } from '@fortawesome/free-brands-svg-icons'
+import {
+  faComments,
+  faEnvelope,
+  faLightbulb,
+} from '@fortawesome/free-regular-svg-icons'
+import {
+  faBook,
+  faBug,
+  faBullseye,
+  faInfo,
+  faList,
+  faQuestion,
+  faServer,
+} from '@fortawesome/free-solid-svg-icons'
+import { User } from '@klicker-uzh/graphql/dist/ops'
+import { H2, Modal } from '@uzh-bf/design-system'
+import Image from 'next/image'
+import SupportEntry from './SupportEntry'
+
+interface SupportModalProps {
+  open: boolean
+  setOpen: (newOpen: boolean) => void
+  user?: User | null
+}
+
+function SupportModal({ open, setOpen, user }: SupportModalProps) {
+  return (
+    <Modal
+      title="Support KlickerUZH"
+      open={open}
+      onClose={() => setOpen(false)}
+      className={{
+        overlay: 'text-black my-auto',
+        title: 'text-xl md:text-2xl',
+      }}
+      fullScreen
+    >
+      <div className="flex flex-col flex-wrap gap-8 md:gap-16 md:flex-row">
+        <div className="flex flex-col justify-between flex-1">
+          <div className="order-2 md:order-1">
+            <H2>Your Feedback</H2>
+            <p className="mb-2 prose prose-lg">
+              Do you have any feedback for us? Are you experiencing issues when
+              using the KlickerUZH? Please provide us with your feedback so we
+              can continue to improve the KlickerUZH for you.
+            </p>
+            <div className="flex flex-col gap-2">
+              <SupportEntry
+                href="https://klicker-uzh.feedbear.com/boards/feature-requests"
+                subtitle="I would like to request a new feature."
+                title="Feature Request"
+                icon={faLightbulb}
+                data={{ cy: 'support-feature-request' }}
+              />
+              <SupportEntry
+                href="https://klicker-uzh.feedbear.com/boards/bug-reports"
+                subtitle="I would like to report a bug or issue."
+                title="Bug Report"
+                icon={faBug}
+                data={{ cy: 'support-bug-report' }}
+              />
+              <SupportEntry
+                href="https://klicker-uzh.feedbear.com/boards/self-hosting"
+                subtitle="I have problems when self-hosting the KlickerUZH."
+                title="Self-Hosting"
+                icon={faServer}
+                data={{ cy: 'support-self-hosting' }}
+              />
+            </div>
+          </div>
+
+          <div className="order-1 md:order-2 w-[200px] py-8 md:p-0 m-auto md:m-0">
+            <Image
+              src="/KlickerLogo.png"
+              width={300}
+              height={90}
+              alt="KlickerUZH Logo"
+              className="mx-auto"
+              data-cy="login-logo"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-between flex-1">
+          <div className="flex flex-col gap-2">
+            <H2>Further Resources</H2>
+            <div className="text-gray-600">Documentation</div>
+            <SupportEntry
+              href="https://www.klicker.uzh.ch/getting_started/welcome"
+              icon={faBook}
+              subtitle="Tutorials, feature documentation, and release notes"
+              title="Documentation"
+              data={{ cy: 'support-documentation' }}
+            />
+            <SupportEntry
+              href="https://www.klicker.uzh.ch/faq"
+              icon={faQuestion}
+              subtitle="Frequently asked questions"
+              title="FAQ"
+              data={{ cy: 'support-faq' }}
+            />
+            <div className="mt-4 text-gray-600">Connect with Us</div>
+            <SupportEntry
+              href="https://www.klicker.uzh.ch/community"
+              icon={faComments}
+              subtitle="A place for discussions and questions regarding the KlickerUZH"
+              title="Community"
+              data={{ cy: 'support-community' }}
+            />
+            {user?.catalyst ? (
+              <SupportEntry
+                href="mailto:klicker.support@uzh.ch"
+                icon={faEnvelope}
+                subtitle="Contact us at klicker.support@uzh.ch"
+                title="Email"
+                data={{ cy: 'support-email' }}
+              />
+            ) : null}
+            <div className="mt-4 text-gray-600">About the Project</div>
+            <SupportEntry
+              href="https://community.klicker.uzh.ch/tag/project-update"
+              icon={faInfo}
+              subtitle="Regular updates regarding the progress of our project"
+              title="Project Updates"
+              data={{ cy: 'support-project-updates' }}
+            />
+            <SupportEntry
+              href="https://www.klicker.uzh.ch/development"
+              icon={faBullseye}
+              subtitle="Our current priorities and plans for the future"
+              title="Roadmap"
+              data={{ cy: 'support-roadmap' }}
+            />
+            <SupportEntry
+              href="https://community.klicker.uzh.ch/tag/release"
+              icon={faList}
+              subtitle="Overview of changes in our latest releases"
+              title="Release Notes"
+              data={{ cy: 'support-release-notes' }}
+            />
+            <div className="mt-4 text-gray-600">Open-Source</div>
+            <SupportEntry
+              href="https://github.com/uzh-bf/klicker-uzh"
+              icon={faGithub}
+              subtitle="Source code of the open-source project"
+              title="Github Repository"
+              data={{ cy: 'support-github-repository' }}
+            />
+          </div>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default SupportModal

--- a/apps/frontend-manage/src/components/common/SupportModal.tsx
+++ b/apps/frontend-manage/src/components/common/SupportModal.tsx
@@ -115,7 +115,7 @@ function SupportModal({ open, setOpen, user }: SupportModalProps) {
             />
             {user?.catalyst ? (
               <SupportEntry
-                href="mailto:klicker.support@uzh.ch"
+                href="mailto:klicker@bf.uzh.ch"
                 title={t('manage.support.email')}
                 subtitle={t('manage.support.emailDesc')}
                 icon={faEnvelope}

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -638,7 +638,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       community: 'Community',
       communityDesc: 'Ein Ort für Diskussionen und Fragen rund um KlickerUZH',
       email: 'E-Mail',
-      emailDesc: 'Kontaktieren Sie uns unter klicker.support@uzh.ch',
+      emailDesc: 'Kontaktieren Sie uns unter klicker@bf.uzh.ch',
       aboutProject: 'Über das Projekt',
       projectUpdates: 'Projekt Updates',
       projectUpdatesDesc: 'Regelmässige Updates zu unserem Projekt',

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -619,6 +619,38 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       catalystRequired:
         'Catalyst-Zugriff erforderlich. Mehr Informationen unter <link></link>.',
     },
+    support: {
+      modalTitle: 'Support KlickerUZH',
+      yourFeedback: 'Ihr Feedback',
+      feedbackText:
+        'Haben Sie Feedback für uns? Haben Sie Probleme bei der Nutzung von KlickerUZH? Bitte geben Sie uns Ihr Feedback, damit wir KlickerUZH für Sie weiter verbessern können.',
+      featureRequest: 'Feature Request',
+      featureRequestDesc: 'Ich möchte ein neues Feature anfragen.',
+      bugReport: 'Bug Report',
+      bugReportDesc: 'Ich möchte einen Fehler oder ein Problem melden.',
+      selfHosting: 'Self-Hosting',
+      selfHostingDesc: 'Ich habe Probleme beim Self-Hosting von KlickerUZH.',
+      furtherResources: 'Weitere Ressourcen',
+      documentationDesc: 'Tutorials, Funktionsdokumentation und Release Notes',
+      faq: 'FAQ',
+      faqDesc: 'Häufig gestellte Fragen',
+      connect: 'Kontakt',
+      community: 'Community',
+      communityDesc: 'Ein Ort für Diskussionen und Fragen rund um KlickerUZH',
+      email: 'E-Mail',
+      emailDesc: 'Kontaktieren Sie uns unter klicker.support@uzh.ch',
+      aboutProject: 'Über das Projekt',
+      projectUpdates: 'Projekt Updates',
+      projectUpdatesDesc: 'Regelmässige Updates zu unserem Projekt',
+      roadmap: 'Roadmap',
+      roadmapDesc: 'Unsere aktuellen Prioritäten und Pläne für die Zukunft',
+      releaseNotes: 'Release Notes',
+      releaseNotesDesc:
+        'Übersicht über Änderungen in unseren neuesten Releases',
+      openSource: 'Open-Source',
+      githubRepository: 'GitHub Repository',
+      githubRepositoryDesc: 'Quellcode des Open-Source Projekts',
+    },
     login: {
       lecturerLogin: 'Login Dozierende',
       installAndroid:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -643,7 +643,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       communityDesc:
         'A place for discussions and questions regarding the KlickerUZH',
       email: 'E-Mail',
-      emailDesc: 'Contact us at klicker.support@uzh.ch',
+      emailDesc: 'Contact us at klicker@bf.uzh.ch',
       aboutProject: 'About the Project',
       projectUpdates: 'Project Updates',
       projectUpdatesDesc:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -623,6 +623,39 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       catalystRequired:
         'Requires catalyst access. For more information, see <link></link>.',
     },
+    support: {
+      modalTitle: 'Support KlickerUZH',
+      yourFeedback: 'Your Feedback',
+      feedbackText:
+        'Do you have any feedback for us? Are you experiencing issues when using the KlickerUZH? Please provide us with your feedback so we can continue to improve the KlickerUZH for you.',
+      featureRequest: 'Feature Request',
+      featureRequestDesc: 'I would like to request a new feature.',
+      bugReport: 'Bug Report',
+      bugReportDesc: 'I would like to report a bug or issue.',
+      selfHosting: 'Self-Hosting',
+      selfHostingDesc: 'I have problems when self-hosting the KlickerUZH.',
+      furtherResources: 'Further Resources',
+      documentationDesc: 'Tutorials, feature documentation, and release notes',
+      faq: 'FAQ',
+      faqDesc: 'Frequently asked questions',
+      connect: 'Connect with Us',
+      community: 'Community',
+      communityDesc:
+        'A place for discussions and questions regarding the KlickerUZH',
+      email: 'E-Mail',
+      emailDesc: 'Contact us at klicker.support@uzh.ch',
+      aboutProject: 'About the Project',
+      projectUpdates: 'Project Updates',
+      projectUpdatesDesc:
+        'Regular updates regarding the progress of our project',
+      roadmap: 'Roadmap',
+      roadmapDesc: 'Our current priorities and plans for the future',
+      releaseNotes: 'Release Notes',
+      releaseNotesDesc: 'Overview of changes in our latest releases',
+      openSource: 'Open-Source',
+      githubRepository: 'GitHub Repository',
+      githubRepositoryDesc: 'Source code of the open-source project',
+    },
     login: {
       lecturerLogin: 'Login Lecturers',
       installAndroid:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       '@fortawesome/fontawesome-svg-core':
         specifier: 6.4.2
         version: 6.4.2
+      '@fortawesome/free-brands-svg-icons':
+        specifier: 6.4.2
+        version: 6.4.2
       '@fortawesome/free-regular-svg-icons':
         specifier: 6.4.2
         version: 6.4.2
@@ -6195,6 +6198,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.17.19:
@@ -6212,6 +6216,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.17.19:
@@ -6229,6 +6234,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.17.19:
@@ -6246,6 +6252,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.17.19:
@@ -6263,6 +6270,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.19:
@@ -6280,6 +6288,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.17.19:
@@ -6297,6 +6306,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.17.19:
@@ -6314,6 +6324,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.17.19:
@@ -6331,6 +6342,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.17.19:
@@ -6348,6 +6360,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.19:
@@ -6365,6 +6378,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.17.19:
@@ -6382,6 +6396,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.17.19:
@@ -6399,6 +6414,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.17.19:
@@ -6416,6 +6432,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.17.19:
@@ -6433,6 +6450,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.17.19:
@@ -6450,6 +6468,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.17.19:
@@ -6467,6 +6486,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.17.19:
@@ -6484,6 +6504,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.17.19:
@@ -6501,6 +6522,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.17.19:
@@ -6518,6 +6540,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.17.19:
@@ -6535,6 +6558,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.17.19:
@@ -6552,6 +6576,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@escape.tech/graphql-armor-block-field-suggestions@1.4.1:
@@ -12737,7 +12762,7 @@ packages:
       '@babel/core': 7.21.8
       find-cache-dir: 3.3.2
       schema-utils: 4.2.0
-      webpack: 5.83.1(esbuild@0.18.20)
+      webpack: 5.83.1(webpack-cli@5.1.1)
 
   /babel-plugin-dynamic-import-node@2.3.3:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
@@ -15827,6 +15852,7 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -19006,7 +19032,7 @@ packages:
       pretty-format: 29.6.2
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.17.4)(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@18.17.4)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19047,7 +19073,7 @@ packages:
       pretty-format: 29.6.2
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.17.4)(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@18.17.4)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26288,6 +26314,7 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.19.2
       webpack: 5.83.1(esbuild@0.18.20)
+    dev: true
 
   /terser-webpack-plugin@5.3.9(webpack@5.83.1):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
@@ -28016,6 +28043,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack@5.83.1(webpack-cli@5.1.1):
     resolution: {integrity: sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==}


### PR DESCRIPTION
Core features:
- All support functionalities of the previous version (including updated links)
- Bilingual support of the entire modal
- Check for the users catalyst state to determine if the direct support email address should be shown or not

<img width="1493" alt="Screenshot 2024-01-09 at 11 57 09" src="https://github.com/uzh-bf/klicker-uzh/assets/80708107/d7221408-d586-44ba-b36a-aa4d12ba750a">
