### PR TITLE
fix(packages/graphql): ensure that repetition interval remains below maximum value

### DIFF
--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -531,7 +531,8 @@ function updateSpacedRepetition({
     } else if (streak === 2) {
       newInterval = 6
     } else {
-      newInterval = Math.ceil(interval * newEfactor)
+      // limit maximum interval to 10'000 days to ensure that dates remain valid
+      newInterval = Math.min(Math.ceil(interval * newEfactor), 10000)
     }
   }
 


### PR DESCRIPTION
With this pull request, a maximum value is added to the spaced repetition logic and the corresponding interval to ensure that when adding the creation date and the number of days computed as the interval, a new valid date results. During the correction of existing response data, it has been observed, that this is not always given with the current algorithm, since numerous subsequent correct answers can cause problems here.