### PR TITLE
fix: ensure that live quiz abortion modal also takes into account cached responses

### DIFF
--- a/apps/frontend-manage/src/components/courses/modals/GroupActivityDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/GroupActivityDeletionModal.tsx
@@ -23,14 +23,13 @@ function GroupActivityConfirmationModal({
   courseId,
 }: GroupActivityConfirmationModalProps) {
   const t = useTranslations()
-  const {
-    data: summaryData,
-    loading: summaryLoading,
-    refetch,
-  } = useQuery(GetGroupActivitySummaryDocument, {
-    variables: { id: activityId },
-    skip: !open,
-  })
+  const { data: summaryData, loading: summaryLoading } = useQuery(
+    GetGroupActivitySummaryDocument,
+    {
+      variables: { id: activityId },
+      skip: !open,
+    }
+  )
 
   const [deleteGroupActivity, { loading: deletingGroupActivity }] = useMutation(
     DeleteGroupActivityDocument,
@@ -55,13 +54,6 @@ function GroupActivityConfirmationModal({
     deleteStartedInstances: false,
     deleteSubmissions: false,
   })
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   useEffect(() => {
     if (summaryData?.getGroupActivitySummary) {

--- a/apps/frontend-manage/src/components/courses/modals/GroupActivityEndingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/GroupActivityEndingModal.tsx
@@ -24,14 +24,13 @@ function GroupActivityEndingModal({
   courseId,
 }: GroupActivityEndingModalProps) {
   const t = useTranslations()
-  const {
-    data: summaryData,
-    loading: summaryLoading,
-    refetch,
-  } = useQuery(GetGroupActivitySummaryDocument, {
-    variables: { id: activityId },
-    skip: !open,
-  })
+  const { data: summaryData, loading: summaryLoading } = useQuery(
+    GetGroupActivitySummaryDocument,
+    {
+      variables: { id: activityId },
+      skip: !open,
+    }
+  )
 
   const [endGroupActivity, { loading: endingGroupActivity }] = useMutation(
     EndGroupActivityDocument,
@@ -56,13 +55,6 @@ function GroupActivityEndingModal({
     startedInstances: false,
     submissions: true,
   })
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   useEffect(() => {
     if (summaryData?.getGroupActivitySummary) {

--- a/apps/frontend-manage/src/components/courses/modals/LiveQuizDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/LiveQuizDeletionModal.tsx
@@ -21,14 +21,13 @@ function LiveQuizDeletionModal({
   deleting,
 }: LiveQuizDeletionModalProps) {
   const t = useTranslations()
-  const {
-    data: summaryData,
-    loading: summaryLoading,
-    refetch,
-  } = useQuery(GetLiveQuizSummaryDocument, {
-    variables: { quizId },
-    skip: !open,
-  })
+  const { data: summaryData, loading: summaryLoading } = useQuery(
+    GetLiveQuizSummaryDocument,
+    {
+      variables: { quizId },
+      skip: !open,
+    }
+  )
 
   const [confirmations, setConfirmations] = useState({
     deleteResponses: false,
@@ -36,13 +35,6 @@ function LiveQuizDeletionModal({
     deleteFeedbacks: false, // Q&A channel
     deleteConfusionFeedbacks: false, // Confusion channel
   })
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   useEffect(() => {
     if (summaryData?.getLiveQuizSummary) {

--- a/apps/frontend-manage/src/components/courses/modals/MicroLearningDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/MicroLearningDeletionModal.tsx
@@ -23,14 +23,13 @@ function MicroLearningDeletionModal({
   courseId,
 }: MicroLearningDeletionModalProps) {
   const t = useTranslations()
-  const {
-    data: summaryData,
-    loading: summaryLoading,
-    refetch,
-  } = useQuery(GetMicroLearningSummaryDocument, {
-    variables: { id: activityId },
-    skip: !open,
-  })
+  const { data: summaryData, loading: summaryLoading } = useQuery(
+    GetMicroLearningSummaryDocument,
+    {
+      variables: { id: activityId },
+      skip: !open,
+    }
+  )
 
   const [deleteMicroLearning, { loading: deletingMicroLearning }] = useMutation(
     DeleteMicroLearningDocument,
@@ -53,13 +52,6 @@ function MicroLearningDeletionModal({
     deleteResponses: false,
     deleteAnonymousResponses: false,
   })
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   useEffect(() => {
     if (summaryData?.getMicroLearningSummary) {

--- a/apps/frontend-manage/src/components/courses/modals/MicroLearningEndingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/MicroLearningEndingModal.tsx
@@ -6,7 +6,6 @@ import {
   PublicationStatus,
 } from '@klicker-uzh/graphql/dist/ops'
 import { useTranslations } from 'next-intl'
-import { useEffect } from 'react'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
@@ -24,14 +23,13 @@ function MicroLearningEndingModal({
   courseId,
 }: MicroLearningEndingModalProps) {
   const t = useTranslations()
-  const {
-    data: summaryData,
-    loading: summaryLoading,
-    refetch,
-  } = useQuery(GetMicroLearningSummaryDocument, {
-    variables: { id: activityId },
-    skip: !open,
-  })
+  const { data: summaryData, loading: summaryLoading } = useQuery(
+    GetMicroLearningSummaryDocument,
+    {
+      variables: { id: activityId },
+      skip: !open,
+    }
+  )
 
   const [endMicroLearning, { loading: endingMicroLearning }] = useMutation(
     EndMicroLearningDocument,
@@ -76,13 +74,6 @@ function MicroLearningEndingModal({
       },
     }
   )
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   if (!summaryData?.getMicroLearningSummary) return null
   const summary = summaryData.getMicroLearningSummary

--- a/apps/frontend-manage/src/components/courses/modals/PracticeQuizDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/PracticeQuizDeletionModal.tsx
@@ -23,14 +23,13 @@ function PracticeQuizDeletionModal({
   courseId,
 }: PracticeQuizDeletionModalProps) {
   const t = useTranslations()
-  const {
-    data: summaryData,
-    loading: summaryLoading,
-    refetch,
-  } = useQuery(GetPracticeQuizSummaryDocument, {
-    variables: { id: activityId },
-    skip: !open,
-  })
+  const { data: summaryData, loading: summaryLoading } = useQuery(
+    GetPracticeQuizSummaryDocument,
+    {
+      variables: { id: activityId },
+      skip: !open,
+    }
+  )
 
   const [deletePracticeQuiz, { loading: deletingPracticeQuiz }] = useMutation(
     DeletePracticeQuizDocument,
@@ -53,13 +52,6 @@ function PracticeQuizDeletionModal({
     deleteResponses: false,
     deleteAnonymousResponses: false,
   })
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   useEffect(() => {
     if (summaryData?.getPracticeQuizSummary) {

--- a/apps/frontend-manage/src/components/liveQuiz/EmbeddingModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/EmbeddingModal.tsx
@@ -14,15 +14,18 @@ function LazyHMACLink({
   quizId,
   params,
   identifier,
+  skipQuery = false,
 }: {
   quizId: string
   params: string
   identifier: string
+  skipQuery?: boolean
 }) {
   const quizHMAC = useQuery(GetLiveQuizHmacDocument, {
     variables: {
       id: quizId,
     },
+    skip: skipQuery,
   })
 
   if (quizHMAC.loading || !quizHMAC.data?.liveQuizHMAC) {
@@ -106,6 +109,7 @@ function EmbeddingModal({
           quizId={quizId}
           params={``}
           identifier="generic-evaluation"
+          skipQuery={!open}
         />
       </div>
       <div className="flex flex-col gap-2">

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/CancelLiveQuizModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/CancelLiveQuizModal.tsx
@@ -45,11 +45,7 @@ function CancelLiveQuizModal({
     })
 
   // fetch course information
-  const {
-    data,
-    loading: queryLoading,
-    refetch,
-  } = useQuery(GetLiveQuizSummaryDocument, {
+  const { data, loading: queryLoading } = useQuery(GetLiveQuizSummaryDocument, {
     variables: { quizId },
     skip: !open,
   })
@@ -75,13 +71,6 @@ function CancelLiveQuizModal({
       refetchQueries: [{ query: GetUserLiveQuizzesDocument }],
     }
   )
-
-  // manually re-trigger the query when the modal is opened
-  useEffect(() => {
-    if (open) {
-      refetch()
-    }
-  }, [open])
 
   useEffect(() => {
     if (!data?.getLiveQuizSummary) {

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
@@ -44,7 +44,7 @@ function LiveQuizQRModal({ quizId }: { quizId: string }): React.ReactElement {
     >
       <div className="flex flex-col gap-8 md:flex-row">
         <div className="flex-1">
-          <H3>Account Link</H3>
+          <H3>{t('manage.cockpit.qrCodeAccountLinkTitle')}</H3>
           <Prose>{t('manage.cockpit.qrCodeAccountLinkDescription')}</Prose>
           <QR
             className={{ title: 'text-base', canvas: 'flex justify-center' }}

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
@@ -81,7 +81,7 @@ function ElementEditModal({
     GetSingleQuestionDocument,
     {
       variables: { id: elementId! },
-      skip: typeof elementId === 'undefined',
+      skip: typeof elementId === 'undefined' || !isOpen,
     }
   )
 

--- a/apps/frontend-pwa/src/components/participant/ParticipantProfileModal.tsx
+++ b/apps/frontend-pwa/src/components/participant/ParticipantProfileModal.tsx
@@ -26,6 +26,7 @@ function ParticipantProfileModal({
   )
   const { data, loading } = useQuery(GetPublicParticipantProfileDocument, {
     variables: { id: selectedParticipant },
+    skip: !isProfileModalOpen,
   })
 
   const participant = data?.publicParticipantProfile

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -1612,18 +1612,45 @@ export async function getLiveQuizSummary(
           elements: true,
         },
       },
+      activeBlock: {
+        include: {
+          elements: true,
+        },
+      },
     },
   })
 
   if (!liveQuiz) return null
 
-  const storedResponses = liveQuiz.blocks.reduce((acc_b, block) => {
+  // get responses for completed blocks
+  let storedResponses = liveQuiz.blocks.reduce((acc_b, block) => {
     acc_b += block.elements.reduce((acc_i, instance) => {
       acc_i += instance.results.total + instance.anonymousResults.total
       return acc_i
     }, 0)
     return acc_b
   }, 0)
+
+  // get results for active blocks
+  if (liveQuiz.activeBlock) {
+    const cachedResults = await getCachedBlockResults({
+      ctx,
+      activeBlock: liveQuiz.activeBlock,
+    })
+
+    if (cachedResults) {
+      const { instanceResults } = cachedResults
+      const cachedResponses = liveQuiz.activeBlock.elements.reduce(
+        (acc, instance) => {
+          acc += instanceResults[instance.id]?.anonymousResults.total ?? 0
+          return acc
+        },
+        0
+      )
+
+      storedResponses += cachedResponses
+    }
+  }
 
   return {
     numOfResponses: storedResponses,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Optimization**
	- Simplified data fetching logic in multiple modals by removing manual query re-triggering
	- Added conditional query execution for several components to prevent unnecessary API calls

- **Localization**
	- Updated QR code modal to support translatable text for account link title

- **Query Handling**
	- Enhanced `getLiveQuizSummary` function to include responses from active and completed quiz blocks
	- Added `skipQuery` option to conditionally execute GraphQL queries in modals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->