### PR TITLE
enhance(apps/frontend-manage): structure course selection during element creation

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -8,7 +8,7 @@
     "@klicker-uzh/prisma": "workspace:*",
     "@klicker-uzh/shared-components": "workspace:*",
     "@next-auth/prisma-adapter": "1.0.7",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "axios": "1.4.0",
     "bcryptjs": "2.4.3",
     "js-cookie": "3.0.5",

--- a/apps/backend-docker/package.json
+++ b/apps/backend-docker/package.json
@@ -52,7 +52,7 @@
     "@types/passport-jwt": "^3.0.6",
     "@types/ramda": "^0.29.3",
     "@types/ws": "^8.5.9",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "axios": "1.4.0",
     "cross-env": "7.0.3",
     "eslint": "8.45.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,7 +20,7 @@
     "@gabrielcsapo/docusaurus-plugin-matomo": "0.1.2",
     "@mdx-js/react": "2.3.0",
     "@tsconfig/docusaurus": "1.0.5",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "autoprefixer": "10.4.14",
     "cross-env": "7.0.3",
     "nodemon": "3.0.1",

--- a/apps/frontend-control/package.json
+++ b/apps/frontend-control/package.json
@@ -18,7 +18,7 @@
     "@sentry/nextjs": "7.61.1",
     "@socialgouv/matomo-next": "1.6.1",
     "@types/js-cookie": "^3.0.3",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "body-parser": "1.20.2",
     "cross-env": "7.0.3",
     "dayjs": "1.11.9",

--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -18,7 +18,7 @@
     "@klicker-uzh/prisma": "workspace:*",
     "@klicker-uzh/shared-components": "workspace:*",
     "@socialgouv/matomo-next": "1.6.1",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "d3": "7.8.4",
     "dayjs": "1.11.9",
     "deepmerge": "4.3.1",

--- a/apps/frontend-manage/src/components/sessions/creation/ElementCreation.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/ElementCreation.tsx
@@ -27,6 +27,13 @@ export enum WizardMode {
   GroupActivity = 'groupActivity',
 }
 
