### PR TITLE
enhance(apps/frontend-pwa): add possibility to mark all content elements as read

### DIFF
--- a/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
@@ -77,7 +77,7 @@ function ElementStack({
     } else {
       return false
     }
-  }, [currentStep, totalSteps, studentResponse])
+  }, [studentResponse])
 
   // initialize student responses
   useEffect(() => {

--- a/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
@@ -218,7 +218,16 @@ function ElementStack({
         onClick={async () => {
           // TODO: check if all instances have a response before starting submission (once questions are implemented)
 
-          if (showMarkAsRead) {
+          // if stack was already answered, just go to next element
+          if (typeof stackStorage !== 'undefined') {
+            setStudentResponse({})
+
+            if (currentStep === totalSteps) {
+              // TODO: re-introduce summary page for practice quiz
+              router.push(`/`)
+            }
+            handleNextElement()
+          } else if (showMarkAsRead) {
             // update the read status of all content elements in studentResponse to true
             setStudentResponse((currentResponses) =>
               Object.entries(currentResponses).reduce(

--- a/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
@@ -10,7 +10,7 @@ import { useLocalStorage } from '@uidotdev/usehooks'
 import { Button, H2 } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import DynamicMarkdown from 'src/components/learningElements/DynamicMarkdown'
 import ContentElement from './ContentElement'
 import Flashcard from './Flashcard'
@@ -64,6 +64,20 @@ function ElementStack({
   const [studentResponse, setStudentResponse] = useState<StudentResponseType>(
     {}
   )
+
+  const showMarkAsRead = useMemo(() => {
+    if (
+      Object.values(studentResponse).some(
+        (response) =>
+          response.type === ElementType.Content &&
+          typeof response.response === 'undefined'
+      )
+    ) {
+      return true
+    } else {
+      return false
+    }
+  }, [currentStep, totalSteps, studentResponse])
 
   // initialize student responses
   useEffect(() => {
@@ -191,21 +205,42 @@ function ElementStack({
       <Button
         className={{ root: 'float-right text-lg mt-4' }}
         disabled={
-          // TODO: remove the type check where questions are considered to be valid
+          // TODO: questions and flashcards with undefined answer should lead to disabling the continue button
+          // TODO: content elements without answers should not disable button, but change functionality to "mark all as read"
           typeof stackStorage !== 'undefined'
             ? false
             : Object.values(studentResponse).some(
                 (response) =>
                   typeof response.response === 'undefined' &&
-                  (response.type === ElementType.Flashcard ||
-                    response.type === ElementType.Content)
+                  response.type === ElementType.Flashcard
               )
         }
         onClick={async () => {
           // TODO: check if all instances have a response before starting submission (once questions are implemented)
 
+          if (showMarkAsRead) {
+            // update the read status of all content elements in studentResponse to true
+            setStudentResponse((currentResponses) =>
+              Object.entries(currentResponses).reduce(
+                (acc, [instanceId, value]) => {
+                  if (value.type === ElementType.Content) {
+                    return {
+                      ...acc,
+                      [instanceId]: {
+                        ...value,
+                        response: true,
+                      },
+                    }
+                  } else {
+                    return { ...acc, [instanceId]: value }
+                  }
+                },
+                {} as StudentResponseType
+              )
+            )
+          }
           // only submit answer if not already answered before
-          if (typeof stackStorage === 'undefined') {
+          else if (typeof stackStorage === 'undefined') {
             const result = await respondToPracticeQuizStack({
               variables: {
                 stackId: stack.id,
@@ -254,17 +289,19 @@ function ElementStack({
             })
 
             setStudentResponse({})
-          }
 
-          if (currentStep === totalSteps) {
-            // TODO: re-introduce summary page for practice quiz
-            router.push(`/`)
+            if (currentStep === totalSteps) {
+              // TODO: re-introduce summary page for practice quiz
+              router.push(`/`)
+            }
+            handleNextElement()
           }
-          handleNextElement()
         }}
         data={{ cy: 'practice-quiz-stack-submit' }}
       >
-        {currentStep === totalSteps
+        {showMarkAsRead
+          ? t('pwa.practiceQuiz.markAllAsRead')
+          : currentStep === totalSteps
           ? t('shared.generic.finish')
           : t('shared.generic.continue')}
       </Button>

--- a/cypress/cypress/e2e/practice-quiz-student.cy.ts
+++ b/cypress/cypress/e2e/practice-quiz-student.cy.ts
@@ -26,6 +26,7 @@ describe('Practice Quizzes as a Student', () => {
     cy.get('[data-cy="flashcard-response-1-Yes"]').click()
     cy.get('[data-cy="practice-quiz-stack-submit"]').click()
 
+    // skip back and forth
     cy.get('[data-cy="practice-quiz-progress-2"]').click()
     cy.get('[data-cy="practice-quiz-progress-1"]').click()
     cy.get('[data-cy="practice-quiz-progress-0"]').click()
@@ -33,6 +34,7 @@ describe('Practice Quizzes as a Student', () => {
     cy.get('[data-cy="practice-quiz-stack-submit"]').click()
     cy.get('[data-cy="practice-quiz-stack-submit"]').click()
 
+    // answer another stack with a single flashcard
     cy.get('[data-cy="flashcard-front-1"]').click()
     cy.get('[data-cy="flashcard-response-1-Partially"]').click()
     cy.get('[data-cy="practice-quiz-stack-submit"]').click()

--- a/cypress/cypress/e2e/practice-quiz-student.cy.ts
+++ b/cypress/cypress/e2e/practice-quiz-student.cy.ts
@@ -1,3 +1,5 @@
+import messages from '../../../packages/i18n/messages/en'
+
 describe('Practice Quizzes as a Student', () => {
   beforeEach(() => {
     // cy.exec('cd .. && pnpm run prisma:setup:yes && cd cypress', {
@@ -102,12 +104,39 @@ describe('Practice Quizzes as a Student', () => {
     cy.get('[data-cy="read-content-element-3"]').click()
     cy.get('[data-cy="practice-quiz-stack-submit"]').click()
 
+    // use automatic marking as read for second content element stack
+    cy.get('[data-cy="read-content-element-1"]').click()
+    cy.get('[data-cy="practice-quiz-stack-submit"]').contains(
+      messages.pwa.practiceQuiz.markAllAsRead
+    ) // contains mark all as read
+    cy.get('[data-cy="practice-quiz-stack-submit"]').click() // mark all as read
+    cy.get('[data-cy="practice-quiz-stack-submit"]').contains(
+      messages.shared.generic.continue
+    ) // contains continue
+    cy.get('[data-cy="practice-quiz-stack-submit"]').click() // continue / submit stack
+
     // answer combined stack with flashcard, content element and question
     cy.get('[data-cy="flashcard-front-1"]').click()
     cy.get('[data-cy="flashcard-response-1-Yes"]').click()
     // TODO: answer question in combined stack
     cy.get('[data-cy="read-content-element-3"]').click()
     cy.get('[data-cy="practice-quiz-stack-submit"]').click()
+
+    // answer combined stack with flashcard, content element and question
+    cy.get('[data-cy="practice-quiz-stack-submit"]')
+      .contains(messages.pwa.practiceQuiz.markAllAsRead)
+      .should('be.disabled') // contains mark all as read and is disabled
+    cy.get('[data-cy="flashcard-front-1"]').click()
+    cy.get('[data-cy="flashcard-response-1-No"]').click()
+    // TODO: answer question in combined stack
+    cy.get('[data-cy="practice-quiz-stack-submit"]').contains(
+      messages.pwa.practiceQuiz.markAllAsRead
+    ) // contains mark all as read
+    cy.get('[data-cy="practice-quiz-stack-submit"]').click() // mark all as read
+    cy.get('[data-cy="practice-quiz-stack-submit"]').contains(
+      messages.shared.generic.finish
+    ) // contains continue
+    cy.get('[data-cy="practice-quiz-stack-submit"]').click() // continue / submit stack
 
     // TODO: check that answers are correctly shown on submission
     // TODO: check that skipping back and forth in quiz saves the previous answers

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -469,6 +469,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       flashcardPartialResponse: 'Teilweise',
       flashcardYesResponse: 'Ja',
       resetAnswers: 'Antworten zurücksetzen',
+      markAllAsRead: 'Alle als gelesen markieren',
       read: 'Gelesen',
     },
     microSession: {

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -469,6 +469,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       flashcardPartialResponse: 'Partially',
       flashcardYesResponse: 'Yes',
       resetAnswers: 'Reset answers',
+      markAllAsRead: 'Mark all as read',
       read: 'Read',
     },
     microSession: {

--- a/packages/prisma/src/data/seedTEST.ts
+++ b/packages/prisma/src/data/seedTEST.ts
@@ -819,15 +819,16 @@ async function seedTest(prisma: Prisma.PrismaClient) {
               },
             },
           })),
-          // create one stack with all content elements
-          {
+          // create two stacks with all content elements
+          ...[0, 1].map((ix) => ({
             displayName: undefined,
             description: undefined,
             order:
               flashcards.length +
               questionsTest.length +
               contentElements.length +
-              2,
+              2 +
+              ix,
             type: Prisma.ElementStackType.PRACTICE_QUIZ,
             options: {},
             elements: {
@@ -844,16 +845,17 @@ async function seedTest(prisma: Prisma.PrismaClient) {
                 })),
               },
             },
-          },
-          // create a stack with one of each kind of elements
-          {
+          })),
+          // create two stacks with one of each kind of elements
+          ...[0, 1].map((ix) => ({
             displayName: undefined,
             description: undefined,
             order:
               flashcards.length +
               questionsTest.length +
               contentElements.length +
-              3,
+              4 +
+              ix,
             type: Prisma.ElementStackType.PRACTICE_QUIZ,
             options: {},
             elements: {
@@ -892,7 +894,7 @@ async function seedTest(prisma: Prisma.PrismaClient) {
                 ],
               },
             },
-          },
+          })),
         ],
       },
     },


### PR DESCRIPTION
With this pull request, it is possible to mark all content elements as read in a single step (using the continue button). This is only possible, when all other components of the stack have already been answered and sets the corresponding student response status values to `true`.

The adapted test passes locally.