### PR TITLE
enhance(apps/analytics): allow switching between courses and activity on analytics dashboards

### DIFF
--- a/apps/frontend-manage/src/components/analytics/activity/ActivityAnalyticsNavigation.tsx
+++ b/apps/frontend-manage/src/components/analytics/activity/ActivityAnalyticsNavigation.tsx
@@ -9,6 +9,7 @@ function ActivityAnalyticsNavigation({ courseId }: { courseId: string }) {
       labelLeft={<QuizDashboardLabel />}
       hrefRight={`/analytics/${courseId}/performance`}
       labelRight={<PerformanceDashboardLabel />}
+      slug="activity"
     />
   )
 }

--- a/apps/frontend-manage/src/components/analytics/overview/AnalyticsNavigation.tsx
+++ b/apps/frontend-manage/src/components/analytics/overview/AnalyticsNavigation.tsx
@@ -1,15 +1,22 @@
+import { useQuery } from '@apollo/client'
 import {
   faChevronLeft,
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { GetUserCoursesDocument } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
+import { SelectField } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 interface AnalyticsNavigationProps {
   hrefLeft: string
   labelLeft: React.ReactNode
   hrefRight: string
   labelRight: React.ReactNode
+  slug: string
 }
 
 function AnalyticsNavigation({
@@ -17,14 +24,46 @@ function AnalyticsNavigation({
   labelLeft,
   hrefRight,
   labelRight,
+  slug,
 }: AnalyticsNavigationProps) {
+  const { data, loading } = useQuery(GetUserCoursesDocument)
+  const router = useRouter()
+  const t = useTranslations()
+
+  if (loading) {
+    return <Loader />
+  }
+
   return (
-    <div className="flex w-full flex-row justify-between">
-      <Link href={hrefLeft} className="mb-6 flex flex-row items-center gap-2">
+    <div className="mb-6 grid w-full grid-cols-2 md:grid-cols-3">
+      <Link
+        href={hrefLeft}
+        className="flex flex-row items-center justify-start gap-2"
+      >
         <FontAwesomeIcon icon={faChevronLeft} size="lg" />
         <div className="flex flex-row items-center gap-0.5">{labelLeft}</div>
       </Link>
-      <Link href={hrefRight} className="mb-6 flex flex-row items-center gap-2">
+      <div className="hidden justify-center md:flex">
+        <SelectField
+          label={`${t('shared.generic.course')}:`}
+          labelType="large"
+          value={router.query.courseId as string}
+          items={
+            data?.userCourses?.map((course) => ({
+              label: course.name,
+              value: course.id,
+            })) ?? []
+          }
+          onChange={(value) => {
+            router.push({ pathname: `/analytics/${value}/${slug}` })
+          }}
+          className={{ select: { trigger: 'h-8' } }}
+        />
+      </div>
+      <Link
+        href={hrefRight}
+        className="flex flex-row items-center justify-end gap-2"
+      >
         <div className="flex flex-row items-center gap-0.5">{labelRight}</div>
         <FontAwesomeIcon icon={faChevronRight} size="lg" />
       </Link>

--- a/apps/frontend-manage/src/components/analytics/performance/PerformanceAnalyticsNavigation.tsx
+++ b/apps/frontend-manage/src/components/analytics/performance/PerformanceAnalyticsNavigation.tsx
@@ -9,6 +9,7 @@ function PerformanceAnalyticsNavigation({ courseId }: { courseId: string }) {
       labelLeft={<ActivityDashboardLabel />}
       hrefRight={`/analytics/${courseId}/quizzes`}
       labelRight={<QuizDashboardLabel />}
+      slug="performance"
     />
   )
 }

--- a/apps/frontend-manage/src/components/analytics/quiz/QuizAnalyticsNavigation.tsx
+++ b/apps/frontend-manage/src/components/analytics/quiz/QuizAnalyticsNavigation.tsx
@@ -1,22 +1,84 @@
+import { useQuery } from '@apollo/client'
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { GetCourseActivitiesDocument } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
+import { SelectField } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
-function QuizAnalyticsNavigation({ courseId }: { courseId: string }) {
+function QuizAnalyticsNavigation({
+  courseId,
+  activityId,
+}: {
+  courseId: string
+  activityId: string
+}) {
+  const { data, loading } = useQuery(GetCourseActivitiesDocument, {
+    variables: { courseId },
+  })
   const t = useTranslations()
+  const router = useRouter()
+
+  if (loading) {
+    return <Loader />
+  }
 
   return (
-    <div className="flex w-full flex-row justify-between">
+    <div className="mb-6 grid w-full grid-cols-3">
       <Link
         href={`/analytics/${courseId}/quizzes`}
-        className="mb-6 flex flex-row items-center gap-2"
+        className="flex flex-row items-center gap-2"
       >
         <FontAwesomeIcon icon={faChevronLeft} size="lg" />
         <div className="flex flex-row items-center gap-0.5">
           {t('manage.analytics.backToActivitySelection')}
         </div>
       </Link>
+      <div className="flex justify-center">
+        <SelectField
+          label={`${t('shared.generic.activity')}:`}
+          labelType="large"
+          value={activityId}
+          groups={[
+            ...(data?.getCourseActivities?.practiceQuizzes &&
+            data.getCourseActivities.practiceQuizzes.length > 0
+              ? [
+                  {
+                    label: `${t('shared.generic.practiceQuizzes')}:`,
+                    items:
+                      data?.getCourseActivities?.practiceQuizzes?.map(
+                        (activity) => ({
+                          label: activity.name,
+                          value: activity.id,
+                        })
+                      ) ?? [],
+                  },
+                ]
+              : []),
+            ...(data?.getCourseActivities?.microLearnings &&
+            data.getCourseActivities.microLearnings.length > 0
+              ? [
+                  {
+                    label: `${t('shared.generic.microlearnings')}:`,
+                    items:
+                      data?.getCourseActivities?.microLearnings?.map(
+                        (activity) => ({
+                          label: activity.name,
+                          value: activity.id,
+                        })
+                      ) ?? [],
+                  },
+                ]
+              : []),
+          ]}
+          onChange={(value) => {
+            router.push({ pathname: `/analytics/${courseId}/quizzes/${value}` })
+          }}
+          className={{ select: { trigger: 'h-8' } }}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/analytics/quiz/QuizSelectionNavigation.tsx
+++ b/apps/frontend-manage/src/components/analytics/quiz/QuizSelectionNavigation.tsx
@@ -9,6 +9,7 @@ function QuizSelectionNavigation({ courseId }: { courseId: string }) {
       labelLeft={<PerformanceDashboardLabel />}
       hrefRight={`/analytics/${courseId}/activity`}
       labelRight={<ActivityDashboardLabel />}
+      slug="quizzes"
     />
   )
 }

--- a/apps/frontend-manage/src/pages/analytics/[courseId]/quizzes/[id].tsx
+++ b/apps/frontend-manage/src/pages/analytics/[courseId]/quizzes/[id].tsx
@@ -22,7 +22,9 @@ function QuizAnalytics() {
     skip: !activityId,
   })
 
-  const navigation = <QuizAnalyticsNavigation courseId={courseId} />
+  const navigation = (
+    <QuizAnalyticsNavigation courseId={courseId} activityId={activityId} />
+  )
   const analytics = data?.getActivityAnalytics
 
   const chartColors = {

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -230,6 +230,7 @@ export default {
       q3: 'Q3',
       weeks: 'Wochen',
       student: 'Studierende(r)',
+      activity: 'Aktivität',
     },
     contentInput: {
       boldStyle:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -230,6 +230,7 @@ export default {
       q3: 'Q3',
       weeks: 'Weeks',
       student: 'Student',
+      activity: 'Activity',
     },
     contentInput: {
       boldStyle:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `AnalyticsNavigation` components across various sections (Activity, Overview, Performance, Quiz) with new `slug` props for improved functionality.
	- Introduced a loading state and a course selection dropdown in the Overview section, allowing users to select and navigate to specific courses.

- **Bug Fixes**
	- Improved layout structure in the Overview section by changing from flexbox to grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->