### PR TITLE
enhance: improve handled edge cases in group assignment cronjobs

### DIFF
--- a/apps/frontend-manage/src/components/courses/ParticipantListEntry.tsx
+++ b/apps/frontend-manage/src/components/courses/ParticipantListEntry.tsx
@@ -23,9 +23,9 @@ function ParticipantListEntry({
         />
       </div>
       <div className="text-sm">{participant.username}</div>
-      <div className="text-sm italic">
-        <Ellipsis maxLines={1}>{participant.email ?? ''}</Ellipsis>
-      </div>
+      <Ellipsis maxLines={1} className={{ content: 'text-sm italic' }}>
+        {participant.email ?? ''}
+      </Ellipsis>
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
@@ -110,6 +110,7 @@ function AssignmentConfirmationModal({
           openExternal={showError}
           setOpenExternal={setShowError}
           duration={5000}
+          className={{ root: 'max-w-[30rem]' }}
         >
           {t('manage.course.groupAssignmentFailed')}
         </Toast>
@@ -121,6 +122,7 @@ function AssignmentConfirmationModal({
           openExternal={showSuccess}
           setOpenExternal={setShowSuccess}
           duration={5000}
+          className={{ root: 'max-w-[30rem]' }}
         >
           {t('manage.course.groupAssignmentSuccessful')}
         </Toast>

--- a/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
@@ -3,8 +3,9 @@ import {
   GetCourseGroupsDocument,
   ManualRandomGroupAssignmentsDocument,
 } from '@klicker-uzh/graphql/dist/ops'
-import { Button, Modal, UserNotification } from '@uzh-bf/design-system'
+import { Button, Modal, Toast, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
+import { useState } from 'react'
 
 function AssignmentConfirmationModal({
   courseId,
@@ -16,6 +17,8 @@ function AssignmentConfirmationModal({
   setOpen: (value: boolean) => void
 }) {
   const t = useTranslations()
+  const [showError, setShowError] = useState(false)
+  const [showSuccess, setShowSuccess] = useState(false)
   const [
     manualRandomGroupAssignments,
     { loading: randomGroupCreationLoading },
@@ -49,52 +52,79 @@ function AssignmentConfirmationModal({
   })
 
   return (
-    <Modal
-      title={t('manage.course.finalizeRandomGroupAssignment')}
-      onPrimaryAction={
-        <Button
-          onClick={async () => {
-            const res = await manualRandomGroupAssignments({
-              variables: { courseId: courseId },
-            })
-            if (res.data?.manualRandomGroupAssignments) {
-              setOpen(false)
-            }
-          }}
-          className={{
-            root: 'bg-primary-80 text-base font-bold text-white',
-          }}
-          data={{ cy: 'confirm-random-group-assignment' }}
-          loading={randomGroupCreationLoading}
+    <>
+      <Modal
+        title={t('manage.course.finalizeRandomGroupAssignment')}
+        onPrimaryAction={
+          <Button
+            onClick={async () => {
+              const res = await manualRandomGroupAssignments({
+                variables: { courseId: courseId },
+              })
+              if (res.data?.manualRandomGroupAssignments) {
+                setOpen(false)
+              } else {
+                console.error('Error while creating random groups')
+                setShowError(true)
+              }
+            }}
+            className={{
+              root: 'bg-primary-80 text-base font-bold text-white',
+            }}
+            data={{ cy: 'confirm-random-group-assignment' }}
+            loading={randomGroupCreationLoading}
+          >
+            {t('shared.generic.confirm')}
+          </Button>
+        }
+        onSecondaryAction={
+          <Button
+            onClick={(): void => setOpen(false)}
+            data={{ cy: 'cancel-random-group-assignment' }}
+            className={{ root: 'text-base' }}
+          >
+            {t('shared.generic.cancel')}
+          </Button>
+        }
+        onClose={(): void => setOpen(false)}
+        open={open}
+        hideCloseButton={true}
+        className={{
+          content: 'h-max min-h-max w-[40rem] self-center pt-0',
+          title: 'text-xl',
+        }}
+      >
+        <div className="mb-2 font-bold">{t('shared.generic.pleaseReview')}</div>
+        <UserNotification type="warning">
+          {t.rich('manage.course.confirmRandomGroupAssignment', {
+            ul: (children) => <ul className="list-disc">{children}</ul>,
+            li: (children) => <li>{children}</li>,
+          })}
+        </UserNotification>
+      </Modal>
+      {showError && (
+        <Toast
+          dismissible
+          type="error"
+          openExternal={showError}
+          setOpenExternal={setShowError}
+          duration={5000}
         >
-          {t('shared.generic.confirm')}
-        </Button>
-      }
-      onSecondaryAction={
-        <Button
-          onClick={(): void => setOpen(false)}
-          data={{ cy: 'cancel-random-group-assignment' }}
-          className={{ root: 'text-base' }}
+          {t('manage.course.groupAssignmentFailed')}
+        </Toast>
+      )}
+      {showSuccess && (
+        <Toast
+          dismissible
+          type="success"
+          openExternal={showSuccess}
+          setOpenExternal={setShowSuccess}
+          duration={5000}
         >
-          {t('shared.generic.cancel')}
-        </Button>
-      }
-      onClose={(): void => setOpen(false)}
-      open={open}
-      hideCloseButton={true}
-      className={{
-        content: 'h-max min-h-max w-[40rem] self-center pt-0',
-        title: 'text-xl',
-      }}
-    >
-      <div className="mb-2 font-bold">{t('shared.generic.pleaseReview')}</div>
-      <UserNotification type="warning">
-        {t.rich('manage.course.confirmRandomGroupAssignment', {
-          ul: (children) => <ul className="list-disc">{children}</ul>,
-          li: (children) => <li>{children}</li>,
-        })}
-      </UserNotification>
-    </Modal>
+          {t('manage.course.groupAssignmentSuccessful')}
+        </Toast>
+      )}
+    </>
   )
 }
 

--- a/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
@@ -62,6 +62,7 @@ function AssignmentConfirmationModal({
                 variables: { courseId: courseId },
               })
               if (res.data?.manualRandomGroupAssignments) {
+                setShowSuccess(true)
                 setOpen(false)
               } else {
                 console.error('Error while creating random groups')

--- a/packages/graphql/src/lib/randomizedGroups.ts
+++ b/packages/graphql/src/lib/randomizedGroups.ts
@@ -29,7 +29,7 @@ export function splitGroupsFinal({
 }: RandomGroupAssignmentArgs) {
   // if only a single participant is left, return null and handle this case on level above
   if (participantIds.length === 1) {
-    return null
+    return []
   }
 
   // check if groups with the preferred size can be created

--- a/packages/graphql/test/index.test.ts
+++ b/packages/graphql/test/index.test.ts
@@ -121,7 +121,8 @@ describe('@klicker-uzh/graphql', () => {
       participantIds: participantIds0,
       preferredGroupSize: 2,
     })
-    expect(groups0).toBeNull()
+    expect(groups0).not.toBeNull()
+    expect(groups0).toHaveLength(0)
 
     // total 2 participants -> create one group with 2 members
     const participantIds = ['1', '2']
@@ -253,7 +254,8 @@ describe('@klicker-uzh/graphql', () => {
       participantIds: participantIds0,
       preferredGroupSize: 3,
     })
-    expect(groups0).toBeNull()
+    expect(groups0).not.toBeNull()
+    expect(groups0).toHaveLength(0)
 
     // total 2 participants -> create one group with 2 members
     const participantIds = ['1', '2']
@@ -407,7 +409,8 @@ describe('@klicker-uzh/graphql', () => {
       participantIds: participantIds0,
       preferredGroupSize: 7,
     })
-    expect(groups0).toBeNull()
+    expect(groups0).not.toBeNull()
+    expect(groups0).toHaveLength(0)
 
     // total 2 participants -> create one group with 2 members
     const participantIds = ['1', '2']

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1552,6 +1552,10 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         <li>Gruppen mit nur einem Teilnehmer werden gelöscht und die entsprechenden Studierenden werden in Gruppen eingeteilt.</li>
         <li>Die Zuweisung zu zufälligen Gruppen kann nicht rückgängig gemacht werden!</li>
         <li>Die Möglichkeit für Studierende, Gruppen manuell über die Studierenden-App zu erstellen oder zu verlassen, wird automatisch deaktiviert. Wenn Sie diese Möglichkeit wieder aktivieren möchten, verschieben Sie einfach das Gruppendeadline-Datum in den Kurseinstellungen in die Zukunft.</li></ul>`,
+      groupAssignmentFailed:
+        'Beim Zuweisen der Gruppen ist ein Fehler aufgetreten. Bitte überprüfen Sie, ob genügend Studierende im Zuweisungspool sind und versuchen Sie es erneut.',
+      groupAssignmentSuccessful:
+        'Die Gruppenzuweisung war erfolgreich. Alle Studierenden aus dem Pool wurden in zufällige Gruppen eingeteilt.',
     },
     groupActivity: {
       activityMissingOrNotCompleted:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1532,6 +1532,10 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         <li>Groups with a single participant will be deleted and the corresponding students will be assigned to randomized groups.</li>
         <li>The assignment to random groups cannot be undone!</li>
         <li>The possibility for students to create / leave groups manually through the student app will be automatically deactivated. Should you wish to re-enable this possibility, simply move the group deadline date in the course settings to the future.</li></ul>`,
+      groupAssignmentFailed:
+        'An error occurred during the group assignment. Please check that sufficiently many students are in the assignment pool and try again.',
+      groupAssignmentSuccessful:
+        'The group assignment was successful. All students from the pool were assigned to random groups.',
     },
     groupActivity: {
       activityMissingOrNotCompleted:


### PR DESCRIPTION
With this PR the following shortcomings of the developments in recent days are addressed:
- Cronjob logic is improved s.t. it also marks a course as finalized with respect to the group assignment logics, if no groups have been created (otherwise the course will be fetched over and over every night)
- Frontend now shows success / error messages on manual group assignment
- Bug with ellipsis styling on group participant listing was fixed