### PR TITLE
fix: aggregated results on element instance for numerical questions need to be computed based on hashed value

### DIFF
--- a/packages/graphql/src/scripts/2024-10-03_fix_numerical_instance_results.ts
+++ b/packages/graphql/src/scripts/2024-10-03_fix_numerical_instance_results.ts
@@ -59,20 +59,16 @@ async function run() {
     console.log('OLD RESULTS', instance.results)
     console.log('NEW RESULTS', newResults)
 
-    promises.push(
-      prisma.elementInstance.update({
-        where: {
-          id: instance.id,
-        },
-        data: {
-          results: newResults,
-        },
-      })
-    )
+    // ! Uncomment this to apply the changes to the database
+    await prisma.elementInstance.update({
+      where: {
+        id: instance.id,
+      },
+      data: {
+        results: newResults,
+      },
+    })
   }
-
-  // ! Uncomment this line to apply the changes to the database
-  // await prisma.$transaction(promises)
 }
 
 await run()

--- a/packages/graphql/src/scripts/2024-10-03_fix_numerical_instance_results.ts
+++ b/packages/graphql/src/scripts/2024-10-03_fix_numerical_instance_results.ts
@@ -1,0 +1,78 @@
+import { ElementType, PrismaClient } from '@klicker-uzh/prisma'
+import { createHash } from 'node:crypto'
+
+async function run() {
+  const prisma = new PrismaClient()
+
+  let promises: any[] = []
+
+  const instances = await prisma.elementInstance.findMany({
+    include: {
+      detailResponses: true,
+      element: true,
+    },
+    where: {
+      elementType: ElementType.NUMERICAL,
+    },
+  })
+
+  for (const instance of instances) {
+    const instanceResults = instance.results
+    let newResults = {
+      responses: {},
+      total: 0,
+    }
+
+    instance.detailResponses.forEach((entry) => {
+      const { value } = entry.response as { value: string }
+      const MD5 = createHash('md5')
+      MD5.update(String(value))
+      const hashedValue = MD5.digest('hex')
+
+      if (Object.keys(newResults.responses).includes(hashedValue)) {
+        newResults.responses[hashedValue].count++
+      } else {
+        if (!Object.keys(instanceResults.responses).includes(hashedValue)) {
+          console.log(instanceResults)
+          console.log('Value:', value)
+          console.log('Hashed value:', hashedValue)
+          throw new Error('Value not found in original results')
+        }
+
+        const correctness = instanceResults.responses[hashedValue].correct
+        newResults.responses[hashedValue] =
+          typeof correctness !== 'undefined'
+            ? {
+                count: 1,
+                correct: instanceResults.responses[hashedValue].correct,
+                value: String(parseFloat(value)),
+              }
+            : {
+                count: 1,
+                value: String(parseFloat(value)),
+              }
+      }
+
+      newResults.total++
+    })
+
+    console.log('OLD RESULTS', instance.results)
+    console.log('NEW RESULTS', newResults)
+
+    promises.push(
+      prisma.elementInstance.update({
+        where: {
+          id: instance.id,
+        },
+        data: {
+          results: newResults,
+        },
+      })
+    )
+  }
+
+  // ! Uncomment this line to apply the changes to the database
+  // await prisma.$transaction(promises)
+}
+
+await run()

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -1483,7 +1483,7 @@ export function updateQuestionResults({
       MD5.update(value)
       const hashedValue = MD5.digest('hex')
 
-      if (Object.keys(results.responses).includes(value)) {
+      if (Object.keys(results.responses).includes(hashedValue)) {
         updatedResults.responses = {
           ...results.responses,
           [hashedValue]: {


### PR DESCRIPTION
Run the following script on the production database to make sure that the results for numerical element instance results are consistent again:
```bash
pnpm run script:prod src/scripts/2024-10-03_fix_numerical_instance_results.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new script to process numerical element instances, enhancing data integrity.
	- Implemented a hashing mechanism for numerical responses to improve uniqueness and security.

- **Bug Fixes**
	- Updated response handling logic to ensure consistent evaluation and processing of numerical inputs.

- **Refactor**
	- Enhanced internal logic for handling responses in various functions to accommodate the new hashing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->