### PR TITLE
fix: ensure that re-ordered answer options on choices questions are displayed consistently

### DIFF
--- a/apps/frontend-manage/package.json
+++ b/apps/frontend-manage/package.json
@@ -35,6 +35,7 @@
     "js-search": "2.0.1",
     "localforage": "1.10.0",
     "lodash": "4.17.21",
+    "nanoid": "5.0.8",
     "next": "15.0.0",
     "next-intl": "3.21.1",
     "nookies": "2.5.2",

--- a/apps/frontend-manage/src/components/evaluation/BarChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/BarChart.tsx
@@ -126,22 +126,20 @@ function BarChart({
             id="bar-chart-block"
           />
           {questionData.__typename === 'ChoicesQuestionData' &&
-            questionData.options.choices
-              .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-              .map(
-                (choice: Choice, index: number): React.ReactElement => (
-                  <Cell
-                    fill={
-                      showSolution
-                        ? choice.correct
-                          ? CHART_SOLUTION_COLORS.correct
-                          : CHART_SOLUTION_COLORS.incorrect
-                        : CHART_COLORS[index % 12]
-                    }
-                    key={index}
-                  />
-                )
-              )}
+            questionData.options.choices.map(
+              (choice: Choice): React.ReactElement => (
+                <Cell
+                  fill={
+                    showSolution
+                      ? choice.correct
+                        ? CHART_SOLUTION_COLORS.correct
+                        : CHART_SOLUTION_COLORS.incorrect
+                      : CHART_COLORS[choice.ix % 12]
+                  }
+                  key={`choice-${choice.ix}`}
+                />
+              )
+            )}
         </Bar>
       </BarChartRecharts>
     </ResponsiveContainer>

--- a/apps/frontend-manage/src/components/evaluation/BarChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/BarChart.tsx
@@ -126,20 +126,22 @@ function BarChart({
             id="bar-chart-block"
           />
           {questionData.__typename === 'ChoicesQuestionData' &&
-            questionData.options.choices.map(
-              (choice: Choice, index: number): React.ReactElement => (
-                <Cell
-                  fill={
-                    showSolution
-                      ? choice.correct
-                        ? CHART_SOLUTION_COLORS.correct
-                        : CHART_SOLUTION_COLORS.incorrect
-                      : CHART_COLORS[index % 12]
-                  }
-                  key={index}
-                />
-              )
-            )}
+            questionData.options.choices
+              .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+              .map(
+                (choice: Choice, index: number): React.ReactElement => (
+                  <Cell
+                    fill={
+                      showSolution
+                        ? choice.correct
+                          ? CHART_SOLUTION_COLORS.correct
+                          : CHART_SOLUTION_COLORS.incorrect
+                        : CHART_COLORS[index % 12]
+                    }
+                    key={index}
+                  />
+                )
+              )}
         </Bar>
       </BarChartRecharts>
     </ResponsiveContainer>

--- a/apps/frontend-manage/src/components/evaluation/TableChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/TableChart.tsx
@@ -36,18 +36,16 @@ function TableChart({
 
   const tableData = useMemo(() => {
     if (questionData.__typename === 'ChoicesQuestionData') {
-      return questionData.options.choices
-        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-        .map((choice: Choice, index: number) => {
-          return {
-            count: data.results[index].count,
-            value: choice.value,
-            correct: choice.correct,
-            percentage: data.participants
-              ? data.results[index].count / data.participants
-              : 0,
-          }
-        })
+      return questionData.options.choices.map((choice: Choice) => {
+        return {
+          count: data.results[choice.ix].count,
+          value: choice.value,
+          correct: choice.correct,
+          percentage: data.participants
+            ? data.results[choice.ix].count / data.participants
+            : 0,
+        }
+      })
     } else {
       return Object.values(
         data.results as FreeTextQuestionData | NumericalQuestionData

--- a/apps/frontend-manage/src/components/evaluation/TableChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/TableChart.tsx
@@ -36,8 +36,9 @@ function TableChart({
 
   const tableData = useMemo(() => {
     if (questionData.__typename === 'ChoicesQuestionData') {
-      return questionData.options.choices.map(
-        (choice: Choice, index: number) => {
+      return questionData.options.choices
+        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+        .map((choice: Choice, index: number) => {
           return {
             count: data.results[index].count,
             value: choice.value,
@@ -46,8 +47,7 @@ function TableChart({
               ? data.results[index].count / data.participants
               : 0,
           }
-        }
-      )
+        })
     } else {
       return Object.values(
         data.results as FreeTextQuestionData | NumericalQuestionData

--- a/apps/frontend-manage/src/components/evaluation/TableChart.tsx
+++ b/apps/frontend-manage/src/components/evaluation/TableChart.tsx
@@ -36,27 +36,23 @@ function TableChart({
 
   const tableData = useMemo(() => {
     if (questionData.__typename === 'ChoicesQuestionData') {
-      return questionData.options.choices.map((choice: Choice) => {
-        return {
-          count: data.results[choice.ix].count,
-          value: choice.value,
-          correct: choice.correct,
-          percentage: data.participants
-            ? data.results[choice.ix].count / data.participants
-            : 0,
-        }
-      })
+      return questionData.options.choices.map((choice: Choice) => ({
+        count: data.results[choice.ix].count,
+        value: choice.value,
+        correct: choice.correct,
+        percentage: data.participants
+          ? data.results[choice.ix].count / data.participants
+          : 0,
+      }))
     } else {
       return Object.values(
         data.results as FreeTextQuestionData | NumericalQuestionData
-      ).map((result) => {
-        return {
-          count: result.count,
-          value: result.value,
-          correct: result.correct,
-          percentage: data.participants ? result.count / data.participants : 0,
-        }
-      })
+      ).map((result) => ({
+        count: result.count,
+        value: result.value,
+        correct: result.correct,
+        percentage: data.participants ? result.count / data.participants : 0,
+      }))
     }
   }, [data])
 

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -123,22 +123,23 @@ function StudentElementPreview({
         values.options.hasAnswerFeedbacks && (
           <div className="mt-4">
             <H3>{t('shared.generic.feedbacks')}</H3>
-            {values.options.choices
-              .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-              .map((choice, index) => (
-                <div key={index} className="border-b pb-1 pt-1 last:border-b-0">
-                  {choice.feedback ? (
-                    <Markdown
-                      className={{
-                        root: 'prose prose-p:!m-0 prose-img:!m-0 leading-6',
-                      }}
-                      content={choice.feedback}
-                    />
-                  ) : (
-                    t('manage.questionForms.noFeedbackDefined')
-                  )}
-                </div>
-              ))}
+            {values.options.choices.map((choice) => (
+              <div
+                key={`choice-${choice.ix}`}
+                className="border-b pb-1 pt-1 last:border-b-0"
+              >
+                {choice.feedback ? (
+                  <Markdown
+                    className={{
+                      root: 'prose prose-p:!m-0 prose-img:!m-0 leading-6',
+                    }}
+                    content={choice.feedback}
+                  />
+                ) : (
+                  t('manage.questionForms.noFeedbackDefined')
+                )}
+              </div>
+            ))}
           </div>
         )}
     </div>

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -60,7 +60,8 @@ function StudentElementPreview({
                             : undefined,
                         accuracy:
                           'accuracy' in values.options &&
-                          values.options.accuracy
+                          typeof values.options.accuracy !== 'undefined' &&
+                          values.options.accuracy !== null
                             ? parseInt(String(values.options.accuracy))
                             : undefined,
                         unit:
@@ -72,7 +73,9 @@ function StudentElementPreview({
                             'restrictions' in values.options &&
                             values.options.restrictions &&
                             'min' in values.options.restrictions &&
-                            values.options.restrictions.min
+                            typeof values.options.restrictions.min ===
+                              'undefined' &&
+                            values.options.restrictions.min !== null
                               ? parseFloat(
                                   String(values.options.restrictions.min)
                                 )
@@ -81,7 +84,9 @@ function StudentElementPreview({
                             'restrictions' in values.options &&
                             values.options.restrictions &&
                             'max' in values.options.restrictions &&
-                            values.options.restrictions.max
+                            typeof values.options.restrictions.max !==
+                              'undefined' &&
+                            values.options.restrictions.max !== null
                               ? parseFloat(
                                   String(values.options.restrictions.max)
                                 )

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -73,7 +73,7 @@ function StudentElementPreview({
                             'restrictions' in values.options &&
                             values.options.restrictions &&
                             'min' in values.options.restrictions &&
-                            typeof values.options.restrictions.min ===
+                            typeof values.options.restrictions.min !==
                               'undefined' &&
                             values.options.restrictions.min !== null
                               ? parseFloat(

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -125,7 +125,7 @@ function StudentElementPreview({
             <H3>{t('shared.generic.feedbacks')}</H3>
             {values.options.choices.map((choice) => (
               <div
-                key={`choice-${choice.ix}`}
+                key={`choice-${choice.id}`}
                 className="border-b pb-1 pt-1 last:border-b-0"
               >
                 {choice.feedback ? (

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -123,20 +123,22 @@ function StudentElementPreview({
         values.options.hasAnswerFeedbacks && (
           <div className="mt-4">
             <H3>{t('shared.generic.feedbacks')}</H3>
-            {values.options.choices.map((choice, index) => (
-              <div key={index} className="border-b pb-1 pt-1 last:border-b-0">
-                {choice.feedback ? (
-                  <Markdown
-                    className={{
-                      root: 'prose prose-p:!m-0 prose-img:!m-0 leading-6',
-                    }}
-                    content={choice.feedback}
-                  />
-                ) : (
-                  t('manage.questionForms.noFeedbackDefined')
-                )}
-              </div>
-            ))}
+            {values.options.choices
+              .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+              .map((choice, index) => (
+                <div key={index} className="border-b pb-1 pt-1 last:border-b-0">
+                  {choice.feedback ? (
+                    <Markdown
+                      className={{
+                        root: 'prose prose-p:!m-0 prose-img:!m-0 leading-6',
+                      }}
+                      content={choice.feedback}
+                    />
+                  ) : (
+                    t('manage.questionForms.noFeedbackDefined')
+                  )}
+                </div>
+              ))}
           </div>
         )}
     </div>

--- a/apps/frontend-manage/src/components/questions/manipulation/helpers.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/helpers.ts
@@ -73,9 +73,9 @@ export function prepareChoicesArgs({
       hasSampleSolution: values.options.hasSampleSolution,
       hasAnswerFeedbacks: values.options.hasAnswerFeedbacks,
       displayMode: values.options.displayMode,
-      choices: values.options.choices.map((choice) => {
+      choices: values.options.choices.map((choice, index) => {
         return {
-          ix: choice.ix,
+          ix: index,
           value: choice.value!,
           correct: choice.correct,
           feedback: choice.feedback,

--- a/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
@@ -82,7 +82,7 @@ function ChoicesOptions({
                   >
                     {({ field, meta }: FastFieldProps) => (
                       <ContentInput
-                        key={`${values.type}-choice-${index}-${values.options.choices.length}-${values.options.choices[index].ix}`}
+                        key={`${values.type}-choice-${values.options.choices[index].ix}`}
                         error={meta.error}
                         touched={meta.touched}
                         content={field.value}
@@ -242,7 +242,7 @@ function ChoicesOptions({
                       >
                         {({ field, meta }: FastFieldProps) => (
                           <ContentInput
-                            key={`${values.type}-feedback-${index}-${values.options.choices[index].ix}`}
+                            key={`${values.type}-feedback-${values.options.choices[index].ix}`}
                             error={meta.error}
                             touched={meta.touched}
                             content={field.value || '<br>'}

--- a/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
@@ -14,6 +14,7 @@ import {
   FieldProps,
   FormikErrors,
 } from 'formik'
+import { nanoid } from 'nanoid'
 import { useTranslations } from 'next-intl'
 import { twMerge } from 'tailwind-merge'
 import ContentInput from '../../../common/ContentInput'
@@ -41,7 +42,7 @@ function ChoicesOptions({
           <div className="flex w-full flex-col gap-2 pt-2">
             {values.options.choices.map((choice, index: number) => (
               <div
-                key={index}
+                key={choice.id}
                 className={twMerge(
                   'border-uzh-grey-80 w-full rounded',
                   values.options.hasSampleSolution && 'p-2',
@@ -75,14 +76,14 @@ function ChoicesOptions({
                           prev.formik.values.type === ElementType.Kprim) &&
                         (next.formik.values.options.choices[index]?.value !==
                           prev.formik.values.options.choices[index]?.value ||
-                          next.formik.values.options.choices[index]?.ix !==
-                            prev.formik.values.options.choices[index]?.ix)) ||
+                          next.formik.values.options.choices[index]?.id !==
+                            prev.formik.values.options.choices[index]?.id)) ||
                       next?.formik.values.type !== prev?.formik.values.type
                     }
                   >
                     {({ field, meta }: FastFieldProps) => (
                       <ContentInput
-                        key={`${values.type}-choice-${values.options.choices[index].ix}`}
+                        key={`${values.type}-choice-${values.options.choices[index].id}`}
                         error={meta.error}
                         touched={meta.touched}
                         content={field.value}
@@ -134,17 +135,7 @@ function ChoicesOptions({
                     <Button
                       className={{ root: 'px-auto py-0.5' }}
                       disabled={index === 0}
-                      onClick={async () => {
-                        await setFieldValue(
-                          `options.choices.${index}.ix`,
-                          index - 1
-                        )
-                        await setFieldValue(
-                          `options.choices.${index - 1}.ix`,
-                          index
-                        )
-                        move(index, index - 1)
-                      }}
+                      onClick={() => move(index, index - 1)}
                       data={{
                         cy: `move-answer-option-ix-${index}-up`,
                       }}
@@ -154,17 +145,7 @@ function ChoicesOptions({
                     <Button
                       className={{ root: 'px-auto py-0.5' }}
                       disabled={index === values.options.choices.length - 1}
-                      onClick={async () => {
-                        await setFieldValue(
-                          `options.choices.${index}.ix`,
-                          index + 1
-                        )
-                        await setFieldValue(
-                          `options.choices.${index + 1}.ix`,
-                          index
-                        )
-                        move(index, index + 1)
-                      }}
+                      onClick={() => move(index, index + 1)}
                       data={{
                         cy: `move-answer-option-ix-${index}-down`,
                       }}
@@ -173,18 +154,7 @@ function ChoicesOptions({
                     </Button>
                   </div>
                   <Button
-                    onClick={() => {
-                      // decrement the choice.ix value of all answers after this one
-                      values.options.choices
-                        .slice(index + 1)
-                        .forEach((choice) => {
-                          setFieldValue(
-                            `options.choices.${choice.ix}.ix`,
-                            choice.ix - 1
-                          )
-                        })
-                      remove(index)
-                    }}
+                    onClick={() => remove(index)}
                     className={{
                       root: 'h-10 w-10 items-center justify-center rounded-md bg-red-600 text-white',
                     }}
@@ -234,15 +204,15 @@ function ChoicesOptions({
                               ?.feedback !==
                               prev?.formik.values.options.choices[index]
                                 ?.feedback ||
-                              next?.formik.values.options.choices[index]?.ix !==
+                              next?.formik.values.options.choices[index]?.id !==
                                 prev?.formik.values.options.choices[index]
-                                  ?.ix)) ||
+                                  ?.id)) ||
                           next?.formik.values.type !== prev?.formik.values.type
                         }
                       >
                         {({ field, meta }: FastFieldProps) => (
                           <ContentInput
-                            key={`${values.type}-feedback-${values.options.choices[index].ix}`}
+                            key={`${values.type}-feedback-${values.options.choices[index].id}`}
                             error={meta.error}
                             touched={meta.touched}
                             content={field.value || '<br>'}
@@ -285,10 +255,8 @@ function ChoicesOptions({
               }
               onClick={() =>
                 push({
-                  ix: values.options.choices[values.options.choices.length - 1]
-                    ? values.options.choices[values.options.choices.length - 1]
-                        .ix + 1
-                    : 0,
+                  id: nanoid(),
+                  ix: values.options.choices.length,
                   value: '<br>',
                   correct: false,
                   feedback: '',

--- a/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
@@ -41,7 +41,7 @@ function ChoicesOptions({
           <div className="flex w-full flex-col gap-2 pt-2">
             {values.options.choices.map((choice, index: number) => (
               <div
-                key={`choice-${choice.value}-${index}`}
+                key={choice.value}
                 className={twMerge(
                   'border-uzh-grey-80 w-full rounded',
                   values.options.hasSampleSolution && 'p-2',
@@ -73,10 +73,10 @@ function ChoicesOptions({
                         (prev.formik.values.type === ElementType.Sc ||
                           prev.formik.values.type === ElementType.Mc ||
                           prev.formik.values.type === ElementType.Kprim) &&
-                        (next.formik.values.options.choices[index].value !==
-                          prev.formik.values.options.choices[index].value ||
-                          next.formik.values.options.choices[index].ix !==
-                            prev.formik.values.options.choices[index].ix)) ||
+                        (next.formik.values.options.choices[index]?.value !==
+                          prev.formik.values.options.choices[index]?.value ||
+                          next.formik.values.options.choices[index]?.ix !==
+                            prev.formik.values.options.choices[index]?.ix)) ||
                       next?.formik.values.type !== prev?.formik.values.type
                     }
                   >
@@ -231,12 +231,12 @@ function ChoicesOptions({
                               prev.formik.values.type === ElementType.Mc ||
                               prev.formik.values.type === ElementType.Kprim) &&
                             (next?.formik.values.options.choices[index]
-                              .feedback !==
+                              ?.feedback !==
                               prev?.formik.values.options.choices[index]
-                                .feedback ||
-                              next?.formik.values.options.choices[index].ix !==
+                                ?.feedback ||
+                              next?.formik.values.options.choices[index]?.ix !==
                                 prev?.formik.values.options.choices[index]
-                                  .ix)) ||
+                                  ?.ix)) ||
                           next?.formik.values.type !== prev?.formik.values.type
                         }
                       >

--- a/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
@@ -41,7 +41,7 @@ function ChoicesOptions({
           <div className="flex w-full flex-col gap-2 pt-2">
             {values.options.choices.map((choice, index: number) => (
               <div
-                key={choice.value}
+                key={index}
                 className={twMerge(
                   'border-uzh-grey-80 w-full rounded',
                   values.options.hasSampleSolution && 'p-2',
@@ -135,15 +135,15 @@ function ChoicesOptions({
                       className={{ root: 'px-auto py-0.5' }}
                       disabled={index === 0}
                       onClick={async () => {
-                        move(index, index - 1)
                         await setFieldValue(
-                          `options.choices.${index - 1}.ix`,
+                          `options.choices.${index}.ix`,
                           index - 1
                         )
                         await setFieldValue(
-                          `options.choices.${index}.ix`,
+                          `options.choices.${index - 1}.ix`,
                           index
                         )
+                        move(index, index - 1)
                       }}
                       data={{
                         cy: `move-answer-option-ix-${index}-up`,
@@ -155,15 +155,15 @@ function ChoicesOptions({
                       className={{ root: 'px-auto py-0.5' }}
                       disabled={index === values.options.choices.length - 1}
                       onClick={async () => {
-                        move(index, index + 1)
                         await setFieldValue(
-                          `options.choices.${index + 1}.ix`,
+                          `options.choices.${index}.ix`,
                           index + 1
                         )
                         await setFieldValue(
-                          `options.choices.${index}.ix`,
+                          `options.choices.${index + 1}.ix`,
                           index
                         )
+                        move(index, index + 1)
                       }}
                       data={{
                         cy: `move-answer-option-ix-${index}-down`,

--- a/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
@@ -41,7 +41,7 @@ function ChoicesOptions({
           <div className="flex w-full flex-col gap-2 pt-2">
             {values.options.choices.map((choice, index: number) => (
               <div
-                key={index}
+                key={`choice-${choice.value}-${index}`}
                 className={twMerge(
                   'border-uzh-grey-80 w-full rounded',
                   values.options.hasSampleSolution && 'p-2',
@@ -73,8 +73,10 @@ function ChoicesOptions({
                         (prev.formik.values.type === ElementType.Sc ||
                           prev.formik.values.type === ElementType.Mc ||
                           prev.formik.values.type === ElementType.Kprim) &&
-                        next.formik.values.options.choices[index].value !==
-                          prev.formik.values.options.choices[index].value) ||
+                        (next.formik.values.options.choices[index].value !==
+                          prev.formik.values.options.choices[index].value ||
+                          next.formik.values.options.choices[index].ix !==
+                            prev.formik.values.options.choices[index].ix)) ||
                       next?.formik.values.type !== prev?.formik.values.type
                     }
                   >
@@ -132,7 +134,17 @@ function ChoicesOptions({
                     <Button
                       className={{ root: 'px-auto py-0.5' }}
                       disabled={index === 0}
-                      onClick={() => move(index, index - 1)}
+                      onClick={async () => {
+                        move(index, index - 1)
+                        await setFieldValue(
+                          `options.choices.${index - 1}.ix`,
+                          index - 1
+                        )
+                        await setFieldValue(
+                          `options.choices.${index}.ix`,
+                          index
+                        )
+                      }}
                       data={{
                         cy: `move-answer-option-ix-${index}-up`,
                       }}
@@ -142,7 +154,17 @@ function ChoicesOptions({
                     <Button
                       className={{ root: 'px-auto py-0.5' }}
                       disabled={index === values.options.choices.length - 1}
-                      onClick={() => move(index, index + 1)}
+                      onClick={async () => {
+                        move(index, index + 1)
+                        await setFieldValue(
+                          `options.choices.${index + 1}.ix`,
+                          index + 1
+                        )
+                        await setFieldValue(
+                          `options.choices.${index}.ix`,
+                          index
+                        )
+                      }}
                       data={{
                         cy: `move-answer-option-ix-${index}-down`,
                       }}
@@ -208,10 +230,13 @@ function ChoicesOptions({
                             (prev.formik.values.type === ElementType.Sc ||
                               prev.formik.values.type === ElementType.Mc ||
                               prev.formik.values.type === ElementType.Kprim) &&
-                            next?.formik.values.options.choices[index]
+                            (next?.formik.values.options.choices[index]
                               .feedback !==
                               prev?.formik.values.options.choices[index]
-                                .feedback) ||
+                                .feedback ||
+                              next?.formik.values.options.choices[index].ix !==
+                                prev?.formik.values.options.choices[index]
+                                  .ix)) ||
                           next?.formik.values.type !== prev?.formik.values.type
                         }
                       >

--- a/apps/frontend-manage/src/components/questions/manipulation/types.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/types.ts
@@ -12,16 +12,18 @@ interface SharedQuestionFormProps {
   tags?: string[] | null
 }
 
+interface ElementFormTypesChoice {
+  id: string
+  value?: string | null
+  correct?: boolean | null
+  feedback?: string | null
+}
+
 export interface ElementFormTypesChoices extends SharedQuestionFormProps {
   type: ElementType.Sc | ElementType.Mc | ElementType.Kprim
   explanation?: string | null
   options: {
-    choices: {
-      ix: number
-      value?: string | null
-      correct?: boolean | null
-      feedback?: string | null
-    }[]
+    choices: ElementFormTypesChoice[]
     displayMode: ElementDisplayMode
     hasAnswerFeedbacks: boolean
     hasSampleSolution: boolean

--- a/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
@@ -62,12 +62,14 @@ function useElementFormInitialValues({
           hasSampleSolution: options.hasSampleSolution ?? false,
           hasAnswerFeedbacks: options.hasAnswerFeedbacks ?? false,
           displayMode: options.displayMode,
-          choices: options.choices.map((choice) => ({
-            ix: choice.ix,
-            value: choice.value,
-            correct: choice.correct,
-            feedback: choice.feedback,
-          })),
+          choices: options.choices
+            .map((choice) => ({
+              ix: choice.ix,
+              value: choice.value,
+              correct: choice.correct,
+              feedback: choice.feedback,
+            }))
+            .sort((a, b) => (a.ix > b.ix ? 1 : -1)),
         },
       }
     } else if (question.__typename === 'NumericalElement') {

--- a/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
@@ -4,6 +4,7 @@ import {
   ElementStatus,
   ElementType,
 } from '@klicker-uzh/graphql/dist/ops'
+import { nanoid } from 'nanoid'
 import { useMemo } from 'react'
 import { sort } from 'remeda'
 import { ElementEditMode } from './ElementEditModal'
@@ -35,7 +36,12 @@ function useElementFormInitialValues({
           hasAnswerFeedbacks: false,
           displayMode: ElementDisplayMode.List,
           choices: [
-            { ix: 0, value: undefined, correct: false, feedback: undefined },
+            {
+              id: nanoid(),
+              value: undefined,
+              correct: false,
+              feedback: undefined,
+            },
           ],
         },
       }
@@ -65,10 +71,8 @@ function useElementFormInitialValues({
           displayMode: options.displayMode,
           choices: sort(
             options.choices.map((choice) => ({
-              ix: choice.ix,
-              value: choice.value,
-              correct: choice.correct,
-              feedback: choice.feedback,
+              ...choice,
+              id: nanoid(),
             })),
             (a, b) => (a.ix > b.ix ? 1 : -1)
           ),

--- a/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
@@ -5,6 +5,7 @@ import {
   ElementType,
 } from '@klicker-uzh/graphql/dist/ops'
 import { useMemo } from 'react'
+import { sort } from 'remeda'
 import { ElementEditMode } from './ElementEditModal'
 import { ElementFormTypes } from './types'
 
@@ -62,14 +63,15 @@ function useElementFormInitialValues({
           hasSampleSolution: options.hasSampleSolution ?? false,
           hasAnswerFeedbacks: options.hasAnswerFeedbacks ?? false,
           displayMode: options.displayMode,
-          choices: options.choices
-            .map((choice) => ({
+          choices: sort(
+            options.choices.map((choice) => ({
               ix: choice.ix,
               value: choice.value,
               correct: choice.correct,
               feedback: choice.feedback,
-            }))
-            .sort((a, b) => (a.ix > b.ix ? 1 : -1)),
+            })),
+            (a, b) => (a.ix > b.ix ? 1 : -1)
+          ),
         },
       }
     } else if (question.__typename === 'NumericalElement') {

--- a/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
+++ b/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
@@ -84,53 +84,55 @@ function QuestionEvaluation({
                   textSize.text
                 )}
               >
-                {questionData.options.choices.map((choice, innerIndex) => {
-                  const correctFraction =
-                    parseInt(currentInstance.results[innerIndex].count) /
-                    totalParticipants
+                {questionData.options.choices
+                  .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+                  .map((choice, innerIndex) => {
+                    const correctFraction =
+                      parseInt(currentInstance.results[innerIndex].count) /
+                      totalParticipants
 
-                  return (
-                    <div key={`${currentInstance.blockIx}-${innerIndex}`}>
-                      <div className="flex flex-row items-center justify-between leading-5">
-                        <div
-                          // TODO: possibly use single color for answer options to highlight correct one? or some other approach to distinguish better
-                          style={{
-                            backgroundColor: showSolution
-                              ? choice.correct
-                                ? '#00de0d'
-                                : '#ff0000'
-                              : CHART_COLORS[innerIndex % 12],
-                            minWidth: '1.75rem',
-                            width: `calc(${correctFraction * 100}%)`,
-                          }}
-                          className={twMerge(
-                            'mr-2 flex h-5 items-center justify-center rounded-md font-bold text-white',
-                            choice.correct && showSolution && 'text-black'
-                          )}
-                        >
-                          {String.fromCharCode(65 + innerIndex)}
+                    return (
+                      <div key={`${currentInstance.blockIx}-${innerIndex}`}>
+                        <div className="flex flex-row items-center justify-between leading-5">
+                          <div
+                            // TODO: possibly use single color for answer options to highlight correct one? or some other approach to distinguish better
+                            style={{
+                              backgroundColor: showSolution
+                                ? choice.correct
+                                  ? '#00de0d'
+                                  : '#ff0000'
+                                : CHART_COLORS[innerIndex % 12],
+                              minWidth: '1.75rem',
+                              width: `calc(${correctFraction * 100}%)`,
+                            }}
+                            className={twMerge(
+                              'mr-2 flex h-5 items-center justify-center rounded-md font-bold text-white',
+                              choice.correct && showSolution && 'text-black'
+                            )}
+                          >
+                            {String.fromCharCode(65 + innerIndex)}
+                          </div>
+                          <div className="whitespace-nowrap text-right">
+                            {Math.round(100 * correctFraction)} %
+                          </div>
                         </div>
-                        <div className="whitespace-nowrap text-right">
-                          {Math.round(100 * correctFraction)} %
+
+                        <div className="line-clamp-3 w-full">
+                          <Ellipsis
+                            // maxLines={3}
+                            maxLength={60}
+                            className={{
+                              tooltip:
+                                'z-20 float-right min-w-[25rem] !text-white',
+                              markdown: textSize.text,
+                            }}
+                          >
+                            {choice.value}
+                          </Ellipsis>
                         </div>
                       </div>
-
-                      <div className="line-clamp-3 w-full">
-                        <Ellipsis
-                          // maxLines={3}
-                          maxLength={60}
-                          className={{
-                            tooltip:
-                              'z-20 float-right min-w-[25rem] !text-white',
-                            markdown: textSize.text,
-                          }}
-                        >
-                          {choice.value}
-                        </Ellipsis>
-                      </div>
-                    </div>
-                  )
-                })}
+                    )
+                  })}
               </div>
             </div>
           )}

--- a/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
+++ b/apps/frontend-manage/src/components/sessions/evaluation/QuestionEvaluation.tsx
@@ -84,55 +84,53 @@ function QuestionEvaluation({
                   textSize.text
                 )}
               >
-                {questionData.options.choices
-                  .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-                  .map((choice, innerIndex) => {
-                    const correctFraction =
-                      parseInt(currentInstance.results[innerIndex].count) /
-                      totalParticipants
+                {questionData.options.choices.map((choice) => {
+                  const correctFraction =
+                    parseInt(currentInstance.results[choice.ix].count) /
+                    totalParticipants
 
-                    return (
-                      <div key={`${currentInstance.blockIx}-${innerIndex}`}>
-                        <div className="flex flex-row items-center justify-between leading-5">
-                          <div
-                            // TODO: possibly use single color for answer options to highlight correct one? or some other approach to distinguish better
-                            style={{
-                              backgroundColor: showSolution
-                                ? choice.correct
-                                  ? '#00de0d'
-                                  : '#ff0000'
-                                : CHART_COLORS[innerIndex % 12],
-                              minWidth: '1.75rem',
-                              width: `calc(${correctFraction * 100}%)`,
-                            }}
-                            className={twMerge(
-                              'mr-2 flex h-5 items-center justify-center rounded-md font-bold text-white',
-                              choice.correct && showSolution && 'text-black'
-                            )}
-                          >
-                            {String.fromCharCode(65 + innerIndex)}
-                          </div>
-                          <div className="whitespace-nowrap text-right">
-                            {Math.round(100 * correctFraction)} %
-                          </div>
+                  return (
+                    <div key={`${currentInstance.blockIx}-${choice.ix}`}>
+                      <div className="flex flex-row items-center justify-between leading-5">
+                        <div
+                          // TODO: possibly use single color for answer options to highlight correct one? or some other approach to distinguish better
+                          style={{
+                            backgroundColor: showSolution
+                              ? choice.correct
+                                ? '#00de0d'
+                                : '#ff0000'
+                              : CHART_COLORS[choice.ix % 12],
+                            minWidth: '1.75rem',
+                            width: `calc(${correctFraction * 100}%)`,
+                          }}
+                          className={twMerge(
+                            'mr-2 flex h-5 items-center justify-center rounded-md font-bold text-white',
+                            choice.correct && showSolution && 'text-black'
+                          )}
+                        >
+                          {String.fromCharCode(65 + choice.ix)}
                         </div>
-
-                        <div className="line-clamp-3 w-full">
-                          <Ellipsis
-                            // maxLines={3}
-                            maxLength={60}
-                            className={{
-                              tooltip:
-                                'z-20 float-right min-w-[25rem] !text-white',
-                              markdown: textSize.text,
-                            }}
-                          >
-                            {choice.value}
-                          </Ellipsis>
+                        <div className="whitespace-nowrap text-right">
+                          {Math.round(100 * correctFraction)} %
                         </div>
                       </div>
-                    )
-                  })}
+
+                      <div className="line-clamp-3 w-full">
+                        <Ellipsis
+                          // maxLines={3}
+                          maxLength={60}
+                          className={{
+                            tooltip:
+                              'z-20 float-right min-w-[25rem] !text-white',
+                            markdown: textSize.text,
+                          }}
+                        >
+                          {choice.value}
+                        </Ellipsis>
+                      </div>
+                    </div>
+                  )
+                })}
               </div>
             </div>
           )}

--- a/apps/lti/package.json
+++ b/apps/lti/package.json
@@ -32,7 +32,6 @@
     "dev:doppler": "doppler run --config dev -- pnpm run dev:lti",
     "dev:lti": "npm-run-all --parallel dev:build dev:run",
     "dev:run": "nodemon -w dist/ --exec 'node ./dist/index.js'",
-    "dev:test": "cross-env NODE_ENV=test pnpm run dev",
     "start": "node dist/index.js"
   },
   "engines": {

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  // TODO: no watch mode in CI
+  watchForFileChanges: true,
   projectId: 'y436dx',
   env: {
     URL_STUDENT: 'http://127.0.0.1:3001/login',

--- a/cypress/cypress/e2e/D-questions-workflow.cy.ts
+++ b/cypress/cypress/e2e/D-questions-workflow.cy.ts
@@ -39,353 +39,353 @@ describe('Create questions', () => {
     cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
   })
 
-  // it('Create a flashcard element', () => {
-  //   const randomQuestionNumber = uuid()
-  //   const questionTitle = 'A Flashcard ' + randomQuestionNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
+  it('Create a flashcard element', () => {
+    const randomQuestionNumber = uuid()
+    const questionTitle = 'A Flashcard ' + randomQuestionNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.SC.typeLabel)
-  //   cy.get('[data-cy="select-question-type"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-type-${messages.shared.FLASHCARD.typeLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.FLASHCARD.typeLabel)
-  //   cy.get('[data-cy="insert-question-title"]').type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.REVIEW.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="insert-question-explanation"]').realClick().type(question)
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.SC.typeLabel)
+    cy.get('[data-cy="select-question-type"]').click()
+    cy.get(
+      `[data-cy="select-question-type-${messages.shared.FLASHCARD.typeLabel}"]`
+    ).click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.FLASHCARD.typeLabel)
+    cy.get('[data-cy="insert-question-title"]').type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.REVIEW.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="insert-question-explanation"]').realClick().type(question)
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
-  //     messages.shared.REVIEW.statusLabel
-  //   )
-  //   cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
-  // })
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
+      messages.shared.REVIEW.statusLabel
+    )
+    cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
+  })
 
-  // it('Create a single choice question', () => {
-  //   const randomQuestionNumber = uuid()
-  //   const questionTitle = 'A Single Choice ' + randomQuestionNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
+  it('Create a single choice question', () => {
+    const randomQuestionNumber = uuid()
+    const questionTitle = 'A Single Choice ' + randomQuestionNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
 
-  //   const choice1 = '50%'
-  //   const choice2 = '100%'
+    const choice1 = '50%'
+    const choice2 = '100%'
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="insert-question-title"]').type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="insert-answer-field-0"]').realClick().type(choice1)
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
-  //   cy.get('[data-cy="add-new-answer"]').click()
-  //   cy.wait(500)
-  //   cy.get('[data-cy="insert-answer-field-1"]').realClick().type(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-question-title"]').click() // remove editor focus
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="insert-question-title"]').type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="insert-answer-field-0"]').realClick().type(choice1)
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
+    cy.get('[data-cy="add-new-answer"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="insert-answer-field-1"]').realClick().type(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
+    cy.get('[data-cy="insert-question-title"]').click() // remove editor focus
 
-  //   cy.get('[data-cy="move-answer-option-ix-0-up"]').should('be.disabled')
-  //   cy.get('[data-cy="move-answer-option-ix-0-down"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
+    cy.get('[data-cy="move-answer-option-ix-0-up"]').should('be.disabled')
+    cy.get('[data-cy="move-answer-option-ix-0-down"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
 
-  //   cy.get('[data-cy="move-answer-option-ix-1-up"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="move-answer-option-ix-1-down"]').should('be.disabled')
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="move-answer-option-ix-1-up"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="move-answer-option-ix-1-down"]').should('be.disabled')
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
-  //     messages.shared.READY.statusLabel
-  //   )
-  //   cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
-  //   cy.get('[data-cy="sc-1-answer-option-1"]').should('exist')
-  //   cy.get('[data-cy="sc-1-answer-option-2"]').should('exist')
-  // })
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
+      messages.shared.READY.statusLabel
+    )
+    cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
+    cy.get('[data-cy="sc-1-answer-option-1"]').should('exist')
+    cy.get('[data-cy="sc-1-answer-option-2"]').should('exist')
+  })
 
-  // it('Create a multiple choice question', () => {
-  //   const randomQuestionNumber = uuid()
-  //   const questionTitle = 'A Multiple Choice ' + randomQuestionNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
+  it('Create a multiple choice question', () => {
+    const randomQuestionNumber = uuid()
+    const questionTitle = 'A Multiple Choice ' + randomQuestionNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
 
-  //   const choice1 = '50%'
-  //   const choice2 = '100%'
+    const choice1 = '50%'
+    const choice2 = '100%'
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.SC.typeLabel)
-  //   cy.get('[data-cy="select-question-type"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-type-${messages.shared.MC.typeLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.MC.typeLabel)
-  //   cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="insert-answer-field-0"]').realClick().type(choice1)
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
-  //   cy.get('[data-cy="add-new-answer"]').click()
-  //   cy.wait(500)
-  //   cy.get('[data-cy="insert-answer-field-1"]').realClick().type(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-question-title"]').click() // remove editor focus
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.SC.typeLabel)
+    cy.get('[data-cy="select-question-type"]').click()
+    cy.get(
+      `[data-cy="select-question-type-${messages.shared.MC.typeLabel}"]`
+    ).click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.MC.typeLabel)
+    cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="insert-answer-field-0"]').realClick().type(choice1)
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
+    cy.get('[data-cy="add-new-answer"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="insert-answer-field-1"]').realClick().type(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
+    cy.get('[data-cy="insert-question-title"]').click() // remove editor focus
 
-  //   cy.get('[data-cy="move-answer-option-ix-0-up"]').should('be.disabled')
-  //   cy.get('[data-cy="move-answer-option-ix-0-down"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
+    cy.get('[data-cy="move-answer-option-ix-0-up"]').should('be.disabled')
+    cy.get('[data-cy="move-answer-option-ix-0-down"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
 
-  //   cy.get('[data-cy="move-answer-option-ix-1-up"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="move-answer-option-ix-1-down"]').should('be.disabled')
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="move-answer-option-ix-1-up"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="move-answer-option-ix-1-down"]').should('be.disabled')
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
-  //     messages.shared.READY.statusLabel
-  //   )
-  //   cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
-  //   cy.get('[data-cy="mc-1-answer-option-1"]').should('exist')
-  //   cy.get('[data-cy="mc-1-answer-option-2"]').should('exist')
-  // })
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
+      messages.shared.READY.statusLabel
+    )
+    cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
+    cy.get('[data-cy="mc-1-answer-option-1"]').should('exist')
+    cy.get('[data-cy="mc-1-answer-option-2"]').should('exist')
+  })
 
-  // it('Create a KPRIM question', () => {
-  //   const randomQuestionNumber = uuid()
-  //   const questionTitle = 'A KPRIM ' + randomQuestionNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
+  it('Create a KPRIM question', () => {
+    const randomQuestionNumber = uuid()
+    const questionTitle = 'A KPRIM ' + randomQuestionNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
 
-  //   const choice1 = '50%'
-  //   const choice2 = '100%'
-  //   const choice3 = '75%'
-  //   const choice4 = '60%'
+    const choice1 = '50%'
+    const choice2 = '100%'
+    const choice3 = '75%'
+    const choice4 = '60%'
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.SC.typeLabel)
-  //   cy.get('[data-cy="select-question-type"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-type-${messages.shared.KPRIM.typeLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.KPRIM.typeLabel)
-  //   cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="insert-answer-field-0"]').realClick().type(choice1)
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
-  //   cy.get('[data-cy="add-new-answer"]').click()
-  //   cy.wait(500)
-  //   cy.get('[data-cy="insert-answer-field-1"]').realClick().type(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
-  //   cy.get('[data-cy="add-new-answer"]').click()
-  //   cy.wait(500)
-  //   cy.get('[data-cy="insert-answer-field-2"]').realClick().type(choice3)
-  //   cy.get('[data-cy="insert-answer-field-2"]').findByText(choice3)
-  //   cy.get('[data-cy="add-new-answer"]').click()
-  //   cy.wait(500)
-  //   cy.get('[data-cy="insert-answer-field-3"]').realClick().type(choice4)
-  //   cy.get('[data-cy="insert-answer-field-3"]').findByText(choice4)
-  //   cy.get('[data-cy="insert-question-title"]').click() // remove editor focus
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.SC.typeLabel)
+    cy.get('[data-cy="select-question-type"]').click()
+    cy.get(
+      `[data-cy="select-question-type-${messages.shared.KPRIM.typeLabel}"]`
+    ).click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.KPRIM.typeLabel)
+    cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="insert-answer-field-0"]').realClick().type(choice1)
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice1)
+    cy.get('[data-cy="add-new-answer"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="insert-answer-field-1"]').realClick().type(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice2)
+    cy.get('[data-cy="add-new-answer"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="insert-answer-field-2"]').realClick().type(choice3)
+    cy.get('[data-cy="insert-answer-field-2"]').findByText(choice3)
+    cy.get('[data-cy="add-new-answer"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="insert-answer-field-3"]').realClick().type(choice4)
+    cy.get('[data-cy="insert-answer-field-3"]').findByText(choice4)
+    cy.get('[data-cy="insert-question-title"]').click() // remove editor focus
 
-  //   cy.get('[data-cy="move-answer-option-ix-0-up"]').should('be.disabled')
-  //   cy.get('[data-cy="move-answer-option-ix-0-down"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
-  //   cy.get('[data-cy="insert-answer-field-2"]').findByText(choice3)
-  //   cy.get('[data-cy="insert-answer-field-3"]').findByText(choice4)
+    cy.get('[data-cy="move-answer-option-ix-0-up"]').should('be.disabled')
+    cy.get('[data-cy="move-answer-option-ix-0-down"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
+    cy.get('[data-cy="insert-answer-field-2"]').findByText(choice3)
+    cy.get('[data-cy="insert-answer-field-3"]').findByText(choice4)
 
-  //   cy.get('[data-cy="move-answer-option-ix-3-up"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="move-answer-option-ix-3-down"]').should('be.disabled')
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
-  //   cy.get('[data-cy="insert-answer-field-2"]').findByText(choice4)
-  //   cy.get('[data-cy="insert-answer-field-3"]').findByText(choice3)
+    cy.get('[data-cy="move-answer-option-ix-3-up"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="move-answer-option-ix-3-down"]').should('be.disabled')
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice1)
+    cy.get('[data-cy="insert-answer-field-2"]').findByText(choice4)
+    cy.get('[data-cy="insert-answer-field-3"]').findByText(choice3)
 
-  //   cy.get('[data-cy="move-answer-option-ix-2-up"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice4)
-  //   cy.get('[data-cy="insert-answer-field-2"]').findByText(choice1)
-  //   cy.get('[data-cy="insert-answer-field-3"]').findByText(choice3)
+    cy.get('[data-cy="move-answer-option-ix-2-up"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice4)
+    cy.get('[data-cy="insert-answer-field-2"]').findByText(choice1)
+    cy.get('[data-cy="insert-answer-field-3"]').findByText(choice3)
 
-  //   cy.get('[data-cy="move-answer-option-ix-2-down"]')
-  //     .should('not.be.disabled')
-  //     .click()
-  //   cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
-  //   cy.get('[data-cy="insert-answer-field-1"]').findByText(choice4)
-  //   cy.get('[data-cy="insert-answer-field-2"]').findByText(choice3)
-  //   cy.get('[data-cy="insert-answer-field-3"]').findByText(choice1)
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="move-answer-option-ix-2-down"]')
+      .should('not.be.disabled')
+      .click()
+    cy.get('[data-cy="insert-answer-field-0"]').findByText(choice2)
+    cy.get('[data-cy="insert-answer-field-1"]').findByText(choice4)
+    cy.get('[data-cy="insert-answer-field-2"]').findByText(choice3)
+    cy.get('[data-cy="insert-answer-field-3"]').findByText(choice1)
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
-  //     messages.shared.READY.statusLabel
-  //   )
-  //   cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
-  //   cy.get('[data-cy="kp-answer-options"]').should('have.length', 4)
-  // })
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
+      messages.shared.READY.statusLabel
+    )
+    cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
+    cy.get('[data-cy="kp-answer-options"]').should('have.length', 4)
+  })
 
-  // it('Create a Numeric question', () => {
-  //   const randomQuestionNumber = uuid()
-  //   const questionTitle = 'A Numeric ' + randomQuestionNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
+  it('Create a Numeric question', () => {
+    const randomQuestionNumber = uuid()
+    const questionTitle = 'A Numeric ' + randomQuestionNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.SC.typeLabel)
-  //   cy.get('[data-cy="select-question-type"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-type-${messages.shared.NUMERICAL.typeLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.NUMERICAL.typeLabel)
-  //   cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="set-numerical-minimum"]').click().type('0')
-  //   cy.get('[data-cy="set-numerical-maximum"]').click().type('100')
-  //   cy.get('[data-cy="set-numerical-unit"]').click().type('%')
-  //   cy.get('[data-cy="set-numerical-accuracy"]').click().type('0')
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.SC.typeLabel)
+    cy.get('[data-cy="select-question-type"]').click()
+    cy.get(
+      `[data-cy="select-question-type-${messages.shared.NUMERICAL.typeLabel}"]`
+    ).click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.NUMERICAL.typeLabel)
+    cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="set-numerical-minimum"]').click().type('0')
+    cy.get('[data-cy="set-numerical-maximum"]').click().type('100')
+    cy.get('[data-cy="set-numerical-unit"]').click().type('%')
+    cy.get('[data-cy="set-numerical-accuracy"]').click().type('0')
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
-  //     messages.shared.READY.statusLabel
-  //   )
-  //   cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
-  //   cy.get('[data-cy="input-numerical-minimum"]').contains('Min: 0')
-  //   cy.get('[data-cy="input-numerical-maximum"]').contains('Max: 100')
-  //   cy.get('[data-cy="input-numerical-accuracy"]').contains('Precision: 0')
-  //   cy.get('[data-cy="input-numerical-unit"]').contains('%')
-  // })
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
+      messages.shared.READY.statusLabel
+    )
+    cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
+    cy.get('[data-cy="input-numerical-minimum"]').contains('Min: 0')
+    cy.get('[data-cy="input-numerical-maximum"]').contains('Max: 100')
+    cy.get('[data-cy="input-numerical-accuracy"]').contains('Precision: 0')
+    cy.get('[data-cy="input-numerical-unit"]').contains('%')
+  })
 
-  // it('Create a Free Text question', () => {
-  //   const randomQuestionNumber = uuid()
-  //   const questionTitle = 'A Free Text ' + randomQuestionNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
+  it('Create a Free Text question', () => {
+    const randomQuestionNumber = uuid()
+    const questionTitle = 'A Free Text ' + randomQuestionNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.SC.typeLabel)
-  //   cy.get('[data-cy="select-question-type"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-type-${messages.shared.FREE_TEXT.typeLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="select-question-type"]')
-  //     .should('exist')
-  //     .contains(messages.shared.FREE_TEXT.typeLabel)
-  //   cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="set-free-text-length"]').click().type('100')
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.SC.typeLabel)
+    cy.get('[data-cy="select-question-type"]').click()
+    cy.get(
+      `[data-cy="select-question-type-${messages.shared.FREE_TEXT.typeLabel}"]`
+    ).click()
+    cy.get('[data-cy="select-question-type"]')
+      .should('exist')
+      .contains(messages.shared.FREE_TEXT.typeLabel)
+    cy.get('[data-cy="insert-question-title"]').click().type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.READY.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="set-free-text-length"]').click().type('100')
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
-  //     messages.shared.READY.statusLabel
-  //   )
-  //   cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
-  //   cy.get('[data-cy="free-text-input-1"]').should('exist')
-  // })
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(question)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(questionTitle)
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).contains(
+      messages.shared.READY.statusLabel
+    )
+    cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
+    cy.get('[data-cy="free-text-input-1"]').should('exist')
+  })
 
-  // it('Create a new question, duplicates it and then deletes the duplicate again', () => {
-  //   const randomNumber = uuid()
-  //   const questionTitle = 'A Single Choice ' + randomNumber
-  //   const question = 'Was ist die Wahrscheinlichkeit? ' + randomNumber
+  it('Create a new question, duplicates it and then deletes the duplicate again', () => {
+    const randomNumber = uuid()
+    const questionTitle = 'A Single Choice ' + randomNumber
+    const question = 'Was ist die Wahrscheinlichkeit? ' + randomNumber
 
-  //   cy.get('[data-cy="create-question"]').click()
-  //   cy.get('[data-cy="insert-question-title"]').type(questionTitle)
-  //   cy.get('[data-cy="select-question-status"]').click()
-  //   cy.get(
-  //     `[data-cy="select-question-status-${messages.shared.DRAFT.statusLabel}"]`
-  //   ).click()
-  //   cy.get('[data-cy="insert-question-text"]').realClick().type(question)
-  //   cy.get('[data-cy="insert-answer-field-0"]').realClick().type('50%')
-  //   cy.get('[data-cy="add-new-answer"]').click()
-  //   cy.wait(500)
-  //   cy.get('[data-cy="insert-answer-field-1"]').realClick().type('100%')
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    cy.get('[data-cy="create-question"]').click()
+    cy.get('[data-cy="insert-question-title"]').type(questionTitle)
+    cy.get('[data-cy="select-question-status"]').click()
+    cy.get(
+      `[data-cy="select-question-status-${messages.shared.DRAFT.statusLabel}"]`
+    ).click()
+    cy.get('[data-cy="insert-question-text"]').realClick().type(question)
+    cy.get('[data-cy="insert-answer-field-0"]').realClick().type('50%')
+    cy.get('[data-cy="add-new-answer"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="insert-answer-field-1"]').realClick().type('100%')
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   // duplicate question and save
-  //   cy.get(`[data-cy="duplicate-question-${questionTitle}"]`).click()
-  //   cy.wait(500)
-  //   cy.findByText(messages.manage.questionForms.DUPLICATETitle).should('exist')
-  //   cy.get('[data-cy="save-new-question"]').click({ force: true })
-  //   cy.wait(500)
+    // duplicate question and save
+    cy.get(`[data-cy="duplicate-question-${questionTitle}"]`).click()
+    cy.wait(500)
+    cy.findByText(messages.manage.questionForms.DUPLICATETitle).should('exist')
+    cy.get('[data-cy="save-new-question"]').click({ force: true })
+    cy.wait(500)
 
-  //   // check if duplicated question exists alongside original question
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).should('exist')
-  //   cy.get(`[data-cy="question-item-${questionTitle + ' (Copy)'}"]`).should(
-  //     'exist'
-  //   )
-  //   cy.get(`[data-cy="question-item-${questionTitle + ' (Copy)'}"]`).contains(
-  //     messages.shared.DRAFT.statusLabel
-  //   )
+    // check if duplicated question exists alongside original question
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).should('exist')
+    cy.get(`[data-cy="question-item-${questionTitle + ' (Copy)'}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="question-item-${questionTitle + ' (Copy)'}"]`).contains(
+      messages.shared.DRAFT.statusLabel
+    )
 
-  //   // delete the duplicated question
-  //   cy.get(`[data-cy="delete-question-${questionTitle} (Copy)"]`).click()
-  //   cy.get('[data-cy="confirm-question-deletion"]').click()
-  //   cy.get(`[data-cy="question-item-${questionTitle}"]`).should('exist')
-  //   cy.get(`[data-cy="question-item-${questionTitle + ' (Copy)'}"]`).should(
-  //     'not.exist'
-  //   )
-  // })
+    // delete the duplicated question
+    cy.get(`[data-cy="delete-question-${questionTitle} (Copy)"]`).click()
+    cy.get('[data-cy="confirm-question-deletion"]').click()
+    cy.get(`[data-cy="question-item-${questionTitle}"]`).should('exist')
+    cy.get(`[data-cy="question-item-${questionTitle + ' (Copy)'}"]`).should(
+      'not.exist'
+    )
+  })
 })

--- a/cypress/cypress/e2e/D-questions-workflow.cy.ts
+++ b/cypress/cypress/e2e/D-questions-workflow.cy.ts
@@ -73,7 +73,7 @@ describe('Create questions', () => {
     cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
   })
 
-  it.only('Create a single choice question', () => {
+  it('Create a single choice question', () => {
     const randomQuestionNumber = uuid()
     const questionTitle = 'A Single Choice ' + randomQuestionNumber
     const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber

--- a/cypress/cypress/e2e/D-questions-workflow.cy.ts
+++ b/cypress/cypress/e2e/D-questions-workflow.cy.ts
@@ -73,7 +73,7 @@ describe('Create questions', () => {
     cy.get(`[data-cy="edit-question-${questionTitle}"]`).click()
   })
 
-  it('Create a single choice question', () => {
+  it.only('Create a single choice question', () => {
     const randomQuestionNumber = uuid()
     const questionTitle = 'A Single Choice ' + randomQuestionNumber
     const question = 'Was ist die Wahrscheinlichkeit? ' + randomQuestionNumber

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "test": "cypress open",
-    "test:run": "cypress run"
+    "test:run": "cypress run",
+    "test:watch": "cypress open --watch"
   },
   "engines": {
     "node": "=20"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dev:lti": "doppler run --config dev_lti -- turbo run dev:lti",
     "dev:migration": "doppler run --config dev -- turbo run dev:migration",
     "dev:offline": "doppler run --config dev -- turbo run dev:offline --concurrency 30",
-    "dev:test": "cross-env NODE_ENV=test turbo run dev:test",
+    "dev:test": "doppler run --config dev_cypress -- cross-env NODE_ENV=test turbo run dev:test",
     "format": "prettier --write . --config .prettierrc.mjs",
     "format:check": "prettier --check . --config .prettierrc.mjs",
     "lint": "turbo run lint --parallel --continue",
@@ -83,7 +83,8 @@
     "syncpack:mismatches:fix": "syncpack fix-mismatches",
     "syncpack:update": "syncpack update",
     "test": "turbo run test",
-    "test:run": "turbo run test:run"
+    "test:run": "turbo run test:run",
+    "test:watch": "run-p test dev:test"
   },
   "engines": {
     "node": "=20"

--- a/packages/graphql/src/lib/questions.ts
+++ b/packages/graphql/src/lib/questions.ts
@@ -9,7 +9,7 @@ export function prepareInitialQuestionInstanceResults(
     case ElementType.MC:
     case ElementType.KPRIM: {
       const choices = questionData.options.choices.reduce(
-        (acc, _, ix) => ({ ...acc, [ix]: 0 }),
+        (acc, choice) => ({ ...acc, [choice.ix]: 0 }),
         {}
       )
       return { choices, total: 0 }

--- a/packages/graphql/src/scripts/2024_10_29_fix_choices_options.ts
+++ b/packages/graphql/src/scripts/2024_10_29_fix_choices_options.ts
@@ -92,6 +92,33 @@ async function run() {
               )} with ${ei.responses.length} responses and ${ei.detailResponses.length} detail responses`
           )
         }
+
+        // if no sample solution has been specified, simply fix the indices
+        if (choices.every((c) => c.correct === false)) {
+          const newChoices = choices.map((c, index) => ({
+            ...c,
+            ix: index,
+          }))
+
+          console.log('OLD CHOICES:')
+          console.log(choices)
+          console.log('NEW CHOICES:')
+          console.log(newChoices)
+
+          // TODO: uncomment to trigger element instance updates
+          // await prisma.elementInstance.update({
+          //   where: { id: ei.id },
+          //   data: {
+          //     elementData: {
+          //       ...ei.elementData,
+          //       options: {
+          //         ...ei.elementData.options,
+          //         choices: newChoices,
+          //       },
+          //     },
+          //   },
+          // })
+        }
       }
     }
   }
@@ -115,6 +142,33 @@ async function run() {
               .map((c) => c.ix)
               .join(', ')}`
           )
+        }
+
+        // if no sample solution has been specified, simply fix the indices
+        if (choices.every((c) => c.correct === false)) {
+          const newChoices = choices.map((c, index) => ({
+            ...c,
+            ix: index,
+          }))
+
+          console.log('OLD CHOICES:')
+          console.log(choices)
+          console.log('NEW CHOICES:')
+          console.log(newChoices)
+
+          // TODO: uncomment to trigger question instance updates
+          // await prisma.questionInstance.update({
+          //   where: { id: qi.id },
+          //   data: {
+          //     questionData: {
+          //       ...qi.questionData,
+          //       options: {
+          //         ...qi.questionData.options,
+          //         choices: newChoices,
+          //       },
+          //     },
+          //   },
+          // })
         }
       }
     }

--- a/packages/graphql/src/scripts/2024_10_29_fix_choices_options.ts
+++ b/packages/graphql/src/scripts/2024_10_29_fix_choices_options.ts
@@ -18,6 +18,7 @@ async function run() {
 
   // loop over all elements, filter for choices questions and check if choices are in order
   let e_errors = 0
+  let e_updates = 0
   for (const e of es) {
     if (
       (e.type === ElementType.SC ||
@@ -51,6 +52,7 @@ async function run() {
         console.log(choices)
         console.log('NEW CHOICES:')
         console.log(newChoices)
+        e_updates += 1
 
         // TODO: uncomment to trigger element updates
         // await prisma.element.update({
@@ -68,6 +70,7 @@ async function run() {
 
   // loop over all element instances, filter for choices instances, check if choices are in order
   let ei_errors = 0
+  let ei_updates = 0
   for (const ei of eis) {
     if (
       (ei.elementType === ElementType.SC ||
@@ -104,6 +107,7 @@ async function run() {
           console.log(choices)
           console.log('NEW CHOICES:')
           console.log(newChoices)
+          ei_updates += 1
 
           // TODO: uncomment to trigger element instance updates
           // await prisma.elementInstance.update({
@@ -124,6 +128,7 @@ async function run() {
   }
 
   let qi_errors = 0
+  let qi_updates = 0
   for (const qi of qis) {
     if (
       qi.questionData.type === ElementType.SC ||
@@ -155,6 +160,7 @@ async function run() {
           console.log(choices)
           console.log('NEW CHOICES:')
           console.log(newChoices)
+          qi_updates += 1
 
           // TODO: uncomment to trigger question instance updates
           // await prisma.questionInstance.update({
@@ -182,6 +188,10 @@ async function run() {
     qi_errors,
     'question instances with out of order choices'
   )
+
+  console.log('Updated', e_updates, 'elements')
+  console.log('Updated', ei_updates, 'element instances')
+  console.log('Updated', qi_updates, 'question instances')
 }
 
 await run()

--- a/packages/graphql/src/scripts/2024_10_29_fix_choices_options.ts
+++ b/packages/graphql/src/scripts/2024_10_29_fix_choices_options.ts
@@ -1,0 +1,133 @@
+import { ElementType, PrismaClient } from '@klicker-uzh/prisma'
+
+async function run() {
+  const prisma = new PrismaClient()
+  const verbose = false // verbose logging setting
+
+  // ! VALIDATION
+  // fetch all elements
+  const es = await prisma.element.findMany()
+
+  // fetch all element instances
+  const eis = await prisma.elementInstance.findMany({
+    include: { responses: true, detailResponses: true },
+  })
+
+  // fetch all question instances
+  const qis = await prisma.questionInstance.findMany()
+
+  // loop over all elements, filter for choices questions and check if choices are in order
+  let e_errors = 0
+  for (const e of es) {
+    if (
+      (e.type === ElementType.SC ||
+        e.type === ElementType.MC ||
+        e.type === ElementType.KPRIM) &&
+      (e.type === ElementType.SC ||
+        e.type === ElementType.MC ||
+        e.type === ElementType.KPRIM)
+    ) {
+      const choices = e.options.choices
+
+      // check if choices are in order with ix attribute
+      if (choices.some((c, index) => c.ix !== index)) {
+        e_errors += 1
+
+        if (verbose) {
+          console.error(
+            `Element ${e.id} has choices out of order: ${choices
+              .map((c) => c.ix)
+              .join(', ')}`
+          )
+        }
+
+        // update the element choices
+        const newChoices = choices.map((c, index) => ({
+          ...c,
+          ix: index,
+        }))
+
+        console.log('OLD CHOICES:')
+        console.log(choices)
+        console.log('NEW CHOICES:')
+        console.log(newChoices)
+
+        // TODO: uncomment to trigger element updates
+        // await prisma.element.update({
+        //   where: { id: e.id },
+        //   data: {
+        //     options: {
+        //       ...e.options,
+        //       choices: newChoices,
+        //     },
+        //   },
+        // })
+      }
+    }
+  }
+
+  // loop over all element instances, filter for choices instances, check if choices are in order
+  let ei_errors = 0
+  for (const ei of eis) {
+    if (
+      (ei.elementType === ElementType.SC ||
+        ei.elementType === ElementType.MC ||
+        ei.elementType === ElementType.KPRIM) &&
+      (ei.elementData.type === ElementType.SC ||
+        ei.elementData.type === ElementType.MC ||
+        ei.elementData.type === ElementType.KPRIM)
+    ) {
+      const choices = ei.elementData.options.choices
+
+      // check if choices are in order with ix attribute
+      if (choices.some((c, index) => c.ix !== index)) {
+        ei_errors += 1
+
+        if (verbose) {
+          console.error(
+            `ElementInstance ${ei.id} has choices out of order: ${choices
+              .map((c) => c.ix)
+              .join(
+                ', '
+              )} with ${ei.responses.length} responses and ${ei.detailResponses.length} detail responses`
+          )
+        }
+      }
+    }
+  }
+
+  let qi_errors = 0
+  for (const qi of qis) {
+    if (
+      qi.questionData.type === ElementType.SC ||
+      qi.questionData.type === ElementType.MC ||
+      qi.questionData.type === ElementType.KPRIM
+    ) {
+      const choices = qi.questionData.options.choices
+
+      // check if choices are in order with ix attribute
+      if (choices.some((c, index) => c.ix !== index)) {
+        qi_errors += 1
+
+        if (verbose) {
+          console.error(
+            `QuestionInstance ${qi.id} has choices out of order: ${choices
+              .map((c) => c.ix)
+              .join(', ')}`
+          )
+        }
+      }
+    }
+  }
+
+  console.log('Done checking choices')
+  console.log('Found', e_errors, 'elements with out of order choices')
+  console.log('Found', ei_errors, 'element instances with out of order choices')
+  console.log(
+    'Found',
+    qi_errors,
+    'question instances with out of order choices'
+  )
+}
+
+await run()

--- a/packages/graphql/src/scripts/2024_10_31_fix_choices_options.ts
+++ b/packages/graphql/src/scripts/2024_10_31_fix_choices_options.ts
@@ -96,33 +96,31 @@ async function run() {
           )
         }
 
-        // if no sample solution has been specified, simply fix the indices
-        if (choices.every((c) => c.correct === false)) {
-          const newChoices = choices.map((c, index) => ({
-            ...c,
-            ix: index,
-          }))
+        // update the indices on the element instances
+        const newChoices = choices.map((c, index) => ({
+          ...c,
+          ix: index,
+        }))
 
-          console.log('OLD CHOICES:')
-          console.log(choices)
-          console.log('NEW CHOICES:')
-          console.log(newChoices)
-          ei_updates += 1
+        console.log('OLD CHOICES:')
+        console.log(choices)
+        console.log('NEW CHOICES:')
+        console.log(newChoices)
+        ei_updates += 1
 
-          // TODO: uncomment to trigger element instance updates
-          // await prisma.elementInstance.update({
-          //   where: { id: ei.id },
-          //   data: {
-          //     elementData: {
-          //       ...ei.elementData,
-          //       options: {
-          //         ...ei.elementData.options,
-          //         choices: newChoices,
-          //       },
-          //     },
-          //   },
-          // })
-        }
+        // TODO: uncomment to trigger element instance updates
+        // await prisma.elementInstance.update({
+        //   where: { id: ei.id },
+        //   data: {
+        //     elementData: {
+        //       ...ei.elementData,
+        //       options: {
+        //         ...ei.elementData.options,
+        //         choices: newChoices,
+        //       },
+        //     },
+        //   },
+        // })
       }
     }
   }
@@ -149,33 +147,31 @@ async function run() {
           )
         }
 
-        // if no sample solution has been specified, simply fix the indices
-        if (choices.every((c) => c.correct === false)) {
-          const newChoices = choices.map((c, index) => ({
-            ...c,
-            ix: index,
-          }))
+        // update the indices on the question instances
+        const newChoices = choices.map((c, index) => ({
+          ...c,
+          ix: index,
+        }))
 
-          console.log('OLD CHOICES:')
-          console.log(choices)
-          console.log('NEW CHOICES:')
-          console.log(newChoices)
-          qi_updates += 1
+        console.log('OLD CHOICES:')
+        console.log(choices)
+        console.log('NEW CHOICES:')
+        console.log(newChoices)
+        qi_updates += 1
 
-          // TODO: uncomment to trigger question instance updates
-          // await prisma.questionInstance.update({
-          //   where: { id: qi.id },
-          //   data: {
-          //     questionData: {
-          //       ...qi.questionData,
-          //       options: {
-          //         ...qi.questionData.options,
-          //         choices: newChoices,
-          //       },
-          //     },
-          //   },
-          // })
-        }
+        // TODO: uncomment to trigger question instance updates
+        // await prisma.questionInstance.update({
+        //   where: { id: qi.id },
+        //   data: {
+        //     questionData: {
+        //       ...qi.questionData,
+        //       options: {
+        //         ...qi.questionData.options,
+        //         choices: newChoices,
+        //       },
+        //     },
+        //   },
+        // })
       }
     }
   }

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -1341,7 +1341,9 @@ function evaluateElementResponse(
       // )
 
       const elementOptions = elementData.options
-      const feedbacks = elementOptions.choices
+      const feedbacks = elementOptions.choices.sort((a, b) =>
+        a.ix > b.ix ? 1 : -1
+      )
 
       if (elementData.type === ElementType.SC) {
         return {

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -1341,9 +1341,7 @@ function evaluateElementResponse(
       // )
 
       const elementOptions = elementData.options
-      const feedbacks = elementOptions.choices.sort((a, b) =>
-        a.ix > b.ix ? 1 : -1
-      )
+      const feedbacks = elementOptions.choices
 
       if (elementData.type === ElementType.SC) {
         return {

--- a/packages/graphql/src/services/sessions.ts
+++ b/packages/graphql/src/services/sessions.ts
@@ -881,7 +881,6 @@ export async function activateSessionBlock(
           choiceCount: questionData.options.choices.length,
           solutions: JSON.stringify(
             questionData.options.choices
-              .map((choice, ix) => ({ ix, correct: choice.correct }))
               .filter((choice) => choice.correct)
               .map((choice) => choice.ix)
           ),

--- a/packages/shared-components/src/hooks/useStudentResponse.ts
+++ b/packages/shared-components/src/hooks/useStudentResponse.ts
@@ -25,8 +25,8 @@ function useStudentResponse({
             [element.id]: {
               type: element.elementData.type as ElementChoicesType,
               response: element.elementData.options.choices.reduce(
-                (acc, _, ix) => {
-                  return { ...acc, [ix]: undefined }
+                (acc, choice) => {
+                  return { ...acc, [choice.ix]: undefined }
                 },
                 {} as Record<number, boolean | undefined>
               ),

--- a/packages/shared-components/src/questions/KPAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/KPAnswerOptions.tsx
@@ -40,73 +40,71 @@ export function KPAnswerOptions({
           : 'flex flex-col'
       )}
     >
-      {choices
-        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-        .map((choice) => (
-          <div key={`kp-choice-${choice.ix}-${choice.value}`}>
-            <div
-              className={twMerge(
-                'flex flex-row items-center justify-between gap-4 rounded border p-2',
-                !hideFeedbacks &&
-                  feedbacks &&
-                  feedbacks[choice.ix] &&
-                  '!rounded-b-none'
-              )}
-              data-cy="kp-answer-options"
-            >
-              <div>
-                <Markdown
-                  withProse
-                  content={choice.value}
-                  className={{
-                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                  }}
-                />
-              </div>
-              <div className="flex flex-row gap-2">
-                <Button
-                  className={{
-                    root: twMerge(
-                      'hover:bg-unset min-h-[2.5rem] border-slate-400'
-                    ),
-                  }}
-                  active={value?.[choice.ix] === true}
-                  onClick={() => onChange({ ...value, [choice.ix]: true })}
-                  data={{
-                    cy: `toggle-kp-${elementIx + 1}-answer-${choice.ix + 1}-correct`,
-                  }}
-                  disabled={disabled}
-                >
-                  <Button.Icon>
-                    <FontAwesomeIcon icon={faCheck} />
-                  </Button.Icon>
-                </Button>
-                <Button
-                  className={{
-                    root: twMerge(
-                      'hover:bg-unset min-h-[2.5rem] border-slate-400'
-                    ),
-                  }}
-                  active={value?.[choice.ix] === false}
-                  onClick={() => onChange({ ...value, [choice.ix]: false })}
-                  data={{
-                    cy: `toggle-kp-${elementIx + 1}-answer-${
-                      choice.ix + 1
-                    }-incorrect`,
-                  }}
-                  disabled={disabled}
-                >
-                  <Button.Icon>
-                    <FontAwesomeIcon icon={faX} />
-                  </Button.Icon>
-                </Button>
-              </div>
-            </div>
-            {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
-              <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
+      {choices.map((choice) => (
+        <div key={`kp-choice-${choice.ix}-${choice.value}`}>
+          <div
+            className={twMerge(
+              'flex flex-row items-center justify-between gap-4 rounded border p-2',
+              !hideFeedbacks &&
+                feedbacks &&
+                feedbacks[choice.ix] &&
+                '!rounded-b-none'
             )}
+            data-cy="kp-answer-options"
+          >
+            <div>
+              <Markdown
+                withProse
+                content={choice.value}
+                className={{
+                  root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                }}
+              />
+            </div>
+            <div className="flex flex-row gap-2">
+              <Button
+                className={{
+                  root: twMerge(
+                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
+                  ),
+                }}
+                active={value?.[choice.ix] === true}
+                onClick={() => onChange({ ...value, [choice.ix]: true })}
+                data={{
+                  cy: `toggle-kp-${elementIx + 1}-answer-${choice.ix + 1}-correct`,
+                }}
+                disabled={disabled}
+              >
+                <Button.Icon>
+                  <FontAwesomeIcon icon={faCheck} />
+                </Button.Icon>
+              </Button>
+              <Button
+                className={{
+                  root: twMerge(
+                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
+                  ),
+                }}
+                active={value?.[choice.ix] === false}
+                onClick={() => onChange({ ...value, [choice.ix]: false })}
+                data={{
+                  cy: `toggle-kp-${elementIx + 1}-answer-${
+                    choice.ix + 1
+                  }-incorrect`,
+                }}
+                disabled={disabled}
+              >
+                <Button.Icon>
+                  <FontAwesomeIcon icon={faX} />
+                </Button.Icon>
+              </Button>
+            </div>
           </div>
-        ))}
+          {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
+            <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
+          )}
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/KPAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/KPAnswerOptions.tsx
@@ -11,7 +11,7 @@ import ChoiceFeedback from '../evaluation/ChoiceFeedback'
 export interface KPAnswerOptionsProps {
   displayMode?: ElementDisplayMode
   type: ElementType
-  choices: Partial<Choice>[]
+  choices: Choice[]
   feedbacks?: QuestionFeedback[] | null
   value?: Record<number, boolean>
   onChange: (newValue: Record<number, boolean>) => void
@@ -40,71 +40,73 @@ export function KPAnswerOptions({
           : 'flex flex-col'
       )}
     >
-      {choices.map((choice, index) => (
-        <div key={`kp-choice-${index}-${choice.value}`}>
-          <div
-            className={twMerge(
-              'flex flex-row items-center justify-between gap-4 rounded border p-2',
-              !hideFeedbacks &&
-                feedbacks &&
-                feedbacks[index] &&
-                '!rounded-b-none'
+      {choices
+        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+        .map((choice) => (
+          <div key={`kp-choice-${choice.ix}-${choice.value}`}>
+            <div
+              className={twMerge(
+                'flex flex-row items-center justify-between gap-4 rounded border p-2',
+                !hideFeedbacks &&
+                  feedbacks &&
+                  feedbacks[choice.ix] &&
+                  '!rounded-b-none'
+              )}
+              data-cy="kp-answer-options"
+            >
+              <div>
+                <Markdown
+                  withProse
+                  content={choice.value}
+                  className={{
+                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                  }}
+                />
+              </div>
+              <div className="flex flex-row gap-2">
+                <Button
+                  className={{
+                    root: twMerge(
+                      'hover:bg-unset min-h-[2.5rem] border-slate-400'
+                    ),
+                  }}
+                  active={value?.[choice.ix] === true}
+                  onClick={() => onChange({ ...value, [choice.ix]: true })}
+                  data={{
+                    cy: `toggle-kp-${elementIx + 1}-answer-${choice.ix + 1}-correct`,
+                  }}
+                  disabled={disabled}
+                >
+                  <Button.Icon>
+                    <FontAwesomeIcon icon={faCheck} />
+                  </Button.Icon>
+                </Button>
+                <Button
+                  className={{
+                    root: twMerge(
+                      'hover:bg-unset min-h-[2.5rem] border-slate-400'
+                    ),
+                  }}
+                  active={value?.[choice.ix] === false}
+                  onClick={() => onChange({ ...value, [choice.ix]: false })}
+                  data={{
+                    cy: `toggle-kp-${elementIx + 1}-answer-${
+                      choice.ix + 1
+                    }-incorrect`,
+                  }}
+                  disabled={disabled}
+                >
+                  <Button.Icon>
+                    <FontAwesomeIcon icon={faX} />
+                  </Button.Icon>
+                </Button>
+              </div>
+            </div>
+            {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
+              <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
             )}
-            data-cy="kp-answer-options"
-          >
-            <div>
-              <Markdown
-                withProse
-                content={choice.value}
-                className={{
-                  root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                }}
-              />
-            </div>
-            <div className="flex flex-row gap-2">
-              <Button
-                className={{
-                  root: twMerge(
-                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
-                  ),
-                }}
-                active={value?.[index] === true}
-                onClick={() => onChange({ ...value, [index]: true })}
-                data={{
-                  cy: `toggle-kp-${elementIx + 1}-answer-${index + 1}-correct`,
-                }}
-                disabled={disabled}
-              >
-                <Button.Icon>
-                  <FontAwesomeIcon icon={faCheck} />
-                </Button.Icon>
-              </Button>
-              <Button
-                className={{
-                  root: twMerge(
-                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
-                  ),
-                }}
-                active={value?.[index] === false}
-                onClick={() => onChange({ ...value, [index]: false })}
-                data={{
-                  cy: `toggle-kp-${elementIx + 1}-answer-${
-                    index + 1
-                  }-incorrect`,
-                }}
-                disabled={disabled}
-              >
-                <Button.Icon>
-                  <FontAwesomeIcon icon={faX} />
-                </Button.Icon>
-              </Button>
-            </div>
           </div>
-          {!hideFeedbacks && feedbacks && feedbacks[index] && (
-            <ChoiceFeedback feedback={feedbacks[index]!} />
-          )}
-        </div>
-      ))}
+        ))}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/KPAnswerOptionsOLD.tsx
+++ b/packages/shared-components/src/questions/KPAnswerOptionsOLD.tsx
@@ -31,54 +31,48 @@ export function KPAnswerOptionsOLD({
           : 'flex flex-col'
       )}
     >
-      {choices
-        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-        .map((choice) => (
-          <div
-            className="flex flex-row items-center justify-between gap-4 border p-2"
-            data-cy="kp-answer-options"
-          >
-            <div>
-              <Markdown
-                withProse
-                content={choice.value}
-                className={{
-                  root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                }}
-              />
-            </div>
-            <div className="flex flex-row gap-2">
-              <Button
-                className={{
-                  root: twMerge(
-                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
-                  ),
-                }}
-                active={value?.[choice.ix] === true}
-                onClick={onChange(choice.ix, true)}
-                data={{ cy: `toggle-kp-answer-${choice.ix}-correct` }}
-              >
-                <Button.Icon>
-                  <FontAwesomeIcon icon={faCheck} />
-                </Button.Icon>
-              </Button>
-              <Button
-                className={{
-                  root: twMerge(
-                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
-                  ),
-                }}
-                active={value?.[choice.ix] === false}
-                onClick={onChange(choice.ix, false)}
-                data={{ cy: `toggle-kp-answer-${choice.ix}-incorrect` }}
-              >
-                <Button.Icon>
-                  <FontAwesomeIcon icon={faX} />
-                </Button.Icon>
-              </Button>
-            </div>
+      {choices.map((choice) => (
+        <div
+          className="flex flex-row items-center justify-between gap-4 border p-2"
+          data-cy="kp-answer-options"
+        >
+          <div>
+            <Markdown
+              withProse
+              content={choice.value}
+              className={{
+                root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+              }}
+            />
           </div>
-        ))}
+          <div className="flex flex-row gap-2">
+            <Button
+              className={{
+                root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
+              }}
+              active={value?.[choice.ix] === true}
+              onClick={onChange(choice.ix, true)}
+              data={{ cy: `toggle-kp-answer-${choice.ix}-correct` }}
+            >
+              <Button.Icon>
+                <FontAwesomeIcon icon={faCheck} />
+              </Button.Icon>
+            </Button>
+            <Button
+              className={{
+                root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
+              }}
+              active={value?.[choice.ix] === false}
+              onClick={onChange(choice.ix, false)}
+              data={{ cy: `toggle-kp-answer-${choice.ix}-incorrect` }}
+            >
+              <Button.Icon>
+                <FontAwesomeIcon icon={faX} />
+              </Button.Icon>
+            </Button>
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/KPAnswerOptionsOLD.tsx
+++ b/packages/shared-components/src/questions/KPAnswerOptionsOLD.tsx
@@ -2,6 +2,7 @@ import { faCheck, faX } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ElementDisplayMode, ElementType } from '@klicker-uzh/graphql/dist/ops'
 import { Markdown } from '@klicker-uzh/markdown'
+import type { Choice } from '@klicker-uzh/types'
 import { Button } from '@uzh-bf/design-system'
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -9,7 +10,7 @@ import { twMerge } from 'tailwind-merge'
 export interface KPAnswerOptionsOLDProps {
   displayMode?: ElementDisplayMode
   type: ElementType
-  choices: { value: string; correct: boolean; feedback: string }[]
+  choices: Choice[]
   value?: { [key: number]: boolean }
   onChange: (answer: any, selectedValue: boolean) => any
   id?: string
@@ -30,48 +31,54 @@ export function KPAnswerOptionsOLD({
           : 'flex flex-col'
       )}
     >
-      {choices.map((choice, index) => (
-        <div
-          className="flex flex-row items-center justify-between gap-4 border p-2"
-          data-cy="kp-answer-options"
-        >
-          <div>
-            <Markdown
-              withProse
-              content={choice.value}
-              className={{
-                root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-              }}
-            />
+      {choices
+        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+        .map((choice) => (
+          <div
+            className="flex flex-row items-center justify-between gap-4 border p-2"
+            data-cy="kp-answer-options"
+          >
+            <div>
+              <Markdown
+                withProse
+                content={choice.value}
+                className={{
+                  root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                }}
+              />
+            </div>
+            <div className="flex flex-row gap-2">
+              <Button
+                className={{
+                  root: twMerge(
+                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
+                  ),
+                }}
+                active={value?.[choice.ix] === true}
+                onClick={onChange(choice.ix, true)}
+                data={{ cy: `toggle-kp-answer-${choice.ix}-correct` }}
+              >
+                <Button.Icon>
+                  <FontAwesomeIcon icon={faCheck} />
+                </Button.Icon>
+              </Button>
+              <Button
+                className={{
+                  root: twMerge(
+                    'hover:bg-unset min-h-[2.5rem] border-slate-400'
+                  ),
+                }}
+                active={value?.[choice.ix] === false}
+                onClick={onChange(choice.ix, false)}
+                data={{ cy: `toggle-kp-answer-${choice.ix}-incorrect` }}
+              >
+                <Button.Icon>
+                  <FontAwesomeIcon icon={faX} />
+                </Button.Icon>
+              </Button>
+            </div>
           </div>
-          <div className="flex flex-row gap-2">
-            <Button
-              className={{
-                root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
-              }}
-              active={value?.[index] === true}
-              onClick={onChange(index, true)}
-              data={{ cy: `toggle-kp-answer-${index}-correct` }}
-            >
-              <Button.Icon>
-                <FontAwesomeIcon icon={faCheck} />
-              </Button.Icon>
-            </Button>
-            <Button
-              className={{
-                root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
-              }}
-              active={value?.[index] === false}
-              onClick={onChange(index, false)}
-              data={{ cy: `toggle-kp-answer-${index}-incorrect` }}
-            >
-              <Button.Icon>
-                <FontAwesomeIcon icon={faX} />
-              </Button.Icon>
-            </Button>
-          </div>
-        </div>
-      ))}
+        ))}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/MCAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/MCAnswerOptions.tsx
@@ -9,7 +9,7 @@ import ChoiceFeedback from '../evaluation/ChoiceFeedback'
 
 export interface MCAnswerOptionsProps {
   displayMode?: ElementDisplayMode
-  choices: Partial<Choice>[]
+  choices: Choice[]
   feedbacks?: QuestionFeedback[] | null
   value?: Record<number, boolean>
   onChange: (value: Record<number, boolean>) => void
@@ -45,41 +45,47 @@ export function MCAnswerOptions({
           b: (text) => <span className="font-bold">{text}</span>,
         })}
       </div>
-      {choices.map((choice, index) => {
-        return (
-          <div key={`mc-choice-${index}-${choice.value}`}>
-            <Button
-              fluid
-              className={{
-                root: twMerge(
-                  'hover:bg-unset min-h-[2.5rem] border-slate-400',
-                  !hideFeedbacks &&
-                    feedbacks &&
-                    feedbacks[index] &&
-                    'rounded-b-none'
-                ),
-              }}
-              onClick={() => onChange({ ...value, [index]: !value?.[index] })}
-              active={value?.[index]}
-              data={{ cy: `mc-${elementIx + 1}-answer-option-${index + 1}` }}
-              disabled={disabled}
-            >
-              <Button.Label>
-                <Markdown
-                  withProse
-                  content={choice.value}
-                  className={{
-                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                  }}
-                />
-              </Button.Label>
-            </Button>
-            {!hideFeedbacks && feedbacks && feedbacks[index] && (
-              <ChoiceFeedback feedback={feedbacks[index]!} />
-            )}
-          </div>
-        )
-      })}
+      {choices
+        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+        .map((choice) => {
+          return (
+            <div key={`mc-choice-${choice.ix}-${choice.value}`}>
+              <Button
+                fluid
+                className={{
+                  root: twMerge(
+                    'hover:bg-unset min-h-[2.5rem] border-slate-400',
+                    !hideFeedbacks &&
+                      feedbacks &&
+                      feedbacks[choice.ix] &&
+                      'rounded-b-none'
+                  ),
+                }}
+                onClick={() =>
+                  onChange({ ...value, [choice.ix]: !value?.[choice.ix] })
+                }
+                active={value?.[choice.ix]}
+                data={{
+                  cy: `mc-${elementIx + 1}-answer-option-${choice.ix + 1}`,
+                }}
+                disabled={disabled}
+              >
+                <Button.Label>
+                  <Markdown
+                    withProse
+                    content={choice.value}
+                    className={{
+                      root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                    }}
+                  />
+                </Button.Label>
+              </Button>
+              {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
+                <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
+              )}
+            </div>
+          )
+        })}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/MCAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/MCAnswerOptions.tsx
@@ -45,47 +45,45 @@ export function MCAnswerOptions({
           b: (text) => <span className="font-bold">{text}</span>,
         })}
       </div>
-      {choices
-        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-        .map((choice) => {
-          return (
-            <div key={`mc-choice-${choice.ix}-${choice.value}`}>
-              <Button
-                fluid
-                className={{
-                  root: twMerge(
-                    'hover:bg-unset min-h-[2.5rem] border-slate-400',
-                    !hideFeedbacks &&
-                      feedbacks &&
-                      feedbacks[choice.ix] &&
-                      'rounded-b-none'
-                  ),
-                }}
-                onClick={() =>
-                  onChange({ ...value, [choice.ix]: !value?.[choice.ix] })
-                }
-                active={value?.[choice.ix]}
-                data={{
-                  cy: `mc-${elementIx + 1}-answer-option-${choice.ix + 1}`,
-                }}
-                disabled={disabled}
-              >
-                <Button.Label>
-                  <Markdown
-                    withProse
-                    content={choice.value}
-                    className={{
-                      root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                    }}
-                  />
-                </Button.Label>
-              </Button>
-              {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
-                <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
-              )}
-            </div>
-          )
-        })}
+      {choices.map((choice) => {
+        return (
+          <div key={`mc-choice-${choice.ix}-${choice.value}`}>
+            <Button
+              fluid
+              className={{
+                root: twMerge(
+                  'hover:bg-unset min-h-[2.5rem] border-slate-400',
+                  !hideFeedbacks &&
+                    feedbacks &&
+                    feedbacks[choice.ix] &&
+                    'rounded-b-none'
+                ),
+              }}
+              onClick={() =>
+                onChange({ ...value, [choice.ix]: !value?.[choice.ix] })
+              }
+              active={value?.[choice.ix]}
+              data={{
+                cy: `mc-${elementIx + 1}-answer-option-${choice.ix + 1}`,
+              }}
+              disabled={disabled}
+            >
+              <Button.Label>
+                <Markdown
+                  withProse
+                  content={choice.value}
+                  className={{
+                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                  }}
+                />
+              </Button.Label>
+            </Button>
+            {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
+              <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/SCAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/SCAnswerOptions.tsx
@@ -9,7 +9,7 @@ import ChoiceFeedback from '../evaluation/ChoiceFeedback'
 
 export interface SCAnswerOptionsProps {
   displayMode?: ElementDisplayMode
-  choices: Partial<Choice>[]
+  choices: Choice[]
   feedbacks?: QuestionFeedback[] | null
   value?: Record<number, boolean>
   onChange: (value: Record<number, boolean>) => void
@@ -45,45 +45,51 @@ export function SCAnswerOptions({
           b: (text) => <span className="font-bold">{text}</span>,
         })}
       </div>
-      {choices.map((choice, index) => {
-        return (
-          <div key={`sc-choice-${index}-${choice.value}`}>
-            <Button
-              fluid
-              className={{
-                root: twMerge(
-                  'hover:bg-unset min-h-[2.5rem] border-slate-400',
-                  !hideFeedbacks &&
-                    feedbacks &&
-                    feedbacks[index] &&
-                    'rounded-b-none'
-                ),
-              }}
-              onClick={() =>
-                onChange(
-                  Object.fromEntries(choices.map((_, i) => [i, i === index]))
-                )
-              }
-              active={value?.[index]}
-              data={{ cy: `sc-${elementIx + 1}-answer-option-${index + 1}` }}
-              disabled={disabled}
-            >
-              <Button.Label>
-                <Markdown
-                  withProse
-                  content={choice.value}
-                  className={{
-                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                  }}
-                />
-              </Button.Label>
-            </Button>
-            {!hideFeedbacks && feedbacks && feedbacks[index] && (
-              <ChoiceFeedback feedback={feedbacks[index]!} />
-            )}
-          </div>
-        )
-      })}
+      {choices
+        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+        .map((choice) => {
+          return (
+            <div key={`sc-choice-${choice.ix}-${choice.value}`}>
+              <Button
+                fluid
+                className={{
+                  root: twMerge(
+                    'hover:bg-unset min-h-[2.5rem] border-slate-400',
+                    !hideFeedbacks &&
+                      feedbacks &&
+                      feedbacks[choice.ix] &&
+                      'rounded-b-none'
+                  ),
+                }}
+                onClick={() =>
+                  onChange(
+                    Object.fromEntries(
+                      choices.map((_, i) => [i, i === choice.ix])
+                    )
+                  )
+                }
+                active={value?.[choice.ix]}
+                data={{
+                  cy: `sc-${elementIx + 1}-answer-option-${choice.ix + 1}`,
+                }}
+                disabled={disabled}
+              >
+                <Button.Label>
+                  <Markdown
+                    withProse
+                    content={choice.value}
+                    className={{
+                      root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                    }}
+                  />
+                </Button.Label>
+              </Button>
+              {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
+                <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
+              )}
+            </div>
+          )
+        })}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/SCAnswerOptions.tsx
+++ b/packages/shared-components/src/questions/SCAnswerOptions.tsx
@@ -45,51 +45,49 @@ export function SCAnswerOptions({
           b: (text) => <span className="font-bold">{text}</span>,
         })}
       </div>
-      {choices
-        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-        .map((choice) => {
-          return (
-            <div key={`sc-choice-${choice.ix}-${choice.value}`}>
-              <Button
-                fluid
-                className={{
-                  root: twMerge(
-                    'hover:bg-unset min-h-[2.5rem] border-slate-400',
-                    !hideFeedbacks &&
-                      feedbacks &&
-                      feedbacks[choice.ix] &&
-                      'rounded-b-none'
-                  ),
-                }}
-                onClick={() =>
-                  onChange(
-                    Object.fromEntries(
-                      choices.map((_, i) => [i, i === choice.ix])
-                    )
+      {choices.map((choice) => {
+        return (
+          <div key={`sc-choice-${choice.ix}-${choice.value}`}>
+            <Button
+              fluid
+              className={{
+                root: twMerge(
+                  'hover:bg-unset min-h-[2.5rem] border-slate-400',
+                  !hideFeedbacks &&
+                    feedbacks &&
+                    feedbacks[choice.ix] &&
+                    'rounded-b-none'
+                ),
+              }}
+              onClick={() =>
+                onChange(
+                  Object.fromEntries(
+                    choices.map((_, i) => [i, i === choice.ix])
                   )
-                }
-                active={value?.[choice.ix]}
-                data={{
-                  cy: `sc-${elementIx + 1}-answer-option-${choice.ix + 1}`,
-                }}
-                disabled={disabled}
-              >
-                <Button.Label>
-                  <Markdown
-                    withProse
-                    content={choice.value}
-                    className={{
-                      root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                    }}
-                  />
-                </Button.Label>
-              </Button>
-              {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
-                <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
-              )}
-            </div>
-          )
-        })}
+                )
+              }
+              active={value?.[choice.ix]}
+              data={{
+                cy: `sc-${elementIx + 1}-answer-option-${choice.ix + 1}`,
+              }}
+              disabled={disabled}
+            >
+              <Button.Label>
+                <Markdown
+                  withProse
+                  content={choice.value}
+                  className={{
+                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                  }}
+                />
+              </Button.Label>
+            </Button>
+            {!hideFeedbacks && feedbacks && feedbacks[choice.ix] && (
+              <ChoiceFeedback feedback={feedbacks[choice.ix]!} />
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/SCAnswerOptionsOLD.tsx
+++ b/packages/shared-components/src/questions/SCAnswerOptionsOLD.tsx
@@ -1,12 +1,13 @@
 import { ElementDisplayMode } from '@klicker-uzh/graphql/dist/ops'
 import { Markdown } from '@klicker-uzh/markdown'
+import type { Choice } from '@klicker-uzh/types'
 import { Button } from '@uzh-bf/design-system'
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export interface SCAnswerOptionsOLDProps {
   displayMode?: ElementDisplayMode
-  choices: { value: string; correct: boolean; feedback: string }[]
+  choices: Choice[]
   value?: number[]
   onChange: (value: any) => any
   id?: string
@@ -27,30 +28,32 @@ export function SCAnswerOptionsOLD({
           : 'flex flex-col'
       )}
     >
-      {choices.map((choice, index) => {
-        return (
-          <Button
-            fluid
-            className={{
-              root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
-            }}
-            onClick={onChange(index)}
-            key={`${choice.value}-${index}`}
-            active={value?.includes(index)}
-            data={{ cy: `sc-answer-option-${index}` }}
-          >
-            <Button.Label>
-              <Markdown
-                withProse
-                content={choice.value}
-                className={{
-                  root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                }}
-              />
-            </Button.Label>
-          </Button>
-        )
-      })}
+      {choices
+        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
+        .map((choice) => {
+          return (
+            <Button
+              fluid
+              className={{
+                root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
+              }}
+              onClick={onChange(choice.ix)}
+              key={`${choice.value}-${choice.ix}`}
+              active={value?.includes(choice.ix)}
+              data={{ cy: `sc-answer-option-${choice.ix}` }}
+            >
+              <Button.Label>
+                <Markdown
+                  withProse
+                  content={choice.value}
+                  className={{
+                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                  }}
+                />
+              </Button.Label>
+            </Button>
+          )
+        })}
     </div>
   )
 }

--- a/packages/shared-components/src/questions/SCAnswerOptionsOLD.tsx
+++ b/packages/shared-components/src/questions/SCAnswerOptionsOLD.tsx
@@ -28,32 +28,30 @@ export function SCAnswerOptionsOLD({
           : 'flex flex-col'
       )}
     >
-      {choices
-        .sort((a, b) => (a.ix > b.ix ? 1 : -1))
-        .map((choice) => {
-          return (
-            <Button
-              fluid
-              className={{
-                root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
-              }}
-              onClick={onChange(choice.ix)}
-              key={`${choice.value}-${choice.ix}`}
-              active={value?.includes(choice.ix)}
-              data={{ cy: `sc-answer-option-${choice.ix}` }}
-            >
-              <Button.Label>
-                <Markdown
-                  withProse
-                  content={choice.value}
-                  className={{
-                    root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
-                  }}
-                />
-              </Button.Label>
-            </Button>
-          )
-        })}
+      {choices.map((choice) => {
+        return (
+          <Button
+            fluid
+            className={{
+              root: twMerge('hover:bg-unset min-h-[2.5rem] border-slate-400'),
+            }}
+            onClick={onChange(choice.ix)}
+            key={`${choice.value}-${choice.ix}`}
+            active={value?.includes(choice.ix)}
+            data={{ cy: `sc-answer-option-${choice.ix}` }}
+          >
+            <Button.Label>
+              <Markdown
+                withProse
+                content={choice.value}
+                className={{
+                  root: 'prose-p:!m-0 prose-img:!m-0 max-w-none p-1 pt-2',
+                }}
+              />
+            </Button.Label>
+          </Button>
+        )
+      })}
     </div>
   )
 }

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -6,6 +6,7 @@ import {
 import {
   type AllElementTypeData,
   type AllQuestionTypeData,
+  type Choice,
   type ElementInstanceResults,
   type ElementKeys,
 } from '@klicker-uzh/types'
@@ -110,9 +111,9 @@ export function getInitialElementResults(
     element.type === PrismaElementType.KPRIM
   ) {
     const choices = element.options.choices.reduce(
-      (acc: Record<string, number>, _: any, ix: number) => ({
+      (acc: Record<string, number>, choice: Choice) => ({
         ...acc,
-        [ix]: 0,
+        [choice.ix]: 0,
       }),
       {}
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 4.24.8
-        version: 4.24.8(next@15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.8(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: 3.21.1
         version: 3.21.1(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -245,7 +245,7 @@ importers:
         version: 9.0.2
       next-auth:
         specifier: 4.24.8
-        version: 4.24.8(next@15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.8(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       passport:
         specifier: 0.7.0
         version: 0.7.0
@@ -300,7 +300,7 @@ importers:
         version: 8.5.12
       '@uzh-bf/design-system':
         specifier: 3.0.0-alpha.32
-        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
+        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
       axios:
         specifier: ~1.7.7
         version: 1.7.7(debug@4.3.7)
@@ -399,7 +399,7 @@ importers:
         version: 0.5.15(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))
       '@uzh-bf/design-system':
         specifier: 3.0.0-alpha.32
-        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))(yup@1.4.0)
+        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))(yup@1.4.0)
       autoprefixer:
         specifier: ~10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -456,7 +456,7 @@ importers:
         version: 3.11.8(@types/react@18.3.11)(graphql-ws@5.16.0(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ducanh2912/next-pwa':
         specifier: 7.3.3
-        version: 7.3.3(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/babel__core@7.20.5)(next@15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(swc-loader@0.2.6(@swc/core@1.3.101(@swc/helpers@0.5.13))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13))))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13)))
+        version: 7.3.3(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/babel__core@7.20.5)(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(swc-loader@0.2.6(@swc/core@1.3.101(@swc/helpers@0.5.13))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13))))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13)))
       '@fortawesome/fontawesome-svg-core':
         specifier: 6.6.0
         version: 6.6.0
@@ -489,7 +489,7 @@ importers:
         version: link:../../packages/shared-components
       '@socialgouv/matomo-next':
         specifier: 1.9.1
-        version: 1.9.1(next@15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.9.1(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@uzh-bf/design-system':
         specifier: 3.0.0-alpha.32
         version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
@@ -528,10 +528,10 @@ importers:
         version: 1.10.0
       next:
         specifier: 15.0.0
-        version: 15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: 3.21.1
-        version: 3.21.1(next@15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 3.21.1(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       nookies:
         specifier: 2.5.2
         version: 2.5.2
@@ -625,7 +625,7 @@ importers:
         version: 12.25.0
       '@ducanh2912/next-pwa':
         specifier: 7.3.3
-        version: 7.3.3(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/babel__core@7.20.5)(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(swc-loader@0.2.6(@swc/core@1.3.101(@swc/helpers@0.5.13))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13))))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13)))
+        version: 7.3.3(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/babel__core@7.20.5)(next@15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(swc-loader@0.2.6(@swc/core@1.3.101(@swc/helpers@0.5.13))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13))))(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13)))
       '@fortawesome/fontawesome-svg-core':
         specifier: 6.6.0
         version: 6.6.0
@@ -661,7 +661,7 @@ importers:
         version: link:../../packages/shared-components
       '@socialgouv/matomo-next':
         specifier: 1.9.1
-        version: 1.9.1(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.9.1(next@15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tanstack/react-table':
         specifier: 8.20.5
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -710,12 +710,15 @@ importers:
       lodash:
         specifier: 4.17.21
         version: 4.17.21
+      nanoid:
+        specifier: 5.0.8
+        version: 5.0.8
       next:
         specifier: 15.0.0
-        version: 15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: 3.21.1
-        version: 3.21.1(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 3.21.1(next@15.0.0(@babel/core@7.21.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       nookies:
         specifier: 2.5.2
         version: 2.5.2
@@ -1096,7 +1099,7 @@ importers:
         version: 20.16.1
       '@uzh-bf/design-system':
         specifier: 3.0.0-alpha.32
-        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
+        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
       azure-functions-core-tools:
         specifier: ~4.0.6280
         version: 4.0.6280
@@ -1249,7 +1252,7 @@ importers:
         version: 20.16.1
       '@uzh-bf/design-system':
         specifier: 3.0.0-alpha.32
-        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
+        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
       azure-functions-core-tools:
         specifier: ~4.0.6280
         version: 4.0.6280
@@ -1525,7 +1528,7 @@ importers:
         version: 4.24.0
       ts-jest:
         specifier: ~29.2.5
-        version: 29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@20.16.1)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.21.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.21.8))(jest@29.7.0(@types/node@20.16.1)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -1721,7 +1724,7 @@ importers:
         version: 3.5.0
       ts-jest:
         specifier: ~29.2.5
-        version: 29.2.5(@babel/core@7.21.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.21.8))(jest@29.7.0(@types/node@20.16.1)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@20.16.1)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(typescript@5.6.3)
       tsx:
         specifier: ~4.19.1
         version: 4.19.1
@@ -2064,7 +2067,7 @@ importers:
         version: 18.3.11
       '@uzh-bf/design-system':
         specifier: 3.0.0-alpha.32
-        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
+        version: 3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)
       react:
         specifier: ~18.3.1
         version: 18.3.1
@@ -5238,8 +5241,8 @@ packages:
   '@radix-ui/react-accordion@1.2.0':
     resolution: {integrity: sha512-HJOzSX8dQqtsp/3jVxCU3CXEONF7/2jlGAB28oX8TTw1Dz8JYbEI1UcL8355PuLBE41/IRRMvCw7VkiK/jcUOQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': npm:types-react@19.0.0-rc.0
+      '@types/react-dom': npm:types-react-dom@19.0.0-rc.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -5316,8 +5319,8 @@ packages:
   '@radix-ui/react-checkbox@1.1.1':
     resolution: {integrity: sha512-0i/EKJ222Afa1FE0C6pNJxDq1itzcl3HChE9DwskA4th4KRse8ojx8a1nVcOjwJdbpDLcz7uol77yYnQNMHdKw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': npm:types-react@19.0.0-beta.2
+      '@types/react-dom': npm:types-react-dom@19.0.0-beta.2
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -5403,7 +5406,7 @@ packages:
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': npm:types-react@19.0.0-beta.2
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5844,8 +5847,8 @@ packages:
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': npm:types-react@19.0.0-beta.2
+      '@types/react-dom': npm:types-react-dom@19.0.0-beta.2
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -5970,7 +5973,7 @@ packages:
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': npm:types-react@19.0.0-rc.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -12610,6 +12613,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.0.8:
+    resolution: {integrity: sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
 
@@ -17215,7 +17223,7 @@ snapshots:
 
   '@azure/msal-common@4.5.1':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17312,7 +17320,7 @@ snapshots:
       '@babel/traverse': 7.25.4
       '@babel/types': 7.25.4
       convert-source-map: 1.9.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17332,7 +17340,7 @@ snapshots:
       '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17352,7 +17360,7 @@ snapshots:
       '@babel/traverse': 7.25.4
       '@babel/types': 7.25.4
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17372,7 +17380,7 @@ snapshots:
       '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17485,7 +17493,7 @@ snapshots:
       '@babel/core': 7.21.8
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -17496,7 +17504,7 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -17507,7 +17515,7 @@ snapshots:
       '@babel/core': 7.25.8
       '@babel/helper-compilation-targets': 7.25.7
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -19682,7 +19690,7 @@ snapshots:
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.0
       '@babel/types': 7.25.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -19694,7 +19702,7 @@ snapshots:
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.7
       '@babel/types': 7.25.8
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -19728,7 +19736,7 @@ snapshots:
       '@ionic/utils-subprocess': 2.1.14
       '@ionic/utils-terminal': 2.3.5
       commander: 9.5.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       env-paths: 2.2.1
       kleur: 4.1.5
       native-run: 1.7.4
@@ -19772,7 +19780,7 @@ snapshots:
       chalk: 4.1.2
       cypress: 13.15.0
       dayjs: 1.11.13
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       execa: 4.1.0
       globby: 11.1.0
       istanbul-lib-coverage: 3.2.2
@@ -19791,7 +19799,7 @@ snapshots:
       chalk: 4.1.2
       cypress: 13.15.0
       dayjs: 1.11.13
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       execa: 4.1.0
       globby: 11.1.0
       istanbul-lib-coverage: 3.2.2
@@ -19828,7 +19836,7 @@ snapshots:
       '@babel/preset-env': 7.25.4(@babel/core@7.25.8)
       babel-loader: 9.2.1(@babel/core@7.25.8)(webpack@5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13)))
       bluebird: 3.7.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash: 4.17.21
       webpack: 5.94.0(@swc/core@1.3.101(@swc/helpers@0.5.13))
     transitivePeerDependencies:
@@ -19840,7 +19848,7 @@ snapshots:
       '@babel/preset-env': 7.25.4(@babel/core@7.25.8)
       babel-loader: 9.2.1(@babel/core@7.25.8)(webpack@5.94.0)
       bluebird: 3.7.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash: 4.17.21
       webpack: 5.94.0
     transitivePeerDependencies:
@@ -21008,7 +21016,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -21022,7 +21030,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -21527,7 +21535,7 @@ snapshots:
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.9.21
       chalk: 4.1.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       dotenv: 16.4.5
       graphql: 16.9.0
       graphql-request: 6.1.0(graphql@16.9.0)
@@ -21679,7 +21687,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21687,7 +21695,7 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21883,14 +21891,14 @@ snapshots:
   '@ionic/cli-framework-output@2.2.8':
     dependencies:
       '@ionic/utils-terminal': 2.3.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
   '@ionic/utils-array@2.1.6':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
@@ -21898,7 +21906,7 @@ snapshots:
   '@ionic/utils-fs@3.1.7':
     dependencies:
       '@types/fs-extra': 8.1.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-extra: 9.1.0
       tslib: 2.8.0
     transitivePeerDependencies:
@@ -21906,7 +21914,7 @@ snapshots:
 
   '@ionic/utils-object@2.1.6':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
@@ -21915,7 +21923,7 @@ snapshots:
     dependencies:
       '@ionic/utils-object': 2.1.6
       '@ionic/utils-terminal': 2.3.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       signal-exit: 3.0.7
       tree-kill: 1.2.2
       tslib: 2.8.0
@@ -21924,7 +21932,7 @@ snapshots:
 
   '@ionic/utils-stream@3.1.6':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
@@ -21937,7 +21945,7 @@ snapshots:
       '@ionic/utils-stream': 3.1.6
       '@ionic/utils-terminal': 2.3.4
       cross-spawn: 7.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
@@ -21945,7 +21953,7 @@ snapshots:
   '@ionic/utils-terminal@2.3.4':
     dependencies:
       '@types/slice-ansi': 4.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       signal-exit: 3.0.7
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -21959,7 +21967,7 @@ snapshots:
   '@ionic/utils-terminal@2.3.5':
     dependencies:
       '@types/slice-ansi': 4.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       signal-exit: 3.0.7
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -22243,7 +22251,7 @@ snapshots:
   '@microsoft/dev-tunnels-contracts@1.1.9':
     dependencies:
       buffer: 5.7.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       vscode-jsonrpc: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -22253,7 +22261,7 @@ snapshots:
       '@microsoft/dev-tunnels-contracts': 1.1.9
       axios: 1.7.7(debug@4.3.7)
       buffer: 5.7.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       vscode-jsonrpc: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -22417,7 +22425,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.21.0(prisma@5.21.0))(next-auth@4.24.8(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@prisma/client': 5.21.0(prisma@5.21.0)
-      next-auth: 4.24.8(next@15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth: 4.24.8(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   '@next/env@14.2.3': {}
 
@@ -22860,6 +22868,20 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-accordion@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collapsible': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-alert-dialog@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -22874,6 +22896,30 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-alert-dialog@1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-alert-dialog@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -22884,6 +22930,13 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-arrow@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22893,6 +22946,12 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-arrow@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-aspect-ratio@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22901,6 +22960,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-aspect-ratio@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-avatar@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -22913,6 +22978,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-avatar@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-checkbox@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -22929,6 +23003,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-checkbox@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-collapsible@1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -22947,6 +23034,20 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-collapsible@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.4
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-collapsible@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -22962,6 +23063,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-collapsible@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-collapsible@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -22992,6 +23106,16 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-collection@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-collection@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -23003,6 +23127,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-collection@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23030,6 +23163,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-context-menu@2.2.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-context-menu@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-context@1.0.1(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23073,6 +23230,26 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-dialog@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.11)(react@18.3.1)
+
   '@radix-ui/react-dialog@1.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23096,6 +23273,26 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-dialog@1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.11)(react@18.3.1)
+
   '@radix-ui/react-dialog@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23117,6 +23314,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-dialog@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.11)(react@18.3.1)
 
   '@radix-ui/react-direction@1.0.1(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23145,6 +23361,17 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-dismissable-layer@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23159,6 +23386,17 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-dismissable-layer@1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23171,6 +23409,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-dismissable-layer@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-dropdown-menu@2.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23187,6 +23435,34 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-dropdown-menu@2.0.5(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-menu': 2.0.5(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-dropdown-menu@2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-menu': 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-focus-guards@1.0.1(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23213,6 +23489,15 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-focus-scope@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23225,6 +23510,15 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-focus-scope@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-focus-scope@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -23235,6 +23529,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-focus-scope@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-hover-card@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23252,6 +23554,36 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-hover-card@1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-hover-card@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-id@1.0.1(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23276,6 +23608,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-label@2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-menu@2.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23304,6 +23642,56 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-menu@2.0.5(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-menu@2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.11)(react@18.3.1)
+
   '@radix-ui/react-menu@2.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23330,6 +23718,54 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-menu@2.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-menu@2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.11)(react@18.3.1)
+
   '@radix-ui/react-menubar@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23347,6 +23783,38 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-menubar@1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-menubar@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-navigation-menu@1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23369,6 +23837,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-navigation-menu@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-popover@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23393,6 +23880,48 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-popover@1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-popover@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.11)(react@18.3.1)
+
   '@radix-ui/react-popper@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23412,6 +23941,22 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-popper@1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/rect': 1.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-popper@1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23430,6 +23975,21 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-popper@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-portal@1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23439,6 +23999,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-portal@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-portal@1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23450,6 +24017,13 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-portal@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-portal@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23459,6 +24033,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-portal@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-presence@1.0.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23471,6 +24052,14 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-presence@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-presence@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -23480,6 +24069,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-presence@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-presence@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23501,6 +24097,13 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-primitive@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -23509,6 +24112,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-primitive@2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-progress@1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23520,6 +24129,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-progress@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-radio-group@1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23539,6 +24156,38 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-radio-group@1.2.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-radio-group@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23557,6 +24206,21 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-roving-focus@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-roving-focus@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23574,6 +24238,20 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-roving-focus@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-scroll-area@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/number': 1.1.0
@@ -23590,6 +24268,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-scroll-area@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-select@1.2.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23621,6 +24313,62 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-select@1.2.2(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-select@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.11)(react@18.3.1)
+
   '@radix-ui/react-separator@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23629,6 +24377,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-separator@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-slider@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23649,6 +24403,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-slider@1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-slot@1.0.2(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23681,6 +24452,19 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-switch@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-tabs@1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -23697,6 +24481,36 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-tabs@1.0.4(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-tabs@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-tabs@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23735,6 +24549,24 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-toast@1.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-toggle-group@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23750,6 +24582,32 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-toggle-group@1.1.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-toggle-group@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-toggle@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -23760,6 +24618,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-toggle@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-tooltip@1.0.6(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23781,6 +24647,44 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-tooltip@1.0.6(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-tooltip@1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
@@ -23891,6 +24795,13 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-visually-hidden@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@radix-ui/react-visually-hidden@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23899,6 +24810,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-visually-hidden@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@radix-ui/rect@1.0.1':
     dependencies:
@@ -25103,33 +26020,14 @@ snapshots:
       '@types/node': 20.16.12
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
-      debug: 4.3.7(supports-color@5.5.0)
-      eslint: 7.32.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare-lite: 1.4.0
-      semver: 7.6.3
-      tsutils: 3.21.0(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -25141,6 +26039,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@4.9.5)':
+    dependencies:
+      '@eslint-community/regexpp': 4.11.0
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
+      debug: 4.3.7(supports-color@8.1.1)
+      eslint: 7.32.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare-lite: 1.4.0
+      semver: 7.6.3
+      tsutils: 3.21.0(typescript@4.9.5)
+    optionalDependencies:
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@6.21.0(eslint@8.45.0)(typescript@5.6.3))(eslint@8.45.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
@@ -25148,7 +26065,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.45.0)(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.45.0)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.45.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -25165,7 +26082,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
     optionalDependencies:
       typescript: 4.9.5
@@ -25177,7 +26094,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
     optionalDependencies:
       typescript: 5.6.3
@@ -25190,7 +26107,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.45.0
     optionalDependencies:
       typescript: 5.6.3
@@ -25211,7 +26128,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -25223,7 +26140,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.6.3)
     optionalDependencies:
@@ -25235,7 +26152,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.45.0)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.45.0
       tsutils: 3.21.0(typescript@5.6.3)
     optionalDependencies:
@@ -25251,7 +26168,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -25265,7 +26182,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -25279,7 +26196,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -25418,7 +26335,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@uzh-bf/design-system@3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))(yup@1.4.0)':
+  '@uzh-bf/design-system@3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.6.0
       '@fortawesome/free-regular-svg-icons': 6.6.0
@@ -25426,35 +26343,101 @@ snapshots:
       '@fortawesome/react-fontawesome': 0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1)
       '@hookform/resolvers': 3.9.0(react-hook-form@7.52.2(react@18.3.1))
       '@radix-ui/react-accordion': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-alert-dialog': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-alert-dialog': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-aspect-ratio': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-avatar': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-checkbox': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-context-menu': 2.2.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context-menu': 2.2.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dropdown-menu': 2.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-hover-card': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.0.5(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-label': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-menubar': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menubar': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-navigation-menu': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popover': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-progress': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-radio-group': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group': 1.2.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-scroll-area': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-select': 1.2.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select': 1.2.2(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-separator': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slider': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
       '@radix-ui/react-switch': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-tabs': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs': 1.0.4(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toast': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toggle': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-toggle-group': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-tooltip': 1.0.6(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.0.6(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority: 0.7.0
       clsx: 2.1.1
-      cmdk: 1.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      cmdk: 1.0.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      date-fns: 3.6.0
+      dayjs: 1.11.13
+      embla-carousel-react: 8.1.8(react@18.3.1)
+      formik: 2.4.6(react@18.3.1)
+      input-otp: 1.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      lucide-react: 0.424.0(react@18.3.1)
+      next-themes: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      postcss: 8.4.47
+      postcss-import: 16.1.0(postcss@8.4.47)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-countdown: 2.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 8.10.1(date-fns@3.6.0)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-hook-form: 7.52.2(react@18.3.1)
+      react-resizable-panels: 2.0.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts: 2.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge: 2.5.4
+      tailwindcss: 3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))
+      tailwindcss-animate: 1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))
+      tailwindcss-radix: 3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))
+      vaul: 0.9.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      yup: 1.4.0
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@uzh-bf/design-system@3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(@types/react@18.3.11)(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))(yup@1.4.0)':
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 6.6.0
+      '@fortawesome/free-regular-svg-icons': 6.6.0
+      '@fortawesome/free-solid-svg-icons': 6.6.0
+      '@fortawesome/react-fontawesome': 0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1)
+      '@hookform/resolvers': 3.9.0(react-hook-form@7.52.2(react@18.3.1))
+      '@radix-ui/react-accordion': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-alert-dialog': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-aspect-ratio': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-avatar': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context-menu': 2.2.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.0.5(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menubar': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-navigation-menu': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group': 1.2.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select': 1.2.2(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-switch': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs': 1.0.4(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.0.6(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      class-variance-authority: 0.7.0
+      clsx: 2.1.1
+      cmdk: 1.0.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       date-fns: 3.6.0
       dayjs: 1.11.13
       embla-carousel-react: 8.1.8(react@18.3.1)
@@ -25477,7 +26460,73 @@ snapshots:
       tailwindcss: 3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3))
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))
       tailwindcss-radix: 3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.14)(typescript@5.6.3)))
-      vaul: 0.9.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      vaul: 0.9.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      yup: 1.4.0
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@uzh-bf/design-system@3.0.0-alpha.32(@fortawesome/fontawesome-svg-core@6.6.0)(@fortawesome/free-regular-svg-icons@6.6.0)(@fortawesome/free-solid-svg-icons@6.6.0)(@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1))(class-variance-authority@0.7.0)(clsx@2.1.1)(dayjs@1.11.13)(formik@2.4.6(react@18.3.1))(lucide-react@0.424.0(react@18.3.1))(postcss-import@16.1.0(postcss@8.4.47))(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss-radix@3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))))(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))(yup@1.4.0)':
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 6.6.0
+      '@fortawesome/free-regular-svg-icons': 6.6.0
+      '@fortawesome/free-solid-svg-icons': 6.6.0
+      '@fortawesome/react-fontawesome': 0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1)
+      '@hookform/resolvers': 3.9.0(react-hook-form@7.52.2(react@18.3.1))
+      '@radix-ui/react-accordion': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-alert-dialog': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-aspect-ratio': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-avatar': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collapsible': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context-menu': 2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menubar': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-navigation-menu': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select': 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-switch': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast': 1.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      class-variance-authority: 0.7.0
+      clsx: 2.1.1
+      cmdk: 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      date-fns: 3.6.0
+      dayjs: 1.11.13
+      embla-carousel-react: 8.1.8(react@18.3.1)
+      formik: 2.4.6(react@18.3.1)
+      input-otp: 1.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      lucide-react: 0.424.0(react@18.3.1)
+      next-themes: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      postcss: 8.4.47
+      postcss-import: 16.1.0(postcss@8.4.47)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-countdown: 2.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 8.10.1(date-fns@3.6.0)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-hook-form: 7.52.2(react@18.3.1)
+      react-resizable-panels: 2.0.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts: 2.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge: 2.5.4
+      tailwindcss: 3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3))
+      tailwindcss-animate: 1.0.7(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))
+      tailwindcss-radix: 3.0.5(tailwindcss@3.4.14(ts-node@10.9.1(@swc/core@1.3.101(@swc/helpers@0.5.13))(@types/node@20.16.1)(typescript@5.6.3)))
+      vaul: 0.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       yup: 1.4.0
       zod: 3.23.8
     transitivePeerDependencies:
@@ -25718,13 +26767,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26073,7 +27122,7 @@ snapshots:
   azure-functions-core-tools@4.0.6280:
     dependencies:
       chalk: 3.0.0
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@8.1.1)
       https-proxy-agent: 5.0.0
       progress: 2.0.3
       rimraf: 4.4.1
@@ -26817,6 +27866,26 @@ snapshots:
     dependencies:
       '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  cmdk@1.0.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  cmdk@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -27760,7 +28829,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27980,7 +29049,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.4.2
       cors: 2.8.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -28218,7 +29287,7 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.45.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.45.0):
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.45.0
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.45.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.45.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.45.0))(eslint@8.45.0)
@@ -28428,7 +29497,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -28477,7 +29546,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -28691,16 +29760,6 @@ snapshots:
       tmp: 0.0.33
 
   extract-files@11.0.0: {}
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
@@ -28930,7 +29989,7 @@ snapshots:
 
   follow-redirects@1.15.9(debug@4.3.7):
     optionalDependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
 
   for-each@0.3.3:
     dependencies:
@@ -29740,7 +30799,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29787,14 +30846,14 @@ snapshots:
   https-proxy-agent@5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29963,7 +31022,7 @@ snapshots:
   ioredis@4.28.5:
     dependencies:
       cluster-key-slot: 1.1.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       denque: 1.5.1
       lodash.defaults: 4.2.0
       lodash.flatten: 4.4.0
@@ -29980,7 +31039,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -30306,7 +31365,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -30934,7 +31993,7 @@ snapshots:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       execa: 8.0.1
       lilconfig: 3.1.2
       listr2: 8.2.5
@@ -31165,7 +32224,7 @@ snapshots:
       body-parser: 1.20.3
       cookie-parser: 1.4.7
       cors: 2.8.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       express: 4.21.1
       fast-url-parser: 1.1.3
       got: 11.8.6
@@ -31947,7 +33006,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -31969,7 +33028,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -32167,7 +33226,7 @@ snapshots:
 
   mquery@5.0.0:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -32219,6 +33278,8 @@ snapshots:
 
   nanoid@3.3.7: {}
 
+  nanoid@5.0.8: {}
+
   napi-build-utils@1.0.2: {}
 
   native-duplexpair@1.0.0: {}
@@ -32228,7 +33289,7 @@ snapshots:
       '@ionic/utils-fs': 3.1.7
       '@ionic/utils-terminal': 2.3.5
       bplist-parser: 0.3.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       elementtree: 0.1.7
       ini: 3.0.1
       plist: 3.1.0
@@ -32249,7 +33310,7 @@ snapshots:
 
   neverthrow@3.2.0: {}
 
-  next-auth@4.24.8(next@15.0.0(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.8(next@15.0.0(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.7
       '@panva/hkdf': 1.2.1
@@ -32728,7 +33789,7 @@ snapshots:
 
   office-addin-lint@2.2.5(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       commander: 6.2.1
       eslint: 7.32.0
@@ -34497,7 +35558,7 @@ snapshots:
 
   require-in-the-middle@7.4.0:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -34576,7 +35637,7 @@ snapshots:
 
   rhea-promise@3.0.3:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       rhea: 3.0.3
       tslib: 2.8.0
     transitivePeerDependencies:
@@ -34584,7 +35645,7 @@ snapshots:
 
   rhea@3.0.3:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34800,7 +35861,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.12.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       dottie: 2.0.6
       inflection: 1.13.4
       lodash: 4.17.21
@@ -35102,7 +36163,7 @@ snapshots:
 
   socket.io-adapter@2.5.5:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -35112,7 +36173,7 @@ snapshots:
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -35121,7 +36182,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       engine.io: 6.5.5
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
@@ -35217,7 +36278,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -35228,7 +36289,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -36025,7 +37086,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.2.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.23.1
       execa: 5.1.1
       joycon: 3.1.1
@@ -36496,6 +37557,24 @@ snapshots:
   vaul@0.9.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@radix-ui/react-dialog': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  vaul@0.9.1(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  vaul@0.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -137,7 +137,6 @@
       "persistent": true
     },
     "dev:test": {
-      "dependsOn": ["^build:test", "build:test"],
       "outputs": ["dist/**", ".next/**", "build/**", "out/**"],
       "persistent": true
     },
@@ -155,6 +154,10 @@
     },
     "test": {
       "cache": false
+    },
+    "test:watch": {
+      "cache": false,
+      "persistent": true
     },
     "test:run": {
       "cache": false


### PR DESCRIPTION
This pull request solves an issue related to the ordering of answer options on choices questions and their grading process. Run the following script to fix all elements and part of the affected instances:

```bash
cd packages/graphql
pnpm run script:prod src/scripts/2024_10_29_fix_choices_options.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering of choice elements across various components using the `ix` property for improved accuracy and stability.
	- Introduced new session management functionalities, including activating session blocks and improved error handling.
	- Added a new script for validating and updating choice order in the database.
	- New configuration options for Cypress to enable file watching during test execution.
	- Added new scripts for running tests in watch mode.

- **Bug Fixes**
	- Corrected choice ordering logic in multiple components to ensure accurate display and interaction.

- **Tests**
	- Reactivated test cases for creating various question types in the Cypress test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->