### PR TITLE
fix(apps/frontend-pwa): correctly indicate student rank difference after live quiz block closure

### DIFF
--- a/apps/frontend-pwa/src/components/common/LiveQuizLeaderboard.tsx
+++ b/apps/frontend-pwa/src/components/common/LiveQuizLeaderboard.tsx
@@ -69,7 +69,7 @@ function LiveQuizLeaderboard({
 
             setBlockDelta({
               score: selfEntry.score - prevStoredEntry.score,
-              rank: selfEntry.rank - prevStoredEntry.rank,
+              rank: -(selfEntry.rank - prevStoredEntry.rank),
             })
           } catch (error) {
             console.warn(error)


### PR DESCRIPTION
<img width="650" alt="Screenshot 2024-12-02 at 09 57 41" src="https://github.com/user-attachments/assets/0a3c02b0-33b7-40dd-a072-40ecf135abbf">
<img width="647" alt="Screenshot 2024-12-02 at 09 57 46" src="https://github.com/user-attachments/assets/c9b11ebf-7413-44d8-ac17-94bcee6630af">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rank calculation in the Live Quiz Leaderboard, enhancing the display of rank changes.

- **Bug Fixes**
	- Adjusted the rank difference calculation to ensure accurate leaderboard updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->