+export type ElementSelectCourse = {
+  label: string
+  value: string
+  isGamified: boolean
+  data: { cy: string }
+}
+
 interface ElementCreationProps {
   creationMode: WizardMode
   closeWizard: () => void
@@ -137,6 +144,27 @@ function ElementCreation({
     } as PracticeQuiz
   }
 
+  const { gamifiedCourses, nonGamifiedCourses } = courseSelection?.reduce<{
+    gamifiedCourses: SelectCourse[]
+    nonGamifiedCourses: SelectCourse[]
+  }>(
+    (acc, course) => {
+      if (course.isGamified) {
+        acc.gamifiedCourses.push({
+          ...course,
+          data: { cy: `select-course-${course.label}` },
+        })
+      } else {
+        acc.nonGamifiedCourses.push({
+          ...course,
+          data: { cy: `select-course-${course.label}` },
+        })
+      }
+      return acc
+    },
+    { gamifiedCourses: [], nonGamifiedCourses: [] }
+  ) ?? { gamifiedCourses: [], nonGamifiedCourses: [] }
+
   return (
     <div className="flex flex-col justify-center print-hidden h-96">
       <div className="w-full h-full rounded-lg">
@@ -144,9 +172,8 @@ function ElementCreation({
           <LiveSessionWizard
             title={t('shared.generic.liveQuiz')}
             closeWizard={closeWizard}
-            courses={
-              courseSelection || [{ label: '', value: '', isGamified: false }]
-            }
+            gamifiedCourses={gamifiedCourses}
+            nonGamifiedCourses={nonGamifiedCourses}
             initialValues={
               dataLiveSession?.liveSession
                 ? duplicationMode === WizardMode.LiveQuiz

--- a/apps/frontend-manage/src/components/sessions/creation/ElementCreation.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/ElementCreation.tsx
@@ -194,6 +194,8 @@ function ElementCreation({
           <MicroLearningWizard
             title={t('shared.generic.microlearning')}
             closeWizard={closeWizard}
+            gamifiedCourses={gamifiedCourses}
+            nonGamifiedCourses={nonGamifiedCourses}
             courses={courseSelection || [{ label: '', value: '' }]}
             initialValues={
               (dataMicroLearning?.microLearning as MicroLearning) ?? undefined
@@ -205,6 +207,8 @@ function ElementCreation({
           <PracticeQuizWizard
             title={t('shared.generic.practiceQuiz')}
             closeWizard={closeWizard}
+            gamifiedCourses={gamifiedCourses}
+            nonGamifiedCourses={nonGamifiedCourses}
             courses={courseSelection || [{ label: '', value: '' }]}
             initialValues={
               (dataPracticeQuiz?.practiceQuiz as PracticeQuiz) ??
@@ -217,6 +221,8 @@ function ElementCreation({
           <GroupActivityWizard
             title={t('shared.generic.groupActivity')}
             closeWizard={closeWizard}
+            gamifiedCourses={gamifiedCourses}
+            nonGamifiedCourses={nonGamifiedCourses}
             courses={courseSelection || [{ label: '', value: '' }]}
             initialValues={
               (dataGroupActivity?.groupActivity as GroupActivity) ?? undefined

--- a/apps/frontend-manage/src/components/sessions/creation/GroupActivityWizard.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/GroupActivityWizard.tsx
@@ -11,12 +11,14 @@ import {
   GroupActivity,
   ParameterType,
 } from '@klicker-uzh/graphql/dist/ops'
+import useGamifiedCourseGrouping from '@lib/hooks/useGamifiedCourseGrouping'
 import {
   Button,
   FormikDateField,
   FormikSelectField,
   FormikTextField,
   Label,
+  UserNotification,
 } from '@uzh-bf/design-system'
 import dayjs from 'dayjs'
 import {
@@ -24,6 +26,7 @@ import {
   FieldArray,
   FieldArrayRenderProps,
   useField,
+  useFormikContext,
 } from 'formik'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
@@ -32,6 +35,7 @@ import * as yup from 'yup'
 import ElementCreationErrorToast from '../../toasts/ElementCreationErrorToast'
 import BlockField from './BlockField'
 import EditorField from './EditorField'
+import { ElementSelectCourse } from './ElementCreation'
 import GroupActivityClueModal from './GroupActivityClueModal'
 import MultistepWizard, {
   GroupActivityClueType,
@@ -42,6 +46,8 @@ import WizardErrorMessage from './WizardErrorMessage'
 interface GroupActivityWizardProps {
   title: string
   closeWizard: () => void
+  gamifiedCourses: ElementSelectCourse[]
+  nonGamifiedCourses: ElementSelectCourse[]
   courses?: {
     label: string
     value: string
@@ -52,6 +58,8 @@ interface GroupActivityWizardProps {
 function GroupActivityWizard({
   title,
   closeWizard,
+  gamifiedCourses,
+  nonGamifiedCourses,
   courses,
   initialValues,
 }: GroupActivityWizardProps) {
@@ -267,7 +275,7 @@ function GroupActivityWizard({
           multiplier: initialValues?.pointsMultiplier
             ? String(initialValues?.pointsMultiplier)
             : '1',
-          courseId: initialValues?.course?.id || courses?.[0]?.value,
+          courseId: initialValues?.course?.id || undefined,
         }}
         onSubmit={onSubmit}
         isCompleted={isWizardCompleted}
@@ -297,7 +305,12 @@ function GroupActivityWizard({
         ]}
       >
         <StepOne validationSchema={stepOneValidationSchema} />
-        <StepTwo validationSchema={stepTwoValidationSchema} courses={courses} />
+        <StepTwo
+          validationSchema={stepTwoValidationSchema}
+          courses={courses}
+          gamifiedCourses={gamifiedCourses}
+          nonGamifiedCourses={nonGamifiedCourses}
+        />
         <StepThree validationSchema={stepThreeValidationSchema} />
       </MultistepWizard>
       <ElementCreationErrorToast
@@ -318,6 +331,8 @@ export default GroupActivityWizard
 interface StepProps {
   onSubmit?: () => void
   validationSchema: any
+  gamifiedCourses?: ElementSelectCourse[]
+  nonGamifiedCourses?: ElementSelectCourse[]
   courses?: {
     label: string
     value: string
@@ -401,27 +416,30 @@ function StepTwo(props: StepProps) {
   const [field, meta, helpers] = useField<GroupActivityClueType[]>('clues')
   const [clueIx, setClueIx] = useState<number | undefined>(undefined)
   const [clueModal, setClueModal] = useState(false)
+  const { values } = useFormikContext<{
+    courseId?: string
+    [key: string]: any
+  }>()
+
+  const groupedCourses = useGamifiedCourseGrouping({
+    gamifiedCourses: props.gamifiedCourses ?? [],
+    nonGamifiedCourses: props.nonGamifiedCourses ?? [],
+  })
 
   return (
     <div className="flex flex-row gap-8">
       <div className="flex flex-col gap-2">
         <div className="flex flex-row items-center gap-4 text-left">
           <FormikSelectField
-            name="courseId"
-            items={
-              props.courses?.map((course) => {
-                return {
-                  ...course,
-                  data: { cy: `select-course-${course.label}` },
-                }
-              }) || []
-            }
             required
+            hideError
+            name="courseId"
+            groups={groupedCourses}
+            placeholder={t('manage.sessionForms.practiceQuizCoursePlaceholder')}
             tooltip={t('manage.sessionForms.groupActivityCourse')}
             label={t('shared.generic.course')}
             data={{ cy: 'select-course' }}
             className={{ tooltip: 'z-20' }}
-            hideError
           />
           <ErrorMessage
             name="courseId"
@@ -429,121 +447,136 @@ function StepTwo(props: StepProps) {
             className="text-sm text-red-400"
           />
         </div>
-        <FormikDateField
-          label={t('shared.generic.startDate')}
-          name="startDate"
-          tooltip={t('manage.sessionForms.groupActivityStartDate')}
-          required
-          className={{
-            root: 'w-[24rem]',
-            input: 'bg-uzh-grey-20',
-            tooltip: 'z-20',
-          }}
-          data={{ cy: 'select-start-date' }}
-        />
-        <FormikDateField
-          label={t('shared.generic.endDate')}
-          name="endDate"
-          tooltip={t('manage.sessionForms.groupActivityEndDate')}
-          required
-          className={{
-            root: 'w-[24rem]',
-            input: 'bg-uzh-grey-20',
-            tooltip: 'z-20',
-          }}
-          data={{ cy: 'select-end-date' }}
-        />
-        <div className="flex flex-row items-center gap-4">
-          <FormikSelectField
-            name="multiplier"
-            placeholder={t('manage.sessionForms.multiplierDefault')}
-            label={t('shared.generic.multiplier')}
-            tooltip={t('manage.sessionForms.groupActivityMultiplier')}
-            required
-            items={[
-              {
-                label: t('manage.sessionForms.multiplier1'),
-                value: '1',
-                data: {
-                  cy: `select-multiplier-${t(
-                    'manage.sessionForms.multiplier1'
-                  )}`,
-                },
-              },
-              {
-                label: t('manage.sessionForms.multiplier2'),
-                value: '2',
-                data: {
-                  cy: `select-multiplier-${t(
-                    'manage.sessionForms.multiplier2'
-                  )}`,
-                },
-              },
-              {
-                label: t('manage.sessionForms.multiplier3'),
-                value: '3',
-                data: {
-                  cy: `select-multiplier-${t(
-                    'manage.sessionForms.multiplier3'
-                  )}`,
-                },
-              },
-              {
-                label: t('manage.sessionForms.multiplier4'),
-                value: '4',
-                data: {
-                  cy: `select-multiplier-${t(
-                    'manage.sessionForms.multiplier4'
-                  )}`,
-                },
-              },
-            ]}
-            data={{ cy: 'select-multiplier' }}
-            className={{ tooltip: 'z-20' }}
-          />
-          <ErrorMessage
-            name="multiplier"
-            component="div"
-            className="text-sm text-red-400"
-          />
-        </div>
+        {values.courseId ? (
+          <>
+            <FormikDateField
+              label={t('shared.generic.startDate')}
+              name="startDate"
+              tooltip={t('manage.sessionForms.groupActivityStartDate')}
+              required
+              className={{
+                root: 'w-[24rem]',
+                input: 'bg-uzh-grey-20',
+                tooltip: 'z-20',
+              }}
+              data={{ cy: 'select-start-date' }}
+            />
+            <FormikDateField
+              label={t('shared.generic.endDate')}
+              name="endDate"
+              tooltip={t('manage.sessionForms.groupActivityEndDate')}
+              required
+              className={{
+                root: 'w-[24rem]',
+                input: 'bg-uzh-grey-20',
+                tooltip: 'z-20',
+              }}
+              data={{ cy: 'select-end-date' }}
+            />
+            <div className="flex flex-row items-center gap-4">
+              <FormikSelectField
+                name="multiplier"
+                placeholder={t('manage.sessionForms.multiplierDefault')}
+                label={t('shared.generic.multiplier')}
+                tooltip={t('manage.sessionForms.groupActivityMultiplier')}
+                required
+                items={[
+                  {
+                    label: t('manage.sessionForms.multiplier1'),
+                    value: '1',
+                    data: {
+                      cy: `select-multiplier-${t(
+                        'manage.sessionForms.multiplier1'
+                      )}`,
+                    },
+                  },
+                  {
+                    label: t('manage.sessionForms.multiplier2'),
+                    value: '2',
+                    data: {
+                      cy: `select-multiplier-${t(
+                        'manage.sessionForms.multiplier2'
+                      )}`,
+                    },
+                  },
+                  {
+                    label: t('manage.sessionForms.multiplier3'),
+                    value: '3',
+                    data: {
+                      cy: `select-multiplier-${t(
+                        'manage.sessionForms.multiplier3'
+                      )}`,
+                    },
+                  },
+                  {
+                    label: t('manage.sessionForms.multiplier4'),
+                    value: '4',
+                    data: {
+                      cy: `select-multiplier-${t(
+                        'manage.sessionForms.multiplier4'
+                      )}`,
+                    },
+                  },
+                ]}
+                data={{ cy: 'select-multiplier' }}
+                className={{ tooltip: 'z-20' }}
+              />
+              <ErrorMessage
+                name="multiplier"
+                component="div"
+                className="text-sm text-red-400"
+              />
+            </div>
+          </>
+        ) : (
+          <UserNotification
+            type="info"
+            className={{ root: 'w-max max-w-[40rem]' }}
+          >
+            {/* // TODO: the case where no gamified course exists should be caught before starting the wizard - otherwise title and description already entered will be lost! */}
+            {props.gamifiedCourses?.length === 0
+              ? t('manage.sessionForms.missingGamifiedCourses')
+              : t('manage.sessionForms.selectGamifiedCourse')}
+          </UserNotification>
+        )}
       </div>
-      <div className="w-full">
-        <FieldArray name="clues">
-          {({ push, remove, replace }: FieldArrayRenderProps) => (
-            <div className="w-full">
-              <div className="flex flex-row gap-4">
-                <div className="flex flex-row items-center gap-3">
-                  <Label
-                    required
-                    tooltip={t(
-                      'manage.sessionForms.groupActivityCluesDescription'
-                    )}
-                    label={t('shared.generic.clues')}
-                    showTooltipSymbol
-                    className={{
-                      root: 'font-bold',
-                      tooltip: 'font-normal text-sm !z-30',
-                    }}
-                  />
+      {values.courseId && (
+        <div className="w-full">
+          <FieldArray name="clues">
+            {({ push, remove, replace }: FieldArrayRenderProps) => (
+              <div className="w-full">
+                <div className="flex flex-row gap-4">
+                  <div className="flex flex-row items-center gap-3">
+                    <Label
+                      required
+                      tooltip={t(
+                        'manage.sessionForms.groupActivityCluesDescription'
+                      )}
+                      label={t('shared.generic.clues')}
+                      showTooltipSymbol
+                      className={{
+                        root: 'font-bold',
+                        tooltip: 'font-normal text-sm !z-30',
+                      }}
+                    />
+                  </div>
                 </div>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 mt-3 w-full max-h-32 overflow-y-auto">
-                {field.value.map((clue, ix) => (
-                  <div
-                    key={clue.name}
-                    className="text-sm rounded flex flex-row justify-between w-full border"
-                    data-cy={`groupActivity-clue-${clue.name}`}
-                  >
-                    <div className="flex flex-col p-1">
-                      <div className="font-bold">{clue.name}</div>
-                      <div className="border-black h-full">
-                        <div className="w-full h-full">
-                          {clue.type === ParameterType.Number && clue.unit
-                            ? `${clue.value} ${clue.unit}`
-                            : clue.value}
-                        </div>
-                        {/* <Button
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 mt-3 w-full max-h-32 overflow-y-auto">
+                  {field.value.map((clue, ix) => (
+                    <div
+                      key={clue.name}
+                      className="text-sm rounded flex flex-row justify-between w-full border"
+                      data-cy={`groupActivity-clue-${clue.name}`}
+                    >
+                      <div className="flex flex-col p-1">
+                        <div className="font-bold">{clue.name}</div>
+                        <div className="border-black h-full">
+                          <div className="w-full h-full">
+                            {clue.type === ParameterType.Number && clue.unit
+                              ? `${clue.value} ${clue.unit}`
+                              : clue.value}
+                          </div>
+                          {/* <Button
                         basic
                         onClick={() => remove(ix)}
                         className={{
@@ -558,59 +591,60 @@ function StepTwo(props: StepProps) {
                           />
                         </Button.Icon>
                       </Button> */}
+                        </div>
+                      </div>
+                      <div className="h-full flex flex-col">
+                        <Button
+                          className={{ root: 'h-1/2' }}
+                          data={{ cy: `edit-clue-${clue.name}` }}
+                          onClick={() => {
+                            setClueIx(ix)
+                            setClueModal(true)
+                          }}
+                        >
+                          <FontAwesomeIcon icon={faPencil} />
+                        </Button>
+                        <Button
+                          className={{ root: 'h-1/2 bg-red-600 text-white' }}
+                          data={{ cy: `remove-clue-${clue.name}` }}
+                          onClick={() => remove(ix)}
+                        >
+                          <FontAwesomeIcon icon={faTrashCan} />
+                        </Button>
                       </div>
                     </div>
-                    <div className="h-full flex flex-col">
-                      <Button
-                        className={{ root: 'h-1/2' }}
-                        data={{ cy: `edit-clue-${clue.name}` }}
-                        onClick={() => {
-                          setClueIx(ix)
-                          setClueModal(true)
-                        }}
-                      >
-                        <FontAwesomeIcon icon={faPencil} />
-                      </Button>
-                      <Button
-                        className={{ root: 'h-1/2 bg-red-600 text-white' }}
-                        data={{ cy: `remove-clue-${clue.name}` }}
-                        onClick={() => remove(ix)}
-                      >
-                        <FontAwesomeIcon icon={faTrashCan} />
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-                <GroupActivityClueModal
-                  open={clueModal}
-                  setOpen={setClueModal}
-                  pushClue={(values) => {
-                    push(values)
-                    setClueIx(undefined)
-                  }}
-                  replaceClue={(values) => {
-                    replace(clueIx ?? -1, values)
-                    setClueIx(undefined)
-                  }}
-                  initialValues={
-                    typeof clueIx !== 'undefined'
-                      ? field.value[clueIx]
-                      : undefined
-                  }
-                  clueIx={clueIx}
-                  unsetClueIx={() => setClueIx(undefined)}
-                />
-              </div>
-              {meta.error && (
-                <div className="text-sm text-red-400 px-2">
-                  <WizardErrorMessage fieldName="clues" />
-                  {typeof meta.error === 'string' && meta.error}
+                  ))}
+                  <GroupActivityClueModal
+                    open={clueModal}
+                    setOpen={setClueModal}
+                    pushClue={(values) => {
+                      push(values)
+                      setClueIx(undefined)
+                    }}
+                    replaceClue={(values) => {
+                      replace(clueIx ?? -1, values)
+                      setClueIx(undefined)
+                    }}
+                    initialValues={
+                      typeof clueIx !== 'undefined'
+                        ? field.value[clueIx]
+                        : undefined
+                    }
+                    clueIx={clueIx}
+                    unsetClueIx={() => setClueIx(undefined)}
+                  />
                 </div>
-              )}
-            </div>
-          )}
-        </FieldArray>
-      </div>
+                {meta.error && (
+                  <div className="text-sm text-red-400 px-2">
+                    <WizardErrorMessage fieldName="clues" />
+                    {typeof meta.error === 'string' && meta.error}
+                  </div>
+                )}
+              </div>
+            )}
+          </FieldArray>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/sessions/creation/LiveSessionWizard.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LiveSessionWizard.tsx
@@ -12,12 +12,12 @@ import {
   Session,
   StartSessionDocument,
 } from '@klicker-uzh/graphql/dist/ops'
+import useLiveQuizCourseGrouping from '@lib/hooks/useLiveQuizCourseGrouping'
 import {
   Button,
   FormikSelectField,
   FormikSwitchField,
   FormikTextField,
-  Group,
 } from '@uzh-bf/design-system'
 import { ErrorMessage, useFormikContext } from 'formik'
 import { useTranslations } from 'next-intl'
@@ -422,29 +422,10 @@ function StepTwo(props: StepProps) {
     }
   }, [values.isGamificationEnabled])
 
-  const groupedCourses: Group[] = [
-    {
-      items: [
-        {
-          label: t('manage.sessionForms.liveQuizNoCourse'),
-          value: '',
-          data: {
-            cy: `select-course-${t('manage.sessionForms.liveQuizNoCourse')}`,
-          },
-        },
-      ],
-    },
-    {
-      items: props.gamifiedCourses ?? [],
-      showSeparator: true,
-      label: t('shared.generic.gamified'),
-    },
-    {
-      items: props.nonGamifiedCourses ?? [],
-      showSeparator: true,
-      label: t('shared.generic.nonGamified'),
-    },
-  ]
+  const groupedCourses = useLiveQuizCourseGrouping({
+    gamifiedCourses: props.gamifiedCourses ?? [],
+    nonGamifiedCourses: props.nonGamifiedCourses ?? [],
+  })
 
   return (
     <div className="flex flex-row gap-16">

--- a/apps/frontend-manage/src/components/sessions/creation/LiveSessionWizard.tsx
+++ b/apps/frontend-manage/src/components/sessions/creation/LiveSessionWizard.tsx
@@ -17,6 +17,7 @@ import {
   FormikSelectField,
   FormikSwitchField,
   FormikTextField,
+  Group,
 } from '@uzh-bf/design-system'
 import { ErrorMessage, useFormikContext } from 'formik'
 import { useTranslations } from 'next-intl'
@@ -25,16 +26,14 @@ import { useEffect, useState } from 'react'
 import * as yup from 'yup'
 import ElementCreationErrorToast from '../../toasts/ElementCreationErrorToast'
 import EditorField from './EditorField'
+import { ElementSelectCourse } from './ElementCreation'
 import MultistepWizard, { LiveSessionFormValues } from './MultistepWizard'
 import SessionBlockField from './SessionBlockField'
 
 interface LiveSessionWizardProps {
   title: string
-  courses?: {
-    label: string
-    value: string
-    isGamified: boolean
-  }[]
+  gamifiedCourses: ElementSelectCourse[]
+  nonGamifiedCourses: ElementSelectCourse[]
   initialValues?: Partial<Session>
   selection: Record<number, Element>
   resetSelection: () => void
@@ -44,7 +43,8 @@ interface LiveSessionWizardProps {
 
 function LiveSessionWizard({
   title,
-  courses,
+  gamifiedCourses,
+  nonGamifiedCourses,
   initialValues,
   selection,
   resetSelection,
@@ -292,7 +292,11 @@ function LiveSessionWizard({
         ]}
       >
         <StepOne validationSchema={stepOneValidationSchema} />
-        <StepTwo validationSchema={stepTwoValidationSchema} courses={courses} />
+        <StepTwo
+          validationSchema={stepTwoValidationSchema}
+          gamifiedCourses={gamifiedCourses}
+          nonGamifiedCourses={nonGamifiedCourses}
+        />
         <StepThree
           validationSchema={stepThreeValidationSchema}
           selection={selection}
@@ -317,11 +321,8 @@ export default LiveSessionWizard
 interface StepProps {
   onSubmit?: () => void
   validationSchema: any
-  courses?: {
-    label: string
-    value: string
-    isGamified: boolean
-  }[]
+  gamifiedCourses?: ElementSelectCourse[]
+  nonGamifiedCourses?: ElementSelectCourse[]
   selection?: Record<number, Element>
   resetSelection?: () => void
 }
@@ -408,8 +409,9 @@ function StepTwo(props: StepProps) {
     } else {
       setFieldValue(
         'isGamificationEnabled',
-        props.courses?.find((course) => course.value === values.courseId)
-          ?.isGamified
+        [...props.gamifiedCourses!, ...props.nonGamifiedCourses!].find(
+          (course) => course.value === values.courseId
+        )?.isGamified
       )
     }
   }, [values.courseId])
@@ -420,118 +422,122 @@ function StepTwo(props: StepProps) {
     }
   }, [values.isGamificationEnabled])
 
-  const preparedCourses = props.courses?.map((course) => {
-    return {
-      ...course,
-      data: { cy: `select-course-${course.label}` },
-    }
-  })
+  const groupedCourses: Group[] = [
+    {
+      items: [
+        {
+          label: t('manage.sessionForms.liveQuizNoCourse'),
+          value: '',
+          data: {
+            cy: `select-course-${t('manage.sessionForms.liveQuizNoCourse')}`,
+          },
+        },
+      ],
+    },
+    {
+      items: props.gamifiedCourses ?? [],
+      showSeparator: true,
+      label: t('shared.generic.gamified'),
+    },
+    {
+      items: props.nonGamifiedCourses ?? [],
+      showSeparator: true,
+      label: t('shared.generic.nonGamified'),
+    },
+  ]
 
   return (
     <div className="flex flex-row gap-16">
-      {props.courses && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-row items-center gap-4">
-            <FormikSelectField
-              name="courseId"
-              label={t('shared.generic.course')}
-              tooltip={t('manage.sessionForms.liveQuizDescCourse')}
-              placeholder={t('manage.sessionForms.liveQuizSelectCourse')}
-              items={[
-                {
-                  label: t('manage.sessionForms.liveQuizNoCourse'),
-                  value: '',
-                  data: {
-                    cy: `select-course-${t(
-                      'manage.sessionForms.liveQuizNoCourse'
-                    )}`,
-                  },
-                },
-                ...(preparedCourses || []),
-              ]}
-              hideError
-              data={{ cy: 'select-course' }}
-              className={{ tooltip: 'z-20' }}
-            />
-            <ErrorMessage
-              name="courseId"
-              component="div"
-              className="text-sm text-red-400"
-            />
-          </div>
-
-          <div>
-            <FormikSwitchField
-              disabled
-              name="isGamificationEnabled"
-              label={t('shared.generic.gamification')}
-              tooltip={t('manage.sessionForms.liveQuizGamification')}
-              standardLabel
-              data={{ cy: 'set-gamification' }}
-              className={{ tooltip: 'z-20' }}
-            />
-            <ErrorMessage
-              name="isGamificationEnabled"
-              component="div"
-              className="text-sm text-red-400"
-            />
-          </div>
-          <div className="flex flex-row items-center gap-4">
-            <FormikSelectField
-              disabled={!values.isGamificationEnabled}
-              name="multiplier"
-              label={t('shared.generic.multiplier')}
-              tooltip={t('manage.sessionForms.liveQuizMultiplier')}
-              placeholder={t('manage.sessionForms.multiplierDefault')}
-              items={[
-                {
-                  label: t('manage.sessionForms.multiplier1'),
-                  value: '1',
-                  data: {
-                    cy: `select-multiplier-${t(
-                      'manage.sessionForms.multiplier1'
-                    )}`,
-                  },
-                },
-                {
-                  label: t('manage.sessionForms.multiplier2'),
-                  value: '2',
-                  data: {
-                    cy: `select-multiplier-${t(
-                      'manage.sessionForms.multiplier2'
-                    )}`,
-                  },
-                },
-                {
-                  label: t('manage.sessionForms.multiplier3'),
-                  value: '3',
-                  data: {
-                    cy: `select-multiplier-${t(
-                      'manage.sessionForms.multiplier3'
-                    )}`,
-                  },
-                },
-                {
-                  label: t('manage.sessionForms.multiplier4'),
-                  value: '4',
-                  data: {
-                    cy: `select-multiplier-${t(
-                      'manage.sessionForms.multiplier4'
-                    )}`,
-                  },
-                },
-              ]}
-              data={{ cy: 'select-multiplier' }}
-              className={{ tooltip: 'z-20' }}
-            />
-            <ErrorMessage
-              name="multiplier"
-              component="div"
-              className="text-sm text-red-400"
-            />
-          </div>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-row items-center gap-4">
+          <FormikSelectField
+            name="courseId"
+            label={t('shared.generic.course')}
+            tooltip={t('manage.sessionForms.liveQuizDescCourse')}
+            placeholder={t('manage.sessionForms.liveQuizSelectCourse')}
+            groups={groupedCourses}
+            hideError
+            data={{ cy: 'select-course' }}
+            className={{ tooltip: 'z-20' }}
+          />
+          <ErrorMessage
+            name="courseId"
+            component="div"
+            className="text-sm text-red-400"
+          />
         </div>
-      )}
+
+        <div>
+          <FormikSwitchField
+            disabled
+            name="isGamificationEnabled"
+            label={t('shared.generic.gamification')}
+            tooltip={t('manage.sessionForms.liveQuizGamification')}
+            standardLabel
+            data={{ cy: 'set-gamification' }}
+            className={{ tooltip: 'z-20' }}
+          />
+          <ErrorMessage
+            name="isGamificationEnabled"
+            component="div"
+            className="text-sm text-red-400"
+          />
+        </div>
+        <div className="flex flex-row items-center gap-4">
+          <FormikSelectField
+            disabled={!values.isGamificationEnabled}
+            name="multiplier"
+            label={t('shared.generic.multiplier')}
+            tooltip={t('manage.sessionForms.liveQuizMultiplier')}
+            placeholder={t('manage.sessionForms.multiplierDefault')}
+            items={[
+              {
+                label: t('manage.sessionForms.multiplier1'),
+                value: '1',
+                data: {
+                  cy: `select-multiplier-${t(
+                    'manage.sessionForms.multiplier1'
+                  )}`,
+                },
+              },
+              {
+                label: t('manage.sessionForms.multiplier2'),
+                value: '2',
+                data: {
+                  cy: `select-multiplier-${t(
+                    'manage.sessionForms.multiplier2'
+                  )}`,
+                },
+              },
+              {
+                label: t('manage.sessionForms.multiplier3'),
+                value: '3',
+                data: {
+                  cy: `select-multiplier-${t(
+                    'manage.sessionForms.multiplier3'
+                  )}`,
+                },
+              },
+              {
+                label: t('manage.sessionForms.multiplier4'),
+                value: '4',
+                data: {
+                  cy: `select-multiplier-${t(
+                    'manage.sessionForms.multiplier4'
+                  )}`,
+                },
+              },
+            ]}
+            data={{ cy: 'select-multiplier' }}
+            className={{ tooltip: 'z-20' }}
+          />
+          <ErrorMessage
+            name="multiplier"
+            component="div"
+            className="text-sm text-red-400"
+          />
+        </div>
+      </div>
       <div className="flex flex-col gap-4">
         <div>
           <FormikSwitchField

--- a/apps/frontend-manage/src/lib/hooks/useGamifiedCourseGrouping.tsx
+++ b/apps/frontend-manage/src/lib/hooks/useGamifiedCourseGrouping.tsx
@@ -1,0 +1,32 @@
+import { Group } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
+import { ElementSelectCourse } from '../../components/sessions/creation/ElementCreation'
+
+interface useGamifiedCourseGroupingProps {
+  gamifiedCourses: ElementSelectCourse[]
+  nonGamifiedCourses: ElementSelectCourse[]
+}
+
+function useGamifiedCourseGrouping({
+  gamifiedCourses,
+  nonGamifiedCourses,
+}: useGamifiedCourseGroupingProps): Group[] {
+  const t = useTranslations()
+
+  return [
+    {
+      items: gamifiedCourses,
+      showSeparator: true,
+      label: t('shared.generic.gamified'),
+    },
+    {
+      items: nonGamifiedCourses.map((course) => {
+        return { ...course, disabled: true }
+      }),
+      showSeparator: true,
+      label: t('shared.generic.nonGamified'),
+    },
+  ]
+}
+
+export default useGamifiedCourseGrouping

--- a/apps/frontend-manage/src/lib/hooks/useLiveQuizCourseGrouping.tsx
+++ b/apps/frontend-manage/src/lib/hooks/useLiveQuizCourseGrouping.tsx
@@ -1,0 +1,41 @@
+import { Group } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
+import { ElementSelectCourse } from '../../components/sessions/creation/ElementCreation'
+
+interface useLiveQuizCourseGroupingProps {
+  gamifiedCourses: ElementSelectCourse[]
+  nonGamifiedCourses: ElementSelectCourse[]
+}
+
+function useLiveQuizCourseGrouping({
+  gamifiedCourses,
+  nonGamifiedCourses,
+}: useLiveQuizCourseGroupingProps): Group[] {
+  const t = useTranslations()
+
+  return [
+    {
+      items: [
+        {
+          label: t('manage.sessionForms.liveQuizNoCourse'),
+          value: '',
+          data: {
+            cy: `select-course-${t('manage.sessionForms.liveQuizNoCourse')}`,
+          },
+        },
+      ],
+    },
+    {
+      items: gamifiedCourses,
+      showSeparator: true,
+      label: t('shared.generic.gamified'),
+    },
+    {
+      items: nonGamifiedCourses,
+      showSeparator: true,
+      label: t('shared.generic.nonGamified'),
+    },
+  ]
+}
+
+export default useLiveQuizCourseGrouping

--- a/apps/frontend-pwa/package.json
+++ b/apps/frontend-pwa/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tabs": "1.0.3",
     "@socialgouv/matomo-next": "1.6.1",
     "@uidotdev/usehooks": "2.4.1",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "body-parser": "1.20.2",
     "dayjs": "1.11.9",
     "deepmerge": "4.3.1",

--- a/apps/func-incoming-responses/package.json
+++ b/apps/func-incoming-responses/package.json
@@ -18,7 +18,7 @@
     "@tsconfig/recommended": "^1.0.2",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^18.17.4",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "azure-functions-core-tools": "4.0.5801",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/func-response-processor/package.json
+++ b/apps/func-response-processor/package.json
@@ -23,7 +23,7 @@
     "@types/md5": "2.3.2",
     "@types/node": "^18.17.4",
     "@types/ramda": "^0.29.3",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "azure-functions-core-tools": "4.0.5801",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/apps/office-addin/package.json
+++ b/apps/office-addin/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.2-rc.1",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "core-js": "3.30.2",
     "es6-promise": "4.2.8",
     "formik": "2.4.3",

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -166,6 +166,8 @@ export default {
       passed: 'Bestanden',
       failed: 'Nicht bestanden',
       survey: 'Umfrage',
+      gamified: 'Gamifiziert',
+      nonGamified: 'Nicht gamifiziert',
     },
     contentInput: {
       boldStyle:

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1017,6 +1017,10 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       practiceQuizSPACED_REPETITION: 'Spaced Repetition',
       practiceQuizUseCase:
         '<link>Übungs-Quizzes</link> können zur Vorbereitung auf Prüfungen und zur Wiederholung von Lerninhalten eingesetzt werden. Im Rahmen einer kompakten Evaluation erhalten die Studierenden Feedback zu ihren Antworten.',
+      missingGamifiedCourses:
+        'Für die Erstellung dieses Elementtyps ist ein gamifizierter Kurs erforderlich. Bitte aktivieren Sie die Gamifizierung in einem Ihrer bestehenden Kurse oder erstellen Sie einen neuen gamifizierten Kurs.',
+      selectGamifiedCourse:
+        'Bitte wählen Sie einen gamifizierten Kurs für die Erstellung dieses Elements.',
       groupActivityTypes:
         'Gruppenaktivitäten können nur Inhaltselemente, Single-Choice, Multiple-Choice, Kprim, Numerische und Freitext-Fragen enthalten.',
       groupActivityCreated:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -166,6 +166,8 @@ export default {
       passed: 'Passed',
       failed: 'Failed',
       survey: 'Survey',
+      gamified: 'Gamified',
+      nonGamified: 'Non-Gamified',
     },
     contentInput: {
       boldStyle:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1010,6 +1010,10 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       practiceQuizSPACED_REPETITION: 'Spaced Repetition',
       practiceQuizUseCase:
         '<link>Practice quizzes</link> can be used to prepare for exams and to review learning content. As part of a compact evaluation, students receive feedback on their answers.',
+      missingGamifiedCourses:
+        'For the creation of this type of element, a gamified course is required. Please enable gamification in one of your existing courses or create a new gamified course.',
+      selectGamifiedCourse:
+        'Please select a gamified course for the creation of this element.',
       groupActivityTypes:
         'A group activity can only contain content elements, single choice, multiple choice, kprim, numerical , and free-text questions.',
       groupActivityCreated:

--- a/packages/lti/package.json
+++ b/packages/lti/package.json
@@ -24,7 +24,7 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "6.4.2",
     "@fortawesome/free-solid-svg-icons": "6.4.2",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-regular-svg-icons": "6.4.2",
     "@fortawesome/free-solid-svg-icons": "6.4.2",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@uzh-bf/design-system": "2.8.0",
+    "@uzh-bf/design-system": "2.11.0",
     "formik": "2.4.3",
     "js-cookie": "3.0.5",
     "localforage": "1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(@prisma/client@5.9.1)(next-auth@4.24.5)
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       axios:
         specifier: 1.4.0
         version: 1.4.0
@@ -275,8 +275,8 @@ importers:
         specifier: ^8.5.9
         version: 8.5.10
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       axios:
         specifier: 1.4.0
         version: 1.4.0
@@ -368,8 +368,8 @@ importers:
         specifier: 1.0.5
         version: 1.0.5
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.27)
@@ -471,8 +471,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.6
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -655,8 +655,8 @@ importers:
         specifier: 1.6.1
         version: 1.6.1(next@14.1.0)
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       d3:
         specifier: 7.8.4
         version: 7.8.4
@@ -917,8 +917,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1(react-dom@18.2.0)(react@18.2.0)
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -1105,8 +1105,8 @@ importers:
         specifier: ^18.17.4
         version: 18.19.14
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       azure-functions-core-tools:
         specifier: 4.0.5801
         version: 4.0.5801
@@ -1300,8 +1300,8 @@ importers:
         specifier: ^0.29.3
         version: 0.29.10
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       azure-functions-core-tools:
         specifier: 4.0.5801
         version: 4.0.5801
@@ -1333,8 +1333,8 @@ importers:
   apps/office-addin:
     dependencies:
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       core-js:
         specifier: 3.30.2
         version: 3.30.2
@@ -1796,8 +1796,8 @@ importers:
   packages/lti:
     dependencies:
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -1860,8 +1860,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.2.0)
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       next:
         specifier: 14.1.0
         version: 14.1.0(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
@@ -2078,8 +2078,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.2.0)
       '@uzh-bf/design-system':
-        specifier: 2.8.0
-        version: 2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
+        specifier: 2.11.0
+        version: 2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0)
       dayjs:
         specifier: 1.11.9
         version: 1.11.9
@@ -10155,7 +10155,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(react@18.2.0)
@@ -13639,8 +13639,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@uzh-bf/design-system@2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0):
-    resolution: {integrity: sha512-feID5dvvBFq+gZld8xBR9dlRd2myocFKj2fg9RMtp3vjJRGHUs5Gd2ol3y9b3sRhqBB6r1aTtpR8aHYxsD+Sdw==}
+  /@uzh-bf/design-system@2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(@types/react-dom@18.2.19)(@types/react@18.2.55)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0):
+    resolution: {integrity: sha512-mxO4FqI3053VuDv0oVy+6GGl5ealtPARbaPU8DiA7AkHlwPeIZJ0HDtfYIAHxMfngeWTmkrak7tWMwoo7i0EQQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ^6.3.0
@@ -13692,8 +13692,8 @@ packages:
       - '@types/react-dom'
     dev: false
 
-  /@uzh-bf/design-system@2.8.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0):
-    resolution: {integrity: sha512-feID5dvvBFq+gZld8xBR9dlRd2myocFKj2fg9RMtp3vjJRGHUs5Gd2ol3y9b3sRhqBB6r1aTtpR8aHYxsD+Sdw==}
+  /@uzh-bf/design-system@2.11.0(@fortawesome/fontawesome-svg-core@6.4.2)(@fortawesome/free-regular-svg-icons@6.4.2)(@fortawesome/free-solid-svg-icons@6.4.2)(@fortawesome/react-fontawesome@0.2.0)(autoprefixer@10.4.14)(dayjs@1.11.9)(formik@2.4.3)(postcss-import@15.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwind-merge@1.14.0)(tailwindcss-radix@2.8.0)(tailwindcss@3.3.3)(yup@1.2.0):
+    resolution: {integrity: sha512-mxO4FqI3053VuDv0oVy+6GGl5ealtPARbaPU8DiA7AkHlwPeIZJ0HDtfYIAHxMfngeWTmkrak7tWMwoo7i0EQQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ^6.3.0


### PR DESCRIPTION
This pull request structures the select menus used in the creation process of live quiz, practice quiz and microlearning elements into gamified and non-gamified courses. For all asynchronous elements, only gamified courses can be selected, since the collection of points, etc. by participants would not be possible otherwise.