### PR TITLE
fix(apps/frontend-manage): do not allow duplicate option values in answer collections

### DIFF
--- a/apps/frontend-manage/src/components/resources/answerCollections/AddAnswerCollectionEntry.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AddAnswerCollectionEntry.tsx
@@ -4,25 +4,33 @@ import { faPlusCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   AddAnswerCollectionOptionDocument,
+  AnswerCollectionEntry,
   GetAnswerCollectionsDocument,
 } from '@klicker-uzh/graphql/dist/ops'
 import { Button, FormikTextField } from '@uzh-bf/design-system'
 import { Form, Formik } from 'formik'
 import { useTranslations } from 'next-intl'
-import { Dispatch, SetStateAction, useState } from 'react'
+import { Dispatch, SetStateAction, useMemo, useState } from 'react'
 import * as Yup from 'yup'
 
 function AddAnswerCollectionEntry({
   collectionId,
+  entries,
   setOptionsEditingDisabled,
 }: {
   collectionId: number
+  entries: AnswerCollectionEntry[]
   setOptionsEditingDisabled: Dispatch<SetStateAction<boolean>>
 }) {
   const t = useTranslations()
   const [fieldOpen, setFieldOpen] = useState(false)
   const [addAnswerCollectionOption] = useMutation(
     AddAnswerCollectionOptionDocument
+  )
+
+  const entryValues = useMemo(
+    () => entries.map((entry) => entry.value),
+    [entries]
   )
 
   if (!fieldOpen) {
@@ -43,11 +51,15 @@ function AddAnswerCollectionEntry({
 
   return (
     <Formik
+      validateOnMount
       initialValues={{
         newValue: undefined,
       }}
+      initialTouched={{ newValue: true }}
       validationSchema={Yup.object({
-        newValue: Yup.string().required(t('manage.resources.valueRequired')),
+        newValue: Yup.string()
+          .required(t('manage.resources.valueRequired'))
+          .notOneOf(entryValues, t('manage.resources.uniqueValuesRequired')),
       })}
       onSubmit={async (values) => {
         await addAnswerCollectionOption({
@@ -94,7 +106,6 @@ function AddAnswerCollectionEntry({
         setFieldOpen(false)
         setOptionsEditingDisabled(false)
       }}
-      validateOnMount
     >
       {({ isValid, isSubmitting }) => (
         <Form className="flex flex-row gap-1">

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionCreation.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionCreation.tsx
@@ -53,7 +53,17 @@ function AnswerCollectionCreation({
           value: Yup.string().required(t('manage.resources.valueRequired')),
         })
       )
-      .min(2, t('manage.resources.minTwoEntriesRequired')),
+      .min(2, t('manage.resources.minTwoEntriesRequired'))
+      .test(
+        'unique',
+        t('manage.resources.uniqueValuesRequired'),
+        function (arr) {
+          if (!arr) return true
+          const values = arr.map((item) => item.value)
+          const uniqueValues = new Set(values)
+          return values.length === uniqueValues.size
+        }
+      ),
   })
 
   return (

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
@@ -57,7 +57,9 @@ function AnswerCollectionEditModal({
           <AnswerCollectionOption
             key={`collection-entry-${entry.id}`}
             entry={entry}
-            index={ix}
+            otherEntries={collection
+              .entries!.filter((e) => e.id !== entry.id)
+              .map((e) => e.value)}
             last={ix === collection.entries!.length - 1}
             collectionId={collection.id}
             deletionDisabled={collection.entries!.length <= 2}

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
@@ -67,6 +67,7 @@ function AnswerCollectionEditModal({
         ))}
         <AddAnswerCollectionEntry
           collectionId={collection.id}
+          entries={collection.entries ?? []}
           setOptionsEditingDisabled={setOptionsEditingDisabled}
         />
       </div>

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionOption.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionOption.tsx
@@ -10,12 +10,14 @@ import {
 } from '@klicker-uzh/graphql/dist/ops'
 import { Button, FormikTextField } from '@uzh-bf/design-system'
 import { Form, Formik } from 'formik'
+import { useTranslations } from 'next-intl'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import * as Yup from 'yup'
 
 function AnswerCollectionOption({
   entry,
-  index,
+  otherEntries,
   last,
   collectionId,
   deletionDisabled,
@@ -23,13 +25,14 @@ function AnswerCollectionOption({
   setEditDisabled,
 }: {
   entry: AnswerCollectionEntry
-  index: number
+  otherEntries: string[]
   last: boolean
   collectionId: number
   deletionDisabled?: boolean
   editDisabled: boolean
   setEditDisabled: Dispatch<SetStateAction<boolean>>
 }) {
+  const t = useTranslations()
   const [editMode, setEditMode] = useState(false)
   const [editAnswerCollectionEntry] = useMutation(
     EditAnswerCollectionEntryDocument
@@ -120,7 +123,17 @@ function AnswerCollectionOption({
       >
         {editMode ? (
           <Formik
+            isInitialValid
             initialValues={{ value: entry.value }}
+            validationSchema={Yup.object({
+              value: Yup.string()
+                .required(t('manage.resources.valueRequired'))
+                .notOneOf(
+                  otherEntries,
+                  t('manage.resources.uniqueValuesRequired')
+                ),
+            })}
+            initialTouched={{ value: true }}
             onSubmit={async (values, { setSubmitting }) => {
               setSubmitting(true)
 
@@ -177,17 +190,18 @@ function AnswerCollectionOption({
               setEditDisabled(false)
             }}
           >
-            {({ isSubmitting }) => (
+            {({ isSubmitting, isValid }) => (
               <Form className="flex flex-row gap-[0.1875rem]">
                 <Button
                   type="submit"
                   className={{
                     root: twMerge(
                       'border-primary-80 hover:border-primary-80 bg-primary-100 h-8 w-8 items-center justify-center border text-white',
-                      isSubmitting && 'bg-primary-60 cursor-not-allowed'
+                      (isSubmitting || !isValid) &&
+                        'bg-primary-60 cursor-not-allowed'
                     ),
                   }}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || !isValid}
                   data={{ cy: 'save-edit-answer-option' }}
                 >
                   <FontAwesomeIcon icon={faSave} />

--- a/cypress/cypress/e2e/K-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/K-resources-workflow.cy.ts
@@ -105,6 +105,7 @@ describe('Create, edit and share answer collections', () => {
       cy.get(`[data-cy="response-entry-${ix + 2}"]`).should('have.value', value)
     })
 
+    // test deletion of answer option
     cy.get(`[data-cy="response-entry-${publicItems.length - 1}"]`).should(
       'exist'
     )
@@ -113,6 +114,16 @@ describe('Create, edit and share answer collections', () => {
       'not.exist'
     )
     cy.get(`[data-cy="response-entry-3"]`).should('have.value', publicItems[4])
+    cy.get('[data-cy="submit-create-answer-collection"]').should(
+      'not.be.disabled'
+    )
+
+    // verify that duplicated answer options are not accepted
+    cy.get('[data-cy="add-response-entry"]').click()
+    cy.get(`[data-cy="response-entry-4"]`).type(publicItems[0])
+    cy.get(`[data-cy="response-entry-4"]`).should('have.value', publicItems[0])
+    cy.get('[data-cy="remove-response-entry-4"]').click()
+    cy.get(`[data-cy="response-entry-4"]`).should('not.exist')
 
     cy.get('[data-cy="submit-create-answer-collection"]').click()
     cy.get(`[data-cy="answer-collection-${publicName}"]`).should('exist')

--- a/cypress/cypress/e2e/K-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/K-resources-workflow.cy.ts
@@ -200,11 +200,17 @@ describe('Create, edit and share answer collections', () => {
       )
     })
 
+    const existingElement = privateItemsNew[0]
     const lastElement = privateItemsNew[privateItemsNew.length - 1]
     cy.get(`[data-cy="delete-answer-option-${lastElement}"]`).click()
     cy.get(`[data-cy="answer-option-${lastElement}"]`).should('not.exist')
     cy.get(`[data-cy="add-answer-option"]`).click()
+    cy.get(`[data-cy="save-new-answer-option"]`).should('be.disabled')
     cy.get(`[data-cy="input-new-answer-option"]`).type(lastElement)
+    cy.get(`[data-cy="save-new-answer-option"]`).should('not.be.disabled')
+    cy.get(`[data-cy="input-new-answer-option"]`).clear().type(existingElement)
+    cy.get(`[data-cy="save-new-answer-option"]`).should('be.disabled')
+    cy.get(`[data-cy="input-new-answer-option"]`).clear().type(lastElement)
     cy.get(`[data-cy="save-new-answer-option"]`).click()
     cy.get(`[data-cy="answer-option-${lastElement}"]`).contains(lastElement)
   })

--- a/cypress/cypress/e2e/K-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/K-resources-workflow.cy.ts
@@ -120,10 +120,19 @@ describe('Create, edit and share answer collections', () => {
 
     // verify that duplicated answer options are not accepted
     cy.get('[data-cy="add-response-entry"]').click()
-    cy.get(`[data-cy="response-entry-4"]`).type(publicItems[0])
-    cy.get(`[data-cy="response-entry-4"]`).should('have.value', publicItems[0])
-    cy.get('[data-cy="remove-response-entry-4"]').click()
-    cy.get(`[data-cy="response-entry-4"]`).should('not.exist')
+    cy.get(`[data-cy="response-entry-${publicItems.length - 1}"]`).type(
+      publicItems[0]
+    )
+    cy.get(`[data-cy="response-entry-${publicItems.length - 1}"]`).should(
+      'have.value',
+      publicItems[0]
+    )
+    cy.get(
+      `[data-cy="remove-response-entry-${publicItems.length - 1}"]`
+    ).click()
+    cy.get(`[data-cy="response-entry-${publicItems.length - 1}"]`).should(
+      'not.exist'
+    )
 
     cy.get('[data-cy="submit-create-answer-collection"]').click()
     cy.get(`[data-cy="answer-collection-${publicName}"]`).should('exist')
@@ -185,9 +194,29 @@ describe('Create, edit and share answer collections', () => {
       .contains(privateDescriptionNew)
     cy.get('[data-cy="save-changes-answer-collection"]').click()
 
+    // check that current values are correct
     privateItems.forEach((value) => {
       cy.get(`[data-cy="answer-option-${value}"]`).contains(value)
     })
+
+    // verify validation for editing answer options
+    cy.get(`[data-cy="edit-answer-option-${privateItems[0]}"]`).click()
+    cy.get(`[data-cy="edit-answer-option-input"]`).should(
+      'have.value',
+      privateItems[0]
+    )
+
+    cy.get(`[data-cy="save-edit-answer-option"]`).should('not.be.disabled')
+    cy.get(`[data-cy="edit-answer-option-input"]`).clear().type(privateItems[1]) // duplicate answer options not allowed
+    cy.get(`[data-cy="save-edit-answer-option"]`).should('be.disabled')
+    cy.get(`[data-cy="edit-answer-option-input"]`).clear().type(privateItems[0])
+    cy.get(`[data-cy="save-edit-answer-option"]`).should('not.be.disabled')
+    cy.get(`[data-cy="edit-answer-option-input"]`).clear() // empty options are not allowed
+    cy.get(`[data-cy="save-edit-answer-option"]`).should('be.disabled')
+    cy.get(`[data-cy="edit-answer-option-input"]`).clear().type(privateItems[0])
+    cy.get(`[data-cy="save-edit-answer-option"]`).click()
+
+    // change all answer option values
     privateItems.forEach((value, ix) => {
       cy.get(`[data-cy="edit-answer-option-${value}"]`).click()
       cy.get(`[data-cy="edit-answer-option-input"]`).should('have.value', value)
@@ -200,6 +229,7 @@ describe('Create, edit and share answer collections', () => {
       )
     })
 
+    // verify validation for newly added answer options and add new answer option
     const existingElement = privateItemsNew[0]
     const lastElement = privateItemsNew[privateItemsNew.length - 1]
     cy.get(`[data-cy="delete-answer-option-${lastElement}"]`).click()
@@ -208,9 +238,13 @@ describe('Create, edit and share answer collections', () => {
     cy.get(`[data-cy="save-new-answer-option"]`).should('be.disabled')
     cy.get(`[data-cy="input-new-answer-option"]`).type(lastElement)
     cy.get(`[data-cy="save-new-answer-option"]`).should('not.be.disabled')
-    cy.get(`[data-cy="input-new-answer-option"]`).clear().type(existingElement)
+    cy.get(`[data-cy="input-new-answer-option"]`).clear().type(existingElement) // duplicate answer options not allowed
     cy.get(`[data-cy="save-new-answer-option"]`).should('be.disabled')
-    cy.get(`[data-cy="input-new-answer-option"]`).clear().type(lastElement)
+    cy.get(`[data-cy="input-new-answer-option"]`).type(lastElement)
+    cy.get(`[data-cy="save-new-answer-option"]`).should('not.be.disabled')
+    cy.get(`[data-cy="input-new-answer-option"]`).clear() // empty answers not allowed
+    cy.get(`[data-cy="save-new-answer-option"]`).should('be.disabled')
+    cy.get(`[data-cy="input-new-answer-option"]`).type(lastElement)
     cy.get(`[data-cy="save-new-answer-option"]`).click()
     cy.get(`[data-cy="answer-option-${lastElement}"]`).contains(lastElement)
   })

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1890,6 +1890,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       valueRequired: 'Bitte geben Sie einen Wert für den Eintrag an.',
       minTwoEntriesRequired:
         'Bitte fügen Sie mindestens zwei Einträge zu Ihrer Sammlung hinzu.',
+      uniqueValuesRequired:
+        'Alle Optionen in einer Antwort-Sammlung müssen einen einzigartigen Wert haben. Bitte stellen Sie sicher, dass keine zwei Antwortoptionen übereinstimmen.',
       infoAccessPUBLIC:
         'Öffentliche Antwort-Sammlungen können von allen Nutzern eingesehen und importiert werden.',
       infoAccessPRIVATE:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1876,6 +1876,8 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       valueRequired: 'Please enter a value for the answer entry.',
       minTwoEntriesRequired:
         'At least two answer entries are required to create an answer collection.',
+      uniqueValuesRequired:
+        'All options in an answer collection need to have a unique value. Please make sure that no two answers options coincide.',
       infoAccessPUBLIC:
         'Public answer collections can be viewed and imported by all users.',
       infoAccessPRIVATE:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation to prevent duplicate entries in answer collections.
  - Introduced a new property to manage existing entries in the answer collection component.

- **Bug Fixes**
  - Ensured unique values are required when creating answer collections.

- **Documentation**
  - Added error messages in German and English explaining unique value requirements.

- **Tests**
  - Implemented Cypress tests to verify unique answer option validation and deletion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->