### PR TITLE
style(apps/frontend-manage): update messages shown on creation editors and mark past courses

### DIFF
--- a/apps/frontend-manage/src/components/courses/CourseListButton.tsx
+++ b/apps/frontend-manage/src/components/courses/CourseListButton.tsx
@@ -1,4 +1,5 @@
 import { faClock, IconDefinition } from '@fortawesome/free-regular-svg-icons'
+import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@uzh-bf/design-system'
 import { Badge } from '@uzh-bf/design-system/dist/future'
@@ -31,6 +32,7 @@ function CourseListButton({
   data,
 }: CourseListButtonProps) {
   const t = useTranslations()
+  const isPast = endDate ? dayjs(endDate).isBefore(dayjs()) : false
 
   return (
     <Button
@@ -59,7 +61,15 @@ function CourseListButton({
           </div>
         )}
       </div>
-      {isArchived && <Badge>{t('shared.generic.archived')}</Badge>}
+      <div className="flex flex-row gap-2">
+        {isPast && (
+          <Badge className="gap-2 bg-green-700 hover:bg-green-800">
+            <FontAwesomeIcon icon={faCheck} />
+            {t('shared.generic.ended')}
+          </Badge>
+        )}
+        {isArchived && <Badge>{t('shared.generic.archived')}</Badge>}
+      </div>
     </Button>
   )
 }

