### PR TITLE
chore: ensure that question responses for flashcards use correct enum value (consistency)

### DIFF
--- a/packages/graphql/src/scripts/checkFlashcardQuestionResponses.ts
+++ b/packages/graphql/src/scripts/checkFlashcardQuestionResponses.ts
@@ -1,0 +1,204 @@
+import { ElementType, PrismaClient } from '@klicker-uzh/prisma'
+import { FlashcardCorrectness, QuestionResponseFlashcard } from 'src/types/app'
+
+async function run() {
+  const prisma = new PrismaClient()
+
+  // fetch all questionResponses and the linked element; filter for flashcards only
+  const questionResponses = await prisma.questionResponse.findMany({
+    include: {
+      elementInstance: {
+        include: {
+          element: true,
+        },
+      },
+    },
+    where: {
+      elementInstance: {
+        element: {
+          type: ElementType.FLASHCARD,
+        },
+      },
+    },
+  })
+
+  // intialize promises array and counters
+  let updatePromises: any[] = []
+  let valueErrors = 0
+  let responseValueUpdates = 0
+  let aggregatedResponseValueUpdates = 0
+
+  // iterate over all questionResponseDetails and check if the correctness uses the correct enum representation
+  questionResponses.forEach((questionResponse) => {
+    const element = questionResponse.elementInstance?.element
+    if (!element) {
+      console.error(
+        'Element not found for question response:',
+        questionResponse.id
+      )
+      valueErrors++
+      return
+    }
+
+    // response should only have a single key with correctness value
+    if (
+      Object.keys(questionResponse.response).length !== 1 ||
+      Object.keys(questionResponse.response)[0] !== 'correctness'
+    ) {
+      console.error(
+        'Flashcard question response detail with invalid response:',
+        questionResponse.response,
+        'and id:',
+        questionResponse.id
+      )
+      valueErrors++
+      return
+    }
+
+    // check response values and potentially correct them
+    let responseUpdate = {}
+    const value = (questionResponse.response as QuestionResponseFlashcard)
+      .correctness
+
+    // check if value is none of the anticipated ones
+    if (
+      value !== 0 &&
+      value !== 1 &&
+      value !== 2 &&
+      value !== FlashcardCorrectness.CORRECT &&
+      value !== FlashcardCorrectness.INCORRECT &&
+      value !== FlashcardCorrectness.PARTIAL
+    ) {
+      console.error(
+        'Flashcard question response detail with invalid correctness value:',
+        value,
+        'and id:',
+        questionResponse.id
+      )
+      valueErrors++
+      return
+    }
+
+    if (value === 0) {
+      responseUpdate = {
+        response: {
+          correctness: FlashcardCorrectness.INCORRECT,
+        },
+      }
+      console.log(
+        'Response value was:',
+        value,
+        'and will be updated to:',
+        responseUpdate
+      )
+    } else if (value === 1) {
+      responseUpdate = {
+        response: {
+          correctness: FlashcardCorrectness.PARTIAL,
+        },
+      }
+      console.log(
+        'Response value was:',
+        value,
+        'and will be updated to:',
+        responseUpdate
+      )
+    } else if (value === 2) {
+      responseUpdate = {
+        response: {
+          correctness: FlashcardCorrectness.CORRECT,
+        },
+      }
+      console.log(
+        'Response value was:',
+        value,
+        'and will be updated to:',
+        responseUpdate
+      )
+    }
+
+    // check aggregated response values and potentially correct them
+    let aggregatedResponseUpdate = {}
+    const responses = questionResponse.aggregatedResponses
+
+    // check if the keys are not either [0,1,2] or [CORRECT, INCORRECT, PARTIAL]
+    const keys = Object.keys(responses)
+    if (
+      !(
+        keys.length === 4 &&
+        keys.includes('0') &&
+        keys.includes('1') &&
+        keys.includes('2') &&
+        keys.includes('total')
+      ) &&
+      !(
+        keys.length === 4 &&
+        keys.includes(FlashcardCorrectness.CORRECT) &&
+        keys.includes(FlashcardCorrectness.PARTIAL) &&
+        keys.includes(FlashcardCorrectness.INCORRECT) &&
+        keys.includes('total')
+      )
+    ) {
+      console.error(
+        'Flashcard question response with invalid aggregated response keys:',
+        responses,
+        'and id:',
+        questionResponse.id
+      )
+      valueErrors++
+      return
+    }
+
+    // if numerical keys are used, translate them to enum keys
+    if (keys.includes('0') && keys.includes('1') && keys.includes('2')) {
+      aggregatedResponseUpdate = {
+        aggregatedResponses: {
+          [FlashcardCorrectness.INCORRECT]: responses['0'],
+          [FlashcardCorrectness.PARTIAL]: responses['1'],
+          [FlashcardCorrectness.CORRECT]: responses['2'],
+          total: responses.total,
+        },
+      }
+      console.log(
+        'previous response struct was:',
+        responses,
+        'and will be updated to:',
+        aggregatedResponseUpdate
+      )
+      aggregatedResponseValueUpdates++
+    }
+
+    // if either one of the updates if defined, add the update to the promises array
+    if (
+      Object.keys(responseUpdate).length > 0 ||
+      Object.keys(aggregatedResponseUpdate).length > 0
+    ) {
+      updatePromises.push(
+        prisma.questionResponse.update({
+          where: {
+            id: questionResponse.id,
+          },
+          data: {
+            ...responseUpdate,
+            ...aggregatedResponseUpdate,
+          },
+        })
+      )
+      responseValueUpdates++
+    }
+  })
+
+  // log number of errors and updates
+  console.log('Value errors:', valueErrors)
+  console.log('Response value updates:', responseValueUpdates)
+  console.log(
+    'Aggregated response value updates:',
+    aggregatedResponseValueUpdates
+  )
+  console.log('Number of combined updates in total:', updatePromises.length)
+
+  // ! USE THIS STATEMENT TO EXECUTE UPDATES
+  //   await prisma.$transaction(updatePromises)
+}
+
+await run()

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
-  "include": ["src", "src/types/app.ts"],
+  "include": [
+    "src",
+    "src/types/app.ts",
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "sourceMap": true

--- a/packages/prisma/src/scripts/2024-04-19_clean_flashcard_responses.ts
+++ b/packages/prisma/src/scripts/2024-04-19_clean_flashcard_responses.ts
@@ -1,5 +1,15 @@
-import { ElementType, PrismaClient } from '@klicker-uzh/prisma'
-import { FlashcardCorrectness, QuestionResponseFlashcard } from 'src/types/app'
+import pMap from 'p-map'
+import { ElementType, PrismaClient } from '../client'
+
+export enum FlashcardCorrectness {
+  INCORRECT = 'INCORRECT',
+  PARTIAL = 'PARTIAL',
+  CORRECT = 'CORRECT',
+}
+
+export type QuestionResponseFlashcard = {
+  correctness: FlashcardCorrectness
+}
 
 async function run() {
   const prisma = new PrismaClient()
@@ -198,7 +208,7 @@ async function run() {
   console.log('Number of combined updates in total:', updatePromises.length)
 
   // ! USE THIS STATEMENT TO EXECUTE UPDATES
-  //   await prisma.$transaction(updatePromises)
+  await pMap(updatePromises, (i) => i, { concurrency: 50 })
 }
 
 await run()


### PR DESCRIPTION
Similar to PR #4094, this pull request checks the content of all question responses (not details) linked to any flashcard element. Both the actual last answer ("response") and the aggregated responses ("aggregatedResponse") are checked for the correctness of the keys and updated if necessary. This could be one of the responsible components for issues in the current frontend implementations including flashcards.

To execute, change into the `packages/graphql` directory and run:
```bash
pnpm run script:prod src/scripts/checkFlashcardQuestionResponses.ts
```