### PR TITLE
chore: add script to clean up element instance options (consistency)

### DIFF
--- a/packages/graphql/src/scripts/checkInstanceOptions.ts
+++ b/packages/graphql/src/scripts/checkInstanceOptions.ts
@@ -1,0 +1,140 @@
+import { PrismaClient } from '@klicker-uzh/prisma'
+
+async function run() {
+  const prisma = new PrismaClient()
+
+  // fetch all element instances and their associated klicker elements
+  const instances = await prisma.elementInstance.findMany({
+    include: {
+      element: true,
+      elementStack: {
+        include: {
+          practiceQuiz: true,
+          microLearning: true,
+          liveQuiz: true,
+        },
+      },
+    },
+  })
+
+  // initialize promises array and counters
+  let updatePromises: any[] = []
+  let practiceQuizInstanceUpdates = 0
+  let microLearningInstanceUpdates = 0
+  let liveQuizInstanceErrors = 0
+
+  // iterate over all element instances and check if the correct options are specified
+  instances.forEach((instance) => {
+    const stack = instance.elementStack
+    const element = instance.element
+    if (!stack || !element) {
+      return
+    }
+
+    if (stack.practiceQuiz) {
+      const quiz = stack.practiceQuiz
+      const options = instance.options
+
+      // check if both the correct pointsMultiplier and correct resetTimeDays are specified
+      if (
+        !options ||
+        !options.pointsMultiplier ||
+        !options.resetTimeDays ||
+        options.pointsMultiplier !==
+          quiz.pointsMultiplier * element.pointsMultiplier ||
+        options.resetTimeDays !== quiz.resetTimeDays
+      ) {
+        console.log(
+          'Element instance (practice quiz) with missing or invalid options:',
+          instance.id,
+          'with pointsMultiplier:',
+          options?.pointsMultiplier,
+          'instead of correct value:',
+          quiz.pointsMultiplier * element.pointsMultiplier,
+          'and resetTimeDays:',
+          options?.resetTimeDays,
+          'instead of correct value:',
+          quiz.resetTimeDays
+        )
+
+        // update the instance with the correct options
+        updatePromises.push(
+          prisma.elementInstance.update({
+            where: {
+              id: instance.id,
+            },
+            data: {
+              options: {
+                pointsMultiplier:
+                  quiz.pointsMultiplier * element.pointsMultiplier,
+                resetTimeDays: quiz.resetTimeDays,
+              },
+            },
+          })
+        )
+        practiceQuizInstanceUpdates++
+      }
+    }
+
+    if (stack.microLearning) {
+      const microLearning = stack.microLearning
+
+      // check if the correct pointsMultiplier is specified
+      if (
+        !instance.options ||
+        !instance.options.pointsMultiplier ||
+        instance.options.pointsMultiplier !==
+          microLearning.pointsMultiplier * element.pointsMultiplier
+      ) {
+        console.log(
+          'Element instance (microlearning) with missing or invalid options:',
+          instance.id,
+          'with pointsMultiplier:',
+          instance.options?.pointsMultiplier,
+          'instead of correct value:',
+          microLearning.pointsMultiplier * element.pointsMultiplier
+        )
+
+        // update the instance with the correct options
+        updatePromises.push(
+          prisma.elementInstance.update({
+            where: {
+              id: instance.id,
+            },
+            data: {
+              options: {
+                pointsMultiplier:
+                  microLearning.pointsMultiplier * element.pointsMultiplier,
+              },
+            },
+          })
+        )
+        microLearningInstanceUpdates++
+      }
+    }
+
+    if (stack.liveQuiz) {
+      const liveQuiz = stack.liveQuiz
+      console.error(
+        'ERROR: Live quizzes should not contain element instances at this point'
+      )
+      liveQuizInstanceErrors++
+    }
+  })
+
+  // log number of updates and errors
+  console.log(
+    'Instance updates (used in practice quizzes):',
+    practiceQuizInstanceUpdates
+  )
+  console.log(
+    'Instance updates (used in microlearnings):',
+    microLearningInstanceUpdates
+  )
+  console.log('Instance errors (used in live quizzes):', liveQuizInstanceErrors)
+
+  // ! USE THIS STATEMENT TO EXECUTE UPDATES
+  //   await prisma.$transaction(updatePromises)
+}
+
+await run()

--- a/packages/prisma/src/scripts/2024-04-19_clean_instance_options.ts
+++ b/packages/prisma/src/scripts/2024-04-19_clean_instance_options.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@klicker-uzh/prisma'
+import { PrismaClient } from '../client'
 
 async function run() {
   const prisma = new PrismaClient()
@@ -39,7 +39,7 @@ async function run() {
       if (
         !options ||
         !options.pointsMultiplier ||
-        !options.resetTimeDays ||
+        typeof options.resetTimeDays === 'undefined' ||
         options.pointsMultiplier !==
           quiz.pointsMultiplier * element.pointsMultiplier ||
         options.resetTimeDays !== quiz.resetTimeDays
@@ -134,7 +134,7 @@ async function run() {
   console.log('Instance errors (used in live quizzes):', liveQuizInstanceErrors)
 
   // ! USE THIS STATEMENT TO EXECUTE UPDATES
-  //   await prisma.$transaction(updatePromises)
+  await prisma.$transaction(updatePromises)
 }
 
 await run()


### PR DESCRIPTION
This pull requests checks for the correctness of the options on all elementInstances.

For practice quizzes, this includes the pointsMultiplier being defined and being consistent with the product of the element and the KlickerUZH element (practice quiz) multipliers. Additionally, the resetTimeDays in the options should correspond to the value defined on the practice quiz. Missing data is added directly.

For microlearnings only the pointsMultiplier on the element/question and on the KlickerUZH element (microlearning) are combined and verified or updated, if necessary.