### PR TITLE
fix: ensure that element instances in microlearning have correct type

### DIFF
--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -271,7 +271,7 @@ export async function manipulateMicroLearning(
                 elementType: element.type,
                 migrationId: uuidv4(),
                 order: elem.order,
-                type: ElementInstanceType.PRACTICE_QUIZ,
+                type: ElementInstanceType.MICROLEARNING,
                 elementData: processedElementData,
                 options: {
                   pointsMultiplier: multiplier * element.pointsMultiplier,


### PR DESCRIPTION
Find element instances in microlearning:
```sql
SELECT ei.* FROM "ElementInstance" ei JOIN "ElementStack" es ON ei."elementStackId" = es.id
WHERE es.type = 'MICROLEARNING'
```

Update statement to update all element instances to the correct type
```sql
UPDATE "ElementInstance" ei SET type = 'MICROLEARNING' WHERE ei.id IN (
    SELECT ei.id FROM "ElementInstance" ei
    JOIN "ElementStack" es ON ei."elementStackId" = es.id
    WHERE es.type = 'MICROLEARNING'
);
```