### PR TITLE
enhance(packages/shared-components): initially sort evaluation table charts by count

### DIFF
--- a/packages/shared-components/src/DataTable.tsx
+++ b/packages/shared-components/src/DataTable.tsx
@@ -41,6 +41,7 @@ interface DataTableProps<TData, TValue> {
   footerContent?: React.ReactNode
   isPaginated?: boolean
   isResetSortingEnabled?: boolean
+  initialSorting?: SortingState
 }
 
 function DataTable<TData, TValue>({
@@ -51,9 +52,10 @@ function DataTable<TData, TValue>({
   footerContent,
   isPaginated,
   isResetSortingEnabled,
+  initialSorting,
 }: DataTableProps<TData, TValue>) {
   const t = useTranslations()
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>(initialSorting ?? [])
 
   const table = useReactTable({
     data,

--- a/packages/shared-components/src/charts/ElementTableChart.tsx
+++ b/packages/shared-components/src/charts/ElementTableChart.tsx
@@ -61,6 +61,7 @@ function ElementTableChart({
         <DataTable
           isPaginated
           isResetSortingEnabled
+          initialSorting={[{ id: 'count', desc: true }]}
           columns={columns}
           data={tableData}
           csvFilename={`${instance.name}_results`}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `initialSorting` property for the `DataTable`, allowing users to set a predefined sorting state.
	- Enhanced `ElementTableChart` to default the `DataTable` sorting to the `count` field in descending order upon initial render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->