### PR TITLE
chore: ensure that question detail responses of flashcards use correct enum value (consistency)

### DIFF
--- a/packages/graphql/src/scripts/checkFlashcardQuestionResponseDetails.ts
+++ b/packages/graphql/src/scripts/checkFlashcardQuestionResponseDetails.ts
@@ -1,0 +1,174 @@
+import { ElementType, PrismaClient } from '@klicker-uzh/prisma'
+import { FlashcardCorrectness, QuestionResponseFlashcard } from 'src/types/app'
+
+async function run() {
+  const prisma = new PrismaClient()
+
+  // fetch all questionResponseDetails and the linked element; filter for flashcards only
+  const questionResponseDetails = await prisma.questionResponseDetail.findMany({
+    include: {
+      elementInstance: {
+        include: {
+          element: true,
+        },
+      },
+    },
+    where: {
+      elementInstance: {
+        element: {
+          type: ElementType.FLASHCARD,
+        },
+      },
+    },
+  })
+
+  // intialize promises array and counters
+  let updatePromises: any[] = []
+  let valueErrors = 0
+  let wrongResultRepresentations = 0
+
+  // iterate over all questionResponseDetails and check if the correctness uses the correct enum representation
+  questionResponseDetails.forEach((questionResponseDetail) => {
+    const element = questionResponseDetail.elementInstance?.element
+    if (!element) {
+      console.error(
+        'Element not found for question response detail:',
+        questionResponseDetail.id
+      )
+      valueErrors++
+      return
+    }
+
+    // response should only have a single key with correctness value
+    if (
+      Object.keys(questionResponseDetail.response).length !== 1 ||
+      Object.keys(questionResponseDetail.response)[0] !== 'correctness'
+    ) {
+      console.error(
+        'Flashcard question response detail with invalid response:',
+        questionResponseDetail.response,
+        'and id:',
+        questionResponseDetail.id
+      )
+      valueErrors++
+      return
+    }
+
+    const value = (questionResponseDetail.response as QuestionResponseFlashcard)
+      .correctness
+
+    // check if value is none of the anticipated ones
+    if (
+      value !== 0 &&
+      value !== 1 &&
+      value !== 2 &&
+      value !== FlashcardCorrectness.CORRECT &&
+      value !== FlashcardCorrectness.INCORRECT &&
+      value !== FlashcardCorrectness.PARTIAL
+    ) {
+      console.error(
+        'Flashcard question response detail with invalid correctness value:',
+        value,
+        'and id:',
+        questionResponseDetail.id
+      )
+      valueErrors++
+      return
+    }
+
+    // if the value is a number, log this error and append a promise to update the value to an enum
+    if (value === 2) {
+      console.error(
+        'Flashcard question response detail with wrong correctness value:',
+        value,
+        'and id:',
+        questionResponseDetail.id,
+        'will be updated to:',
+        FlashcardCorrectness.CORRECT
+      )
+      wrongResultRepresentations++
+
+      updatePromises.push(
+        prisma.questionResponseDetail.update({
+          where: {
+            id: questionResponseDetail.id,
+          },
+          data: {
+            response: {
+              correctness: FlashcardCorrectness.CORRECT,
+            },
+          },
+        })
+      )
+    } else if (value === 1) {
+      console.error(
+        'Flashcard question response detail with wrong correctness value:',
+        value,
+        'and id:',
+        questionResponseDetail.id,
+        'will be updated to:',
+        FlashcardCorrectness.PARTIAL
+      )
+      wrongResultRepresentations++
+
+      updatePromises.push(
+        prisma.questionResponseDetail.update({
+          where: {
+            id: questionResponseDetail.id,
+          },
+          data: {
+            response: {
+              correctness: FlashcardCorrectness.PARTIAL,
+            },
+          },
+        })
+      )
+    } else if (value === 0) {
+      console.error(
+        'Flashcard question response detail with wrong correctness value:',
+        value,
+        'and id:',
+        questionResponseDetail.id,
+        'will be updated to:',
+        FlashcardCorrectness.INCORRECT
+      )
+      wrongResultRepresentations++
+
+      updatePromises.push(
+        prisma.questionResponseDetail.update({
+          where: {
+            id: questionResponseDetail.id,
+          },
+          data: {
+            response: {
+              correctness: FlashcardCorrectness.INCORRECT,
+            },
+          },
+        })
+      )
+    } else if (
+      value === FlashcardCorrectness.CORRECT ||
+      value === FlashcardCorrectness.INCORRECT ||
+      value === FlashcardCorrectness.PARTIAL
+    ) {
+      return // do nothing
+    } else {
+      console.error(
+        'Unexpected flashcard question response detail with correct correctness value:',
+        value,
+        'and id:',
+        questionResponseDetail.id
+      )
+      valueErrors++
+    }
+  })
+
+  // log number of errors and updates
+  console.log('Value errors:', valueErrors)
+  console.log('Wrong result representations:', wrongResultRepresentations)
+
+  // ! USE THIS STATEMENT TO EXECUTE UPDATES
+  //   await prisma.$transaction(updatePromises)
+}
+
+await run()

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -29,6 +29,7 @@
     "eslint": "8.45.0",
     "fs-extra": "11.1.1",
     "npm-run-all": "4.1.5",
+    "p-map": "7.0.2",
     "prettier": "2.8.8",
     "prettier-plugin-organize-imports": "3.2.3",
     "prisma": "5.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1996,6 +1996,9 @@ importers:
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
+      p-map:
+        specifier: 7.0.2
+        version: 7.0.2
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -18705,7 +18708,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.19.14)(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@18.19.14)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21863,6 +21866,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
+
+  /p-map@7.0.2:
+    resolution: {integrity: sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==}
+    engines: {node: '>=18'}
+    dev: true
 
   /p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}


### PR DESCRIPTION
At some point, the saved correctness value for flashcards has been changed from an integer to an enum, representing correct, partially correct and incorrect self gradings. While these values are correctly tracked for new instances, they still need to be corrected for older responses for all components to work properly and get the expected values (corresponding modules currently might be broken in the student frontend).

This pull request checks for all of these inconsistencies in the production database and creates an array of promises to be applied to correct the inconsistencies.

In `packages/graphql` run:
```bash
pnpm run script:prod src/scripts/checkFlashcardQuestionResponseDetails.ts
```