### PR TITLE
fix(apps/frontend-manage): make sure that runtime counter on live quiz cockpit does not trigger re-rendering of timeline

### DIFF
--- a/.github/workflows/test-grading.yml
+++ b/.github/workflows/test-grading.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches: ['v3', 'v3*']
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'packages/grading/**'
-      - '.github/workflows/test-grading.yml'
 
 jobs:
   test:

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches: ['v3', 'v3*']
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'packages/graphql/**'
-      - '.github/workflows/test-graphql.yml'
 
 jobs:
   test:

--- a/apps/frontend-manage/src/components/sessions/cockpit/RuntimeCounter.tsx
+++ b/apps/frontend-manage/src/components/sessions/cockpit/RuntimeCounter.tsx
@@ -1,0 +1,49 @@
+import { faClock, faPlay } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import dayjs from 'dayjs'
+import durationPlugin from 'dayjs/plugin/duration'
+import { useEffect, useState } from 'react'
+
+dayjs.extend(durationPlugin)
+
+const calculateRuntime = ({ startedAt }: { startedAt?: string }) => {
+  const start = dayjs(startedAt)
+  const duration = dayjs.duration(dayjs().diff(start))
+
+  const days = duration.days()
+  const hours = `0${duration.hours()}`.slice(-2)
+  const minutes = `0${duration.minutes()}`.slice(-2)
+  const seconds = `0${duration.seconds()}`.slice(-2)
+
+  if (days > 0) {
+    return `${days}d ${hours}:${minutes}:${seconds}`
+  }
+  return `${hours}:${minutes}:${seconds}`
+}
+
+function RuntimeCounter({ startedAt }: { startedAt?: string }) {
+  const [runtime, setRuntime] = useState(calculateRuntime({ startedAt }))
+  const startingTime = runtime.includes('d')
+    ? dayjs(startedAt).format('DD.MM HH:mm:ss')
+    : dayjs(startedAt).format('HH:mm:ss')
+
+  useEffect(() => {
+    const currentRuntime = setInterval(() => {
+      setRuntime(calculateRuntime({ startedAt }))
+    }, 1000)
+    return () => clearInterval(currentRuntime)
+  }, [runtime, startedAt])
+
+  return (
+    <>
+      <div>
+        <FontAwesomeIcon icon={faClock} className="mr-1" /> {startingTime}
+      </div>
+      <div>
+        <FontAwesomeIcon icon={faPlay} className="mr-1" /> {runtime}
+      </div>
+    </>
+  )
+}
+
+export default RuntimeCounter

--- a/apps/frontend-manage/src/components/sessions/cockpit/SessionTimeline.tsx
+++ b/apps/frontend-manage/src/components/sessions/cockpit/SessionTimeline.tsx
@@ -1,6 +1,5 @@
 import { faPauseCircle } from '@fortawesome/free-regular-svg-icons'
 import {
-  faClock,
   faCode,
   faPlay,
   faStop,
@@ -8,8 +7,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, H1 } from '@uzh-bf/design-system'
-import dayjs from 'dayjs'
-import durationPlugin from 'dayjs/plugin/duration'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -17,25 +14,9 @@ import React, { useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import EmbeddingModal from '../EmbeddingModal'
 import CancelSessionModal from './CancelSessionModal'
+import RuntimeCounter from './RuntimeCounter'
 import SessionBlock, { SessionTimelineBlock } from './SessionBlock'
 import SessionQRModal from './SessionQRModal'
-
-dayjs.extend(durationPlugin)
-
-const calculateRuntime = ({ startedAt }: { startedAt?: string }): string => {
-  const start = dayjs(startedAt)
-  const duration = dayjs.duration(dayjs().diff(start))
-
-  const days = duration.days()
-  const hours = `0${duration.hours()}`.slice(-2)
-  const minutes = `0${duration.minutes()}`.slice(-2)
-  const seconds = `0${duration.seconds()}`.slice(-2)
-
-  if (days > 0) {
-    return `${days}d ${hours}:${minutes}:${seconds}`
-  }
-  return `${hours}:${minutes}:${seconds}`
-}
 
 interface SessionTimelineProps {
   blocks?: SessionTimelineBlock[]
@@ -68,7 +49,6 @@ function SessionTimeline({
 
   const [cancelSessionModal, setCancelSessionModal] = useState(false)
   const [inCooldown, setInCooldown] = useState<boolean>(false)
-  const [runtime, setRuntime] = useState(calculateRuntime({ startedAt }))
 
   // logic: keep track of the current and previous block
   const [buttonState, setButtonState] = useState<
@@ -77,17 +57,6 @@ function SessionTimeline({
   const [activeBlockId, setActiveBlockId] = useState(-1)
   const [lastActiveBlockId, setLastActiveBlockId] = useState(-1)
   const [embedModalOpen, setEmbedModalOpen] = useState<boolean>(false)
-
-  const startingTime = runtime.includes('d')
-    ? dayjs(startedAt).format('DD.MM HH:mm:ss')
-    : dayjs(startedAt).format('HH:mm:ss')
-
-  useEffect(() => {
-    const currentRuntime = setInterval(() => {
-      setRuntime(calculateRuntime({ startedAt }))
-    }, 1000)
-    return () => clearInterval(currentRuntime)
-  }, [runtime, startedAt])
 
   // basic session timeline logic - identifying the currently active block as well as the state of the session
   useEffect(() => {
@@ -139,12 +108,7 @@ function SessionTimeline({
       <div className="flex flex-1 flex-row flex-wrap items-end justify-between md:flex-auto md:pb-2">
         <div className="flex flex-row flex-wrap items-end gap-8">
           <H1 className={{ root: 'm-0 text-xl' }}>Quiz: {sessionName}</H1>
-          <div>
-            <FontAwesomeIcon icon={faClock} className="mr-1" /> {startingTime}
-          </div>
-          <div>
-            <FontAwesomeIcon icon={faPlay} className="mr-1" /> {runtime}
-          </div>
+          <RuntimeCounter startedAt={startedAt} />
         </div>
 
         <div className="mt-1.5 flex flex-row flex-wrap items-end gap-2 sm:mt-0">

--- a/apps/frontend-manage/src/pages/sessions/[id]/cockpit.tsx
+++ b/apps/frontend-manage/src/pages/sessions/[id]/cockpit.tsx
@@ -91,7 +91,6 @@ function Cockpit() {
   return (
     <Layout>
       <div className="mb-8 print:hidden">
-        {/* // TODO: readd all removed features like authenticated sessions, etc. */}
         <SessionTimeline
           blocks={blocks ?? []}
           sessionName={name}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `RuntimeCounter` component to display session runtime.
	- Enhanced `SessionTimeline` to utilize `RuntimeCounter` for runtime display.
	- Improved session management and user feedback mechanisms in the `Cockpit` component.

- **Bug Fixes**
	- Updated error handling logic for session data fetching to improve user feedback.

- **Chores**
	- Streamlined GitHub Actions workflows by removing path restrictions for pull request triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->