### PR TITLE
 enhance(apps/frontend-manage): add modal to confirm delegated access login creation

### DIFF
--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -672,6 +672,9 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       languageSettings: 'Spracheinstellungen',
       languageTooltip:
         'Ändern Sie hier die Programmsprache der KlickerUZH Manage App. Beachten Sie, dass dies keinerlei Einfluss auf Ihre Kursinhalte oder die Spracheinstellungen bei anderen Nutzern oder Studierenden in Ihren Kursen hat.',
+      confirmDelegatedAcces: 'Delegierten Login bestätigen',
+      confirmDelegatedAccesTooltip:
+        'Bitte überprüfen Sie die Zugangsdaten für den delegierten Login. Kopieren Sie das Passwort, bevor Sie dieses Pop-Up schliessen, da es nicht erneut angezeigt werden kann.',
       FULL_ACCESS: 'Voller Zugriff',
       SESSION_EXEC: 'Durchführung von Sessionen',
       READ_ONLY: 'Nur Lesen',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -677,6 +677,9 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       languageSettings: 'Language Settings',
       languageTooltip:
         'Change the language of the KlickerUZH Manage App here. Please note that this has no influence on your course content or the language settings of other users or students in your courses.',
+      confirmDelegatedAcces: 'Confirm delegated login creation',
+      confirmDelegatedAccesTooltip:
+        'Please check your delegated access login credentials. Make sure to copy the password before closing this dialogue, as it cannot be shown again.',
       FULL_ACCESS: 'Full Access',
       SESSION_EXEC: 'Session Execution',
       READ_ONLY: 'Read Only',


### PR DESCRIPTION
<img width="747" alt="Screenshot 2024-01-09 at 20 03 41" src="https://github.com/uzh-bf/klicker-uzh/assets/80708107/241451e3-df40-4358-828d-202aa043f28d">
