### PR TITLE
enhance(apps/frontend-manage): add QR modal to live quiz list for embedding

### DIFF
--- a/apps/frontend-manage/src/components/liveQuiz/LiveQuiz.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/LiveQuiz.tsx
@@ -8,6 +8,7 @@ import {
   faCode,
   faPencil,
   faPlay,
+  faQrcode,
   faTrash,
   faUserGroup,
 } from '@fortawesome/free-solid-svg-icons'
@@ -30,6 +31,7 @@ import { WizardMode } from '../activities/ElementCreation'
 import LiveQuizDeletionModal from '../courses/modals/LiveQuizDeletionModal'
 import EmbeddingModal from './EmbeddingModal'
 import LiveQuizNameChangeModal from './LiveQuizNameChangeModal'
+import LiveQuizQRModal from './cockpit/LiveQuizQRModal'
 
 function LiveQuiz({
   quiz,
@@ -108,6 +110,7 @@ function LiveQuiz({
   const [showDetails, setShowDetails] = useState<boolean>(false)
   const [selectedLiveQuiz, setSelectedLiveQuiz] = useState<string>('')
   const [embedModalOpen, setEmbedModalOpen] = useState<boolean>(false)
+  const [qrModalOpen, setQrModalOpen] = useState<boolean>(false)
   const [deletionModal, setDeletionModal] = useState<boolean>(false)
   const [changeName, setChangeName] = useState<boolean>(false)
 
@@ -183,6 +186,27 @@ function LiveQuiz({
                           (instance) =>
                             typeof instance !== 'undefined' && instance !== null
                         )}
+                    />
+                  </>
+                )}
+
+                {quiz.status !== PublicationStatus.Ended && (
+                  <>
+                    <Button
+                      basic
+                      onClick={() => setQrModalOpen(true)}
+                      className={{
+                        root: 'hover:text-primary-100 flex cursor-pointer flex-row items-center gap-2 text-sm',
+                      }}
+                      data={{ cy: `show-qr-modal-${quiz.name}` }}
+                    >
+                      <FontAwesomeIcon icon={faQrcode} size="sm" />
+                      {t('manage.general.qrCode')}
+                    </Button>
+                    <LiveQuizQRModal
+                      quizId={quiz.id}
+                      open={qrModalOpen}
+                      setOpen={setQrModalOpen}
                     />
                   </>
                 )}

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
@@ -1,17 +1,22 @@
 import { useQuery } from '@apollo/client'
-import { faQrcode } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { UserProfileDocument } from '@klicker-uzh/graphql/dist/ops'
 import QR from '@pages/qr/[...args]'
 import { Button, H3, Modal, Prose } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
-import React, { useState } from 'react'
+import React, { Dispatch, SetStateAction } from 'react'
 import { twMerge } from 'tailwind-merge'
 
-function LiveQuizQRModal({ quizId }: { quizId: string }): React.ReactElement {
+function LiveQuizQRModal({
+  quizId,
+  open,
+  setOpen,
+}: {
+  quizId: string
+  open: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+}): React.ReactElement {
   const t = useTranslations()
-  const [modalOpen, setModalOpen] = useState(false)
 
   const { data } = useQuery(UserProfileDocument, {
     fetchPolicy: 'cache-only',
@@ -23,21 +28,9 @@ function LiveQuizQRModal({ quizId }: { quizId: string }): React.ReactElement {
 
   return (
     <Modal
-      title="QR Code"
-      trigger={
-        <Button
-          className={{ root: '!mr-0 w-[41%] sm:w-max' }}
-          onClick={() => setModalOpen(true)}
-          data={{ cy: `qr-modal-trigger-${shortname}` }}
-        >
-          <Button.Icon>
-            <FontAwesomeIcon icon={faQrcode} />
-          </Button.Icon>
-          {t('manage.general.qrCode')}
-        </Button>
-      }
-      open={modalOpen}
-      onClose={() => setModalOpen(false)}
+      title={t('manage.general.qrCode')}
+      open={open}
+      onClose={() => setOpen(false)}
       className={{
         content: 'h-max max-h-full !w-max max-w-6xl overflow-y-auto',
       }}

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizTimeline.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizTimeline.tsx
@@ -2,6 +2,7 @@ import { faPauseCircle } from '@fortawesome/free-regular-svg-icons'
 import {
   faCode,
   faPlay,
+  faQrcode,
   faStop,
   faUpRightFromSquare,
 } from '@fortawesome/free-solid-svg-icons'
@@ -48,6 +49,7 @@ function LiveQuizTimeline({
   const { locale } = useRouter()
 
   const [cancelLiveQuizModal, setCancelLiveQuizModal] = useState(false)
+  const [qrModal, setQRModal] = useState(false)
   const [inCooldown, setInCooldown] = useState<boolean>(false)
 
   // logic: keep track of the current and previous block
@@ -134,7 +136,16 @@ function LiveQuizTimeline({
                 elements={blocks.flatMap((block) => block.elements ?? [])}
               />
             )}
-            <LiveQuizQRModal quizId={quizId} />
+            <Button
+              className={{ root: 'h-8 sm:w-max' }}
+              onClick={() => setQRModal(true)}
+              data={{ cy: `qr-modal-${quizId}` }}
+            >
+              <Button.Icon>
+                <FontAwesomeIcon icon={faQrcode} />
+              </Button.Icon>
+              {t('manage.general.qrCode')}
+            </Button>
             <a
               className="flex-1"
               href={`${process.env.NEXT_PUBLIC_PWA_URL}/${locale}/session/${quizId}`}
@@ -287,6 +298,7 @@ function LiveQuizTimeline({
           />
         </>
       )}
+      <LiveQuizQRModal quizId={quizId} open={qrModal} setOpen={setQRModal} />
     </div>
   )
 }


### PR DESCRIPTION
<img width="1435" alt="Screenshot 2025-02-13 at 17 43 53" src="https://github.com/user-attachments/assets/743ba951-51b7-4f6a-a439-113991c4caee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a QR code modal, allowing users to access relevant QR codes during live quiz sessions.
  - Added an interactive button with an icon to trigger the QR code view when the quiz is active.
  - The modal now features a dynamically translated title for a more user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->