### PR TITLE
fix: ensure that user inputs are properly trimmed

### DIFF
--- a/packages/graphql/src/scripts/checkWhitespaces.ts
+++ b/packages/graphql/src/scripts/checkWhitespaces.ts
@@ -16,6 +16,13 @@ async function run() {
         `User ${user.id} has a shortname with whitespaces: ${shortname}`
       )
     }
+
+    const email = user.email
+    const trimmedEmail = email.trim()
+
+    if (email !== trimmedEmail) {
+      console.log(`User ${user.id} has an email with whitespaces: ${email}`)
+    }
   })
 
   // fetch all participants
@@ -41,6 +48,116 @@ async function run() {
       )
     }
   })
+
+  // fetch all participant groups
+  const participantGroups = await prisma.participantGroup.findMany()
+
+  // iterate over all participant groups and print the names which do not match their trimmed version
+  participantGroups.forEach((participantGroup) => {
+    const name = participantGroup.name
+    const trimmedName = name.trim()
+
+    if (name !== trimmedName) {
+      console.log(
+        `ParticipantGroup ${participantGroup.id} has a name with whitespaces: ${name}`
+      )
+    }
+  })
+
+  // fetch all courses and check name and displayName
+  const courses = await prisma.course.findMany()
+
+  // iterate over all courses and print the names which do not match their trimmed version
+  courses.forEach((course) => {
+    const name = course.name
+    const trimmedName = name.trim()
+
+    if (name !== trimmedName) {
+      console.log(`Course ${course.id} has a name with whitespaces: ${name}`)
+    }
+
+    const displayName = course.displayName
+    const trimmedDisplayName = displayName.trim()
+
+    if (displayName !== trimmedDisplayName) {
+      console.log(
+        `Course ${course.id} has a displayName with whitespaces: ${displayName}`
+      )
+    }
+  })
+
+  // check name and displayName of all microlearnings
+  const microlearnings = await prisma.microLearning.findMany()
+
+  // iterate over all microlearnings and print the names which do not match their trimmed version
+  microlearnings.forEach((microlearning) => {
+    const name = microlearning.name
+    const trimmedName = name.trim()
+
+    if (name !== trimmedName) {
+      console.log(
+        `Microlearning ${microlearning.id} has a name with whitespaces: ${name}`
+      )
+    }
+
+    const displayName = microlearning.displayName
+    const trimmedDisplayName = displayName.trim()
+
+    if (displayName !== trimmedDisplayName) {
+      console.log(
+        `Microlearning ${microlearning.id} has a displayName with whitespaces: ${displayName}`
+      )
+    }
+  })
+
+  // check name and displayName of all practice quizzes
+  const practiceQuizzes = await prisma.practiceQuiz.findMany()
+
+  // iterate over all practice quizzes and print the names which do not match their trimmed version
+  practiceQuizzes.forEach((practiceQuiz) => {
+    const name = practiceQuiz.name
+    const trimmedName = name.trim()
+
+    if (name !== trimmedName) {
+      console.log(
+        `PracticeQuiz ${practiceQuiz.id} has a name with whitespaces: ${name}`
+      )
+    }
+
+    const displayName = practiceQuiz.displayName
+    const trimmedDisplayName = displayName.trim()
+
+    if (displayName !== trimmedDisplayName) {
+      console.log(
+        `PracticeQuiz ${practiceQuiz.id} has a displayName with whitespaces: ${displayName}`
+      )
+    }
+  })
+
+  // TODO: if desired, update live sessions with trimmed name and displayNames (too many for manual update)
+  // // check name and displayName of all live sessions
+  // const liveSessions = await prisma.liveSession.findMany()
+
+  // // iterate over all live sessions and print the names which do not match their trimmed version
+  // liveSessions.forEach((liveSession) => {
+  //   const name = liveSession.name
+  //   const trimmedName = name.trim()
+
+  //   if (name !== trimmedName) {
+  //     console.log(
+  //       `LiveSession ${liveSession.id} has a name with whitespaces: ${name}`
+  //     )
+  //   }
+
+  //   const displayName = liveSession.displayName
+  //   const trimmedDisplayName = displayName.trim()
+
+  //   if (displayName !== trimmedDisplayName) {
+  //     console.log(
+  //       `LiveSession ${liveSession.id} has a displayName with whitespaces: ${displayName}`
+  //     )
+  //   }
+  // })
 
   await prisma.$disconnect()
 }