--- a/apps/frontend-manage/src/pages/courses/index.tsx
+++ b/apps/frontend-manage/src/pages/courses/index.tsx
@@ -63,7 +63,7 @@ function CourseSelectionPage() {
       return showArchive ? true : !course.isArchived
     })
     .sort((a, b) => {
-      return dayjs(b.startDate).diff(dayjs(a.startDate))
+      return dayjs(b.endDate).diff(dayjs(a.endDate))
     })
 
   return (

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -211,6 +211,7 @@ export default {
       withoutGroups: 'Ohne Gruppen',
       forgotPassword: 'Passwort vergessen?',
       archived: 'Archiviert',
+      ended: 'Beendet',
     },
     contentInput: {
       boldStyle:
@@ -1027,7 +1028,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       microLearningInformation:
         'Geben Sie in diesem Schritt den Namen für das Microlearning ein und finden Sie hilfreiche Informationen zur Erstellung des Elements.',
       microLearningNoCourse:
-        'Microlearnings müssen immer einem Kurs zugeordnet werden. Bitte erstellen Sie zuerst einen Kurs über das entsprechende Menü, bevor sie mit der Erstellung fortfahren.',
+        'Microlearnings müssen immer einem laufenden Kurs zugeordnet werden. Bitte erstellen Sie zuerst einen Kurs über das entsprechende Menü oder verlängern Sie einen bestehenden Kurs, bevor sie mit der Erstellung fortfahren.',
       microLearningLecturerDocs:
         'Für weitere Informationen zur Erstellung und Durchführung von Microlearnings, besuchen Sie die <link>Dozierenden-Dokumentation</link>.',
       microLearningStudentDocs:
@@ -1133,7 +1134,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Die Zeit bis zum Ende der Vergabe von Bonuspunkten muss mindestens 1 Sekunde betragen.',
       liveQuizTSinceFirstCorrect: 'Zeit seit erster korrekter Antwort [s]',
       practiceQuizNoCourse:
-        'Übungs-Quizzes müssen einem Kurs zugeordnet werden. Bitte erstellen Sie zuerst einen Kurs über das entsprechende Menü, bevor sie mit der Erstellung fortfahren.',
+        'Übungs-Quizzes müssen einem laufenden Kurs zugeordnet werden. Bitte erstellen Sie zuerst einen Kurs über das entsprechende Menü oder verlängern Sie einen bestehenden Kurs, bevor sie mit der Erstellung fortfahren.',
       practiceQuizIntroductionName:
         'Bitte geben Sie einen Namen für Ihr Übungs-Quiz ein. Für weitere Informationen zu den spezifischen Feldern während der Erstellung können Sie die entsprechenden Tooltips konsultieren.',
       practiceQuizInformation:
@@ -1202,7 +1203,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       groupActivityEdited:
         'Ihre Gruppenaktivität <b>{name}</b> wurde erfolgreich bearbeitet.',
       groupActivityNoCourse:
-        'Gruppenaktivitäten müssen immer einem Kurs zugeordnet werden, in dem Gamifizierung und Gruppenbildung aktiviert sind. Bitte stellen Sie sicher, dass mindestens ein Kurs existiert, in welchem beide Optionen aktiviert ist, bevor sie mit der Erstellung fortfahren.',
+        'Gruppenaktivitäten müssen immer einem laufenden Kurs zugeordnet werden, in dem Gamifizierung und Gruppenbildung aktiviert sind. Bitte stellen Sie sicher, dass mindestens ein Kurs existiert, in welchem beide Optionen aktiviert ist, bevor sie mit der Erstellung fortfahren.',
       groupActivityIntroductionName:
         'Bitte geben Sie einen Namen für Ihre Gruppenaktivität ein. Für weitere Informationen zu den spezifischen Feldern während der Erstellung können Sie die entsprechenden Tooltips konsultieren.',
       groupActivityLecturerDocs:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -211,6 +211,7 @@ export default {
       withoutGroups: 'Without groups',
       forgotPassword: 'Forgot password?',
       archived: 'Archived',
+      ended: 'Ended',
     },
     contentInput: {
       boldStyle:
@@ -1027,7 +1028,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       microLearningInformation:
         'In this step, enter the name and description of the microlearning and find helpful information for creating the element.',
       microLearningNoCourse:
-        'Microlearnings must always be assigned to a course. Please create a course first via the corresponding menu before continuing with the creation.',
+        'Microlearnings must always be assigned to a running course. Please create a course first via the corresponding menu or extend an existing one before continuing with the creation.',
       microLearningLecturerDocs:
         'For more information on the creation and execution of microlearnings, visit the <link>Lecturer Documentation</link>.',
       microLearningStudentDocs:
@@ -1127,7 +1128,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         'The time to zero bonus points must be at least 1.',
       liveQuizTSinceFirstCorrect: 'Time since first correct answer [s]',
       practiceQuizNoCourse:
-        'Practice quizzes must be assigned to a course. Please create a course first via the corresponding menu before continuing with the creation.',
+        'Practice quizzes must be assigned to a running course. Please create a course first via the corresponding menu or extend an existing one before continuing with the creation.',
       practiceQuizIntroductionName:
         'Please enter a name for your practice quiz. For more information on the specific fields during creation, you can refer to the corresponding tooltips.',
       practiceQuizInformation:
@@ -1194,7 +1195,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       groupActivityEdited:
         'Your group activity <b>{name}</b> has been edited successfully.',
       groupActivityNoCourse:
-        'Group activities must always be assigned to a course, where gamification and group creation are enabled. Please make sure that there exists at least one course with both options enabled.',
+        'Group activities must always be assigned to a running course, where gamification and group creation are enabled. Please make sure that there exists at least one course with both options enabled.',
       groupActivityIntroductionName:
         'Please enter a name for your group activity. For more information on the specific fields during creation, you can refer to the corresponding tooltips.',
       groupActivityLecturerDocs:


### PR DESCRIPTION
<img width="692" alt="Screenshot 2024-10-08 at 21 34 04" src="https://github.com/user-attachments/assets/be7ac122-e873-425e-ae9d-7c38c1b67224">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a badge to indicate when a course has ended, enhancing visual clarity.
	- Updated course sorting to prioritize by end date instead of start date.

- **Localization**
	- Introduced new localization keys for "Ended" in both German and English.
	- Updated existing localization messages to clarify the requirement for microlearnings and practice quizzes to be associated with active courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->