### PR TITLE
fix: ensure that originalId uniqueness is only enforced per user to allow same migration into multiple new accounts

### DIFF
--- a/packages/prisma/src/data/helpers.ts
+++ b/packages/prisma/src/data/helpers.ts
@@ -182,7 +182,10 @@ export function prepareQuestion({
 
     return {
       where: {
-        originalId: args.originalId,
+        ownerId_originalId: {
+          ownerId: args.ownerId,
+          originalId: args.originalId,
+        },
       },
       create: data,
       update: data,
@@ -197,7 +200,10 @@ export function prepareQuestion({
 
   return {
     where: {
-      originalId: args.originalId,
+      ownerId_originalId: {
+        ownerId: args.ownerId,
+        originalId: args.originalId,
+      },
     },
     create: data,
     update: data,
@@ -1071,7 +1077,10 @@ export async function prepareFlashcardsFromFile(
     quizInfo.elements.map(async (data: any) => {
       const flashcard = await prismaClient.element.upsert({
         where: {
-          originalId: data.originalId,
+          ownerId_originalId: {
+            ownerId: userId,
+            originalId: data.originalId,
+          },
         },
         create: {
           ...data,

--- a/packages/prisma/src/prisma/migrations/20240930093724_combine_original_id_uniqueness_user/migration.sql
+++ b/packages/prisma/src/prisma/migrations/20240930093724_combine_original_id_uniqueness_user/migration.sql
@@ -1,0 +1,53 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[ownerId,originalId]` on the table `Element` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId,originalId]` on the table `ElementInstance` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId,originalId]` on the table `LiveSession` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId,originalId]` on the table `MediaFile` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId,originalId]` on the table `QuestionInstance` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[sessionId,originalId]` on the table `SessionBlock` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId,originalId]` on the table `Tag` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Element_originalId_key";
+
+-- DropIndex
+DROP INDEX "ElementInstance_originalId_key";
+
+-- DropIndex
+DROP INDEX "LiveSession_originalId_key";
+
+-- DropIndex
+DROP INDEX "MediaFile_originalId_key";
+
+-- DropIndex
+DROP INDEX "QuestionInstance_originalId_key";
+
+-- DropIndex
+DROP INDEX "SessionBlock_originalId_key";
+
+-- DropIndex
+DROP INDEX "Tag_originalId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Element_ownerId_originalId_key" ON "Element"("ownerId", "originalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ElementInstance_ownerId_originalId_key" ON "ElementInstance"("ownerId", "originalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LiveSession_ownerId_originalId_key" ON "LiveSession"("ownerId", "originalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MediaFile_ownerId_originalId_key" ON "MediaFile"("ownerId", "originalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QuestionInstance_ownerId_originalId_key" ON "QuestionInstance"("ownerId", "originalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SessionBlock_sessionId_originalId_key" ON "SessionBlock"("sessionId", "originalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_ownerId_originalId_key" ON "Tag"("ownerId", "originalId");

--- a/packages/prisma/src/prisma/schema/element.prisma
+++ b/packages/prisma/src/prisma/schema/element.prisma
@@ -31,7 +31,7 @@ model Element {
 
   version Int @default(1) // used to track question versions, incremented on each update
 
-  originalId String? @unique
+  originalId String?
 
   isArchived Boolean @default(false)
   isDeleted  Boolean @default(false)
@@ -60,6 +60,8 @@ model Element {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([ownerId, originalId])
 }
 
 enum ElementInstanceType {
@@ -72,7 +74,7 @@ enum ElementInstanceType {
 model ElementInstance {
   id Int @id @default(autoincrement())
 
-  originalId String? @unique
+  originalId String?
 
   // TODO: remove after migration to new data structure
   migrationId String
@@ -110,6 +112,7 @@ model ElementInstance {
 
   @@unique([type, migrationId])
   @@unique([type, elementStackId, order])
+  @@unique([ownerId, originalId])
 }
 
 model InstanceStatistics {
@@ -205,7 +208,7 @@ enum QuestionInstanceType {
 model QuestionInstance {
   id Int @id @default(autoincrement())
 
-  originalId String? @unique
+  originalId String?
 
   type  QuestionInstanceType?
   order Int?
@@ -234,6 +237,7 @@ model QuestionInstance {
   updatedAt DateTime @updatedAt
 
   @@unique([type, sessionBlockId, order])
+  @@unique([ownerId, originalId])
 }
 
 // #endregion
@@ -246,7 +250,7 @@ model Tag {
 
   order Int @default(0)
 
-  originalId String? @unique
+  originalId String?
 
   questions Element[]
 
@@ -257,6 +261,7 @@ model Tag {
   updatedAt DateTime @updatedAt
 
   @@unique([ownerId, name])
+  @@unique([ownerId, originalId])
 }
 
 // #endregion
@@ -271,13 +276,15 @@ model MediaFile {
   type        String
   description String?
 
-  originalId String? @unique
+  originalId String?
 
   owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   ownerId String @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([ownerId, originalId])
 }
 
 // #endregion

--- a/packages/prisma/src/prisma/schema/quiz.prisma
+++ b/packages/prisma/src/prisma/schema/quiz.prisma
@@ -54,7 +54,7 @@ enum SessionBlockStatus {
 model SessionBlock {
   id Int @id @default(autoincrement())
 
-  originalId String? @unique
+  originalId String?
 
   order  Int
   status SessionBlockStatus @default(SCHEDULED)
@@ -76,6 +76,7 @@ model SessionBlock {
   updatedAt DateTime @updatedAt
 
   @@unique([sessionId, order])
+  @@unique([sessionId, originalId])
 }
 
 // TODO: delete after migration
@@ -95,7 +96,7 @@ enum AccessMode {
 model LiveSession {
   id String @id @default(uuid()) @db.Uuid
 
-  originalId                 String? @unique
+  originalId                 String?
   isLiveQAEnabled            Boolean @default(false)
   isConfusionFeedbackEnabled Boolean @default(true)
   isModerationEnabled        Boolean @default(true)
@@ -135,6 +136,8 @@ model LiveSession {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([ownerId, originalId])
 }
 
 enum LiveQuizStatus {


### PR DESCRIPTION
Until now, the original id property on different elements across the new KlickerUZH was defined to be globally unique. However, this resulted in issues when users tried to migrate the same old KlickerUZH v2 account to multiple new accounts, causing the tag upserting to fail. By only enforcing uniqueness of the originalId when considering the same user, these issues should be resolved.