--- a/packages/graphql/src/scripts/checkWhitespaces.ts
+++ b/packages/graphql/src/scripts/checkWhitespaces.ts
@@ -1,0 +1,48 @@
+import { PrismaClient } from '@klicker-uzh/prisma'
+
+async function run() {
+  const prisma = new PrismaClient()
+
+  // fetch all users
+  const users = await prisma.user.findMany()
+
+  // iterate over all users and print the shortnames, which do not match their trimmed version
+  users.forEach((user) => {
+    const shortname = user.shortname
+    const trimmedShortname = shortname.trim()
+
+    if (shortname !== trimmedShortname) {
+      console.log(
+        `User ${user.id} has a shortname with whitespaces: ${shortname}`
+      )
+    }
+  })
+
+  // fetch all participants
+  const participants = await prisma.participant.findMany()
+
+  // iterate over all participants and print the usernames / emails which do not match their trimmed version
+  participants.forEach((participant) => {
+    const username = participant.username
+    const trimmedUsername = username.trim()
+
+    if (username !== trimmedUsername) {
+      console.log(
+        `Participant ${participant.id} has a username with whitespaces: ${username}`
+      )
+    }
+
+    const email = participant.email
+    const trimmedEmail = email?.trim()
+
+    if (email && email !== trimmedEmail) {
+      console.log(
+        `Participant ${participant.id} has an email with whitespaces: ${email}`
+      )
+    }
+  })
+
+  await prisma.$disconnect()
+}
+
+await run()

--- a/packages/graphql/src/services/accounts.ts
+++ b/packages/graphql/src/services/accounts.ts
@@ -315,7 +315,7 @@ export async function createParticipantAccount(
   try {
     const participant = await ctx.prisma.participant.create({
       data: {
-        email,
+        email: email.trim().toLowerCase(),
         username: username.trim(),
         password: await bcrypt.hash(password, 10),
         isEmailValid: false,

--- a/packages/graphql/src/services/accounts.ts
+++ b/packages/graphql/src/services/accounts.ts
@@ -33,7 +33,7 @@ export async function loginUserToken(
   ctx: Context
 ) {
   const user = await ctx.prisma.user.findUnique({
-    where: { shortname },
+    where: { shortname: shortname.trim() },
   })
 
   if (!user) {
@@ -113,10 +113,10 @@ export async function loginParticipant(
   ctx: Context
 ) {
   const participantWithUsername = await ctx.prisma.participant.findUnique({
-    where: { username: usernameOrEmail },
+    where: { username: usernameOrEmail.trim() },
   })
   const participantWithEmail = await ctx.prisma.participant.findUnique({
-    where: { email: usernameOrEmail },
+    where: { email: usernameOrEmail.trim() },
   })
 
   const participant = participantWithUsername || participantWithEmail
@@ -268,7 +268,7 @@ export async function createParticipantAccount(
       ) as { email: string; sub: string }
       // check if the username is already taken by another user
       const existingUser = await ctx.prisma.participant.findUnique({
-        where: { username },
+        where: { username: username.trim() },
       })
 
       if (existingUser) {
@@ -282,7 +282,7 @@ export async function createParticipantAccount(
           participant: {
             create: {
               email: ltiData.email,
-              username,
+              username: username.trim(),
               password: await bcrypt.hash(password, 10),
               isEmailValid: true,
               isProfilePublic,
@@ -316,7 +316,7 @@ export async function createParticipantAccount(
     const participant = await ctx.prisma.participant.create({
       data: {
         email,
-        username,
+        username: username.trim(),
         password: await bcrypt.hash(password, 10),
         isEmailValid: false,
         isProfilePublic,
@@ -406,7 +406,7 @@ export async function checkParticipantNameAvailable(
   ctx: Context
 ) {
   const participant = await ctx.prisma.participant.findUnique({
-    where: { username },
+    where: { username: username.trim() },
   })
 
   if (!participant || participant.id === ctx.user?.sub) return true
@@ -419,7 +419,7 @@ export async function checkShortnameAvailable(
   ctx: Context
 ) {
   const user = await ctx.prisma.user.findUnique({
-    where: { shortname: shortname },
+    where: { shortname: shortname.trim() },
   })
 
   if (!user || user.id === ctx.user?.sub) return true
@@ -441,7 +441,7 @@ export async function createUserLogin(
   const login = await ctx.prisma.userLogin.create({
     data: {
       password: hashedPassword,
-      name,
+      name: name.trim(),
       // scope,
       // TODO: allow creation of other access levels once auth is handled granularly
       scope: UserLoginScope.FULL_ACCESS,
@@ -482,7 +482,7 @@ export async function changeShortname(
 ) {
   // check if the shortname is already taken
   const existingUser = await ctx.prisma.user.findUnique({
-    where: { shortname },
+    where: { shortname: shortname.trim() },
   })
 
   if (existingUser && existingUser.id !== ctx.user.sub) {
@@ -496,7 +496,7 @@ export async function changeShortname(
 
   const user = await ctx.prisma.user.update({
     where: { id: ctx.user.sub },
-    data: { shortname },
+    data: { shortname: shortname.trim() },
   })
 
   return user
@@ -523,7 +523,7 @@ export async function changeInitialSettings(
   ctx: ContextWithUser
 ) {
   const existingUser = await ctx.prisma.user.findFirst({
-    where: { shortname },
+    where: { shortname: shortname.trim() },
   })
 
   if (existingUser && existingUser.id !== ctx.user.sub) {
@@ -541,7 +541,7 @@ export async function changeInitialSettings(
   const user = await ctx.prisma.user.update({
     where: { id: ctx.user.sub },
     data: {
-      shortname,
+      shortname: shortname.trim(),
       locale,
       sendProjectUpdates: sendUpdates,
       firstLogin: false,

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -410,8 +410,8 @@ export async function createCourse(
 
   const course = await ctx.prisma.course.create({
     data: {
-      name: name,
-      displayName: displayName,
+      name: name.trim(),
+      displayName: displayName.trim(),
       description: description,
       color: color ?? '#CCD5ED',
       startDate: startDate,

--- a/packages/graphql/src/services/groups.ts
+++ b/packages/graphql/src/services/groups.ts
@@ -25,7 +25,7 @@ export async function createParticipantGroup(
 
   const participantGroup = await ctx.prisma.participantGroup.create({
     data: {
-      name,
+      name: name.trim(),
       code: code,
       course: {
         connect: {

--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -177,8 +177,8 @@ export async function manipulateMicroLearning(
   )
 
   const createOrUpdateJSON = {
-    name,
-    displayName: displayName ?? name,
+    name: name.trim(),
+    displayName: displayName.trim(),
     description,
     pointsMultiplier: multiplier,
     scheduledStartAt: dayjs(startDate).toDate(),
@@ -188,7 +188,7 @@ export async function manipulateMicroLearning(
         return {
           type: ElementStackType.MICROLEARNING,
           order: stack.order,
-          displayName: stack.displayName ?? '',
+          displayName: stack.displayName?.trim() ?? '',
           description: stack.description ?? '',
           options: {},
           elements: {

--- a/packages/graphql/src/services/participants.ts
+++ b/packages/graphql/src/services/participants.ts
@@ -48,7 +48,7 @@ export async function updateParticipantProfile(
             typeof isProfilePublic === 'boolean' ? isProfilePublic : undefined,
           email,
           password: hashedPassword,
-          username: username ?? undefined,
+          username: username?.trim() ?? undefined,
         },
       })
     } else {
@@ -62,7 +62,7 @@ export async function updateParticipantProfile(
       isProfilePublic:
         typeof isProfilePublic === 'boolean' ? isProfilePublic : undefined,
       email: email ?? undefined,
-      username: username ?? undefined,
+      username: username?.trim() ?? undefined,
     },
   })
 

--- a/packages/graphql/src/services/participants.ts
+++ b/packages/graphql/src/services/participants.ts
@@ -30,7 +30,7 @@ export async function updateParticipantProfile(
   // check that username corresponds to no other participant
   if (username) {
     const existingParticipant = await ctx.prisma.participant.findUnique({
-      where: { username },
+      where: { username: username.trim() },
     })
 
     if (existingParticipant && existingParticipant.id !== ctx.user.sub) {

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -1353,8 +1353,8 @@ export async function manipulatePracticeQuiz(
   )
 
   const createOrUpdateJSON = {
-    name,
-    displayName: displayName ?? name,
+    name: name.trim(),
+    displayName: displayName.trim(),
     description,
     pointsMultiplier: multiplier,
     orderType: order,
@@ -1364,7 +1364,7 @@ export async function manipulatePracticeQuiz(
         return {
           type: ElementStackType.PRACTICE_QUIZ,
           order: stack.order,
-          displayName: stack.displayName ?? '',
+          displayName: stack.displayName?.trim() ?? '',
           description: stack.description ?? '',
           options: {},
           elements: {

--- a/packages/graphql/src/services/sessions.ts
+++ b/packages/graphql/src/services/sessions.ts
@@ -99,8 +99,8 @@ export async function createSession(
 
   const session = await ctx.prisma.liveSession.create({
     data: {
-      name,
-      displayName: displayName ?? name,
+      name.trim(),
+      displayName: displayName.trim(),
       description,
       pointsMultiplier: multiplier,
       isGamificationEnabled,
@@ -241,8 +241,8 @@ export async function editSession(
   const session = await ctx.prisma.liveSession.update({
     where: { id },
     data: {
-      name,
-      displayName: displayName ?? name,
+      name: name.trim(),
+      displayName: displayName.trim(),
       description,
       pointsMultiplier: multiplier,
       isGamificationEnabled: isGamificationEnabled,

--- a/packages/graphql/src/services/sessions.ts
+++ b/packages/graphql/src/services/sessions.ts
@@ -99,7 +99,7 @@ export async function createSession(
 
   const session = await ctx.prisma.liveSession.create({
     data: {
-      name.trim(),
+      name: name.trim(),
       displayName: displayName.trim(),
       description,
       pointsMultiplier: multiplier,

--- a/packages/graphql/src/services/sessions.ts
+++ b/packages/graphql/src/services/sessions.ts
@@ -1451,7 +1451,7 @@ export async function getRunningSessions(
 ) {
   const userWithSessions = await ctx.prisma.user.findUnique({
     where: {
-      shortname,
+      shortname: shortname.trim(),
     },
     include: {
       sessions: {

--- a/packages/prisma/src/data/helpers.ts
+++ b/packages/prisma/src/data/helpers.ts
@@ -42,7 +42,7 @@ export async function prepareUser({
     firstLogin: false,
     logins: {
       create: {
-        name: name,
+        name: name.trim(),
         password: hashedPassword,
         scope: UserLoginScope.FULL_ACCESS,
       },
@@ -1045,7 +1045,7 @@ export async function prepareContentElements(
     Object.entries(content).map(async ([name, data]) => {
       const contentElement = await prismaClient.element.create({
         data: {
-          name: name,
+          name: name.trim(),
           content: data,
           options: {},
           type: ElementType.CONTENT,


### PR DESCRIPTION
Before merging this PR, we need to ensure the following things:
- [x] No user account shortname should have leading or trailing whitespaces
- [x] No participant account usernames should have leading or trailing whitespaces (8 conflicts with different users remaining)
- [x] OPTIONAL: Check session names / course names / etc.
- [ ] The test suite should pass