### PR TITLE
chore(packages/graphql): extend unit tests to cover template access control and template answer collection queries

### DIFF
--- a/packages/graphql/src/services/templates.ts
+++ b/packages/graphql/src/services/templates.ts
@@ -8,6 +8,7 @@ import { getInitialInstanceStatistics } from '@klicker-uzh/util'
 import { v4 as uuidv4 } from 'uuid'
 import type { ContextWithUser } from '../lib/context.js'
 import { getAnswerCollectionsElements } from './resources.js'
+import { MISSING_CATALOG_COLLECTION_ID } from './sharing.js'
 
 // ! Helper functions
 // #region
@@ -276,7 +277,8 @@ export async function validateTemplateAccessible(
     activity.catalogAssignments.some(
       (assignment) =>
         assignment.access === DB.ObjectAccess.PUBLIC &&
-        assignment.catalogCollection.access === DB.ObjectAccess.PUBLIC
+        (assignment.catalogCollectionId === MISSING_CATALOG_COLLECTION_ID ||
+          assignment.catalogCollection.access === DB.ObjectAccess.PUBLIC)
     )
   ) {
     return true

--- a/packages/graphql/test/sharing.test.ts
+++ b/packages/graphql/test/sharing.test.ts
@@ -4,10 +4,11 @@ import {
   PermissionLevel,
   PermissionStatus,
   PrismaClient,
+  PublicationStatus,
   UserLoginScope,
   UserRole,
 } from '@klicker-uzh/prisma'
-import { CatalogObjectType } from '@klicker-uzh/types'
+import { ActivityType, CatalogObjectType } from '@klicker-uzh/types'
 import { EventEmitter } from 'events'
 import type { ContextWithUser } from '../src/lib/context.js'
 import {
@@ -41,6 +42,10 @@ import {
   transferAnswerCollectionOwnership,
   transferCatalogCollectionOwnership,
 } from '../src/services/sharing.js'
+import {
+  deleteActivityTemplate,
+  validateTemplateAccessible,
+} from '../src/services/templates.js'
 import {
   answerCollection1,
   answerCollection2,
@@ -2738,6 +2743,286 @@ describe('Unit tests for sharing service', () => {
       },
     })
     expect(dbPermission5).toBeNull()
+  })
+
+  // TODO: extend this test workflow as soon as direct sharing functionalities for activities / activity templates are available
+  const LQAT1Id = 'ca9f1fc4-0daf-4cdb-92b3-e55557b24831'
+  const LQAT2Id = '86ff081d-07cd-4bea-91b7-fc633ed7a092'
+  const LQAT3Id = '3be3228c-4a64-4a84-8743-46c4ba0ed333'
+  it('Validate that access to activity templates is correctly checked', async () => {
+    // create activity templates (without content, simply for access validation)
+    const templateData = [
+      { id: LQAT1Id, name: 'LQAT1' },
+      { id: LQAT2Id, name: 'LQAT2' },
+      { id: LQAT3Id, name: 'LQAT3' },
+    ]
+    const ATs = await Promise.all(
+      templateData.map(({ id, name }) =>
+        prisma.activityTemplate.create({
+          data: {
+            description: `${name} Description`,
+            instructions: `${name} Instructions`,
+            liveQuiz: {
+              create: {
+                id, // activity id is relevant (connected to assignments, etc. - templateId mainly for routing)
+                name,
+                displayName: name,
+                status: PublicationStatus.TEMPLATE,
+                owner: {
+                  connect: {
+                    id: userOne.id,
+                  },
+                },
+              },
+            },
+          },
+        })
+      )
+    )
+    const templateId1 = ATs.find((AT) => AT.liveQuizId === LQAT1Id)!.id
+    const templateId2 = ATs.find((AT) => AT.liveQuizId === LQAT2Id)!.id
+    const templateId3 = ATs.find((AT) => AT.liveQuizId === LQAT3Id)!.id
+
+    // verify that the creation was successful
+    const templates = await prisma.liveQuiz.findMany({
+      where: {
+        status: PublicationStatus.TEMPLATE,
+      },
+    })
+    expect(templates.length).toBe(3)
+    expect(templates.map((template) => template.id)).toEqual(
+      expect.arrayContaining([LQAT1Id, LQAT2Id, LQAT3Id])
+    )
+
+    // add LQAT1 to top level catlaog collection with public access -> should be accessible to everyone
+    const assignment1 = await prisma.catalogCollectionAssignment.upsert({
+      where: {
+        liveQuizId_catalogCollectionId: {
+          liveQuizId: LQAT1Id,
+          catalogCollectionId: MISSING_CATALOG_COLLECTION_ID,
+        },
+      },
+      create: {
+        access: ObjectAccess.PUBLIC,
+        liveQuiz: {
+          connect: {
+            id: LQAT1Id,
+          },
+        },
+        catalogCollection: {
+          connect: {
+            id: publicCatalogId,
+          },
+        },
+      },
+      update: {
+        access: ObjectAccess.PUBLIC,
+      },
+    })
+
+    // check accessible for everyone
+    const res1 = await validateTemplateAccessible(
+      { templateId: templateId1 },
+      userOneCtx
+    )
+    expect(res1).toBeTruthy()
+    const res2 = await validateTemplateAccessible(
+      { templateId: templateId1 },
+      userTwoCtx
+    )
+    expect(res2).toBeTruthy()
+    const res3 = await validateTemplateAccessible(
+      { templateId: templateId1 },
+      userThreeCtx
+    )
+    expect(res3).toBeTruthy()
+    const res4 = await validateTemplateAccessible(
+      { templateId: templateId1 },
+      userFourCtx
+    )
+    expect(res4).toBeTruthy()
+    const res5 = await validateTemplateAccessible(
+      { templateId: templateId1 },
+      userFiveCtx
+    )
+    expect(res5).toBeTruthy()
+
+    // add LQAT2 to public catalog collection with public access rights -> should be accessible to everyone
+    const assignment2 = await prisma.catalogCollectionAssignment.upsert({
+      where: {
+        liveQuizId_catalogCollectionId: {
+          liveQuizId: LQAT2Id,
+          catalogCollectionId: publicCatalogId,
+        },
+      },
+      create: {
+        access: ObjectAccess.PUBLIC,
+        liveQuiz: {
+          connect: {
+            id: LQAT2Id,
+          },
+        },
+        catalogCollection: {
+          connect: {
+            id: publicCatalogId,
+          },
+        },
+      },
+      update: {
+        access: ObjectAccess.PUBLIC,
+      },
+    })
+
+    // check accessible for everyone
+    const res6 = await validateTemplateAccessible(
+      { templateId: templateId2 },
+      userOneCtx
+    )
+    expect(res6).toBeTruthy()
+    const res7 = await validateTemplateAccessible(
+      { templateId: templateId2 },
+      userTwoCtx
+    )
+    expect(res7).toBeTruthy()
+    const res8 = await validateTemplateAccessible(
+      { templateId: templateId2 },
+      userThreeCtx
+    )
+    expect(res8).toBeTruthy()
+    const res9 = await validateTemplateAccessible(
+      { templateId: templateId2 },
+      userFourCtx
+    )
+    expect(res9).toBeTruthy()
+    const res10 = await validateTemplateAccessible(
+      { templateId: templateId2 },
+      userFiveCtx
+    )
+    expect(res10).toBeTruthy()
+
+    // add LQAT3 to restricted catalog collection with public access rights -> should be accessible to users with access to the restricted catalog collection
+    const assignment3 = await prisma.catalogCollectionAssignment.upsert({
+      where: {
+        liveQuizId_catalogCollectionId: {
+          liveQuizId: LQAT3Id,
+          catalogCollectionId: restrictedCatalogId,
+        },
+      },
+      create: {
+        access: ObjectAccess.PUBLIC,
+        liveQuiz: {
+          connect: {
+            id: LQAT3Id,
+          },
+        },
+        catalogCollection: {
+          connect: {
+            id: restrictedCatalogId,
+          },
+        },
+      },
+      update: {
+        access: ObjectAccess.PUBLIC,
+      },
+    })
+
+    // check accessilbe only to users with access to restricted catalog collection
+    const res11 = await validateTemplateAccessible(
+      { templateId: templateId3 },
+      userOneCtx
+    )
+    expect(res11).toBeTruthy() // owner of restricted catalog collection
+    const res12 = await validateTemplateAccessible(
+      { templateId: templateId3 },
+      userTwoCtx
+    )
+    expect(res12).toBeTruthy() // read permissions on restricted catalog collection
+    const res13 = await validateTemplateAccessible(
+      { templateId: templateId3 },
+      userThreeCtx
+    )
+    expect(res13).toBeTruthy() // write permissions on restricted catalog collection
+    const res14 = await validateTemplateAccessible(
+      { templateId: templateId3 },
+      userFourCtx
+    )
+    expect(res14).toBeTruthy() // admin permissions on restricted catalog collection
+    const res115 = await validateTemplateAccessible(
+      { templateId: templateId3 },
+      userFiveCtx
+    )
+    expect(res115).toBeFalsy() // no permissions on restricted catalog collection
+  })
+
+  // TODO: extend this test to verify that also users with admin permissions on an activity / activity template can delete these
+  it('Verify that only users with sufficient permissions can delete the created activity templates', async () => {
+    // deleting activity template is only possible with sufficient permissions
+    const res1 = await deleteActivityTemplate(
+      {
+        activityId: LQAT1Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userTwoCtx
+    )
+    expect(res1).toBeNull()
+    const res2 = await deleteActivityTemplate(
+      {
+        activityId: LQAT1Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userThreeCtx
+    )
+    expect(res2).toBeNull()
+    const res3 = await deleteActivityTemplate(
+      {
+        activityId: LQAT1Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userFourCtx
+    )
+    expect(res3).toBeNull()
+    const res4 = await deleteActivityTemplate(
+      {
+        activityId: LQAT1Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userFiveCtx
+    )
+    expect(res4).toBeNull()
+
+    // delete activity templates with owner / admin permissions
+    const res5 = await deleteActivityTemplate(
+      {
+        activityId: LQAT1Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userOneCtx
+    )
+    expect(res5).toBeTruthy()
+    const res6 = await deleteActivityTemplate(
+      {
+        activityId: LQAT2Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userOneCtx
+    )
+    expect(res6).toBeTruthy()
+    const res7 = await deleteActivityTemplate(
+      {
+        activityId: LQAT3Id,
+        activityType: ActivityType.LIVE_QUIZ,
+      },
+      userOneCtx
+    )
+    expect(res7).toBeTruthy()
+
+    // verify that the activity templates have been removed from the database
+    const liveQuizTemplates = await prisma.liveQuiz.findMany({
+      where: {
+        status: PublicationStatus.TEMPLATE,
+      },
+    })
+    expect(liveQuizTemplates.length).toBe(0)
   })
 
   it('Verify that only users with ADMIN or OWNER permissions can delete a catalog collection', async () => {

--- a/packages/graphql/test/template.test.ts
+++ b/packages/graphql/test/template.test.ts
@@ -1,11 +1,17 @@
 import {
   ElementType,
+  PermissionLevel,
+  PermissionStatus,
   PrismaClient,
   UserLoginScope,
   UserRole,
 } from '@klicker-uzh/prisma'
 import { EventEmitter } from 'events'
 import type { ContextWithUser } from '../src/lib/context.js'
+import {
+  getAnswerCollectionsElements,
+  getAnswerCollectionsInfo,
+} from '../src/services/resources.js'
 import { getMatchingUserElementsTemplate } from '../src/services/templates.js'
 import { questionsSLAF, userOne, userTwo } from './templateData.js'
 
@@ -520,6 +526,178 @@ describe('Unit tests for sharing service', () => {
     // cleanup: delete all elements from the database
     const elementIds = elements.map((element) => element.id)
     await prisma.element.deleteMany({ where: { id: { in: elementIds } } })
+  })
+
+  it('Verify access to correct answer collections when using activity template', async () => {
+    const templateId = 'e920481c-c6d0-44ea-9486-5a068633d30d'
+    const activityId = '6e795dd4-dc50-4fc6-a4c8-847255e443f6'
+
+    // create unshared answer collection for user 1 (used in activity template)
+    const AC1 = await prisma.answerCollection.create({
+      data: {
+        name: 'AC1',
+        description: '',
+        owner: { connect: { id: userOne.id } },
+        permissions: {
+          create: {
+            permissionLevel: PermissionLevel.READ,
+            permissionStatus: PermissionStatus.REQUESTED, // requested permissions should not affect access
+            user: { connect: { id: userTwo.id } },
+          },
+        },
+      },
+    })
+
+    // create unshared answer collection for user 1 (not used in activity template)
+    const AC2 = await prisma.answerCollection.create({
+      data: {
+        name: 'AC2',
+        description: '',
+        owner: { connect: { id: userOne.id } },
+      },
+    })
+
+    // create answer collection for user 1 (shared with user 2, used in activity template)
+    const AC3 = await prisma.answerCollection.create({
+      data: {
+        name: 'AC3',
+        description: '',
+        owner: { connect: { id: userOne.id } },
+        permissions: {
+          create: {
+            permissionLevel: PermissionLevel.READ,
+            permissionStatus: PermissionStatus.GRANTED,
+            user: { connect: { id: userTwo.id } },
+          },
+        },
+      },
+    })
+
+    // create answer collection for user 1 (shared with user 2, not used in activity template)
+    const AC4 = await prisma.answerCollection.create({
+      data: {
+        name: '',
+        description: '',
+        owner: { connect: { id: userOne.id } },
+        permissions: {
+          create: {
+            permissionLevel: PermissionLevel.WRITE,
+            permissionStatus: PermissionStatus.GRANTED,
+            user: { connect: { id: userTwo.id } },
+          },
+        },
+      },
+    })
+
+    // create unshared answer collection for user 2
+    const AC5 = await prisma.answerCollection.create({
+      data: {
+        name: '',
+        description: '',
+        owner: { connect: { id: userTwo.id } },
+      },
+    })
+
+    // verify access to answer collections (user 1: 1-4, user 2: 3-5)
+    const collectionsUser1 = await getAnswerCollectionsInfo(userOneCtx)
+    expect(collectionsUser1).toHaveLength(4)
+    const collectionIdsUser1 = collectionsUser1.map(
+      (collection) => collection.id
+    )
+    expect(collectionIdsUser1).toEqual(
+      expect.arrayContaining([AC1.id, AC2.id, AC3.id, AC4.id])
+    )
+
+    const collectionsUser2 = await getAnswerCollectionsInfo(userTwoCtx)
+    expect(collectionsUser2).toHaveLength(3)
+    const collectionIdsUser2 = collectionsUser2.map(
+      (collection) => collection.id
+    )
+    expect(collectionIdsUser2).toEqual(
+      expect.arrayContaining([AC3.id, AC4.id, AC5.id])
+    )
+
+    // create activity template with answer collection (user 1)
+    const template = await prisma.activityTemplate.create({
+      data: {
+        id: templateId,
+        description: '',
+        instructions: '',
+        liveQuiz: {
+          create: {
+            id: activityId,
+            name: '',
+            displayName: '',
+            owner: { connect: { id: userOne.id } },
+          },
+        },
+        answerCollections: {
+          connect: [{ id: AC1.id }, { id: AC3.id }],
+        },
+      },
+    })
+
+    // queries not related to the template should still only return owned or directly shared answer collections
+    const collectionsUser1Alt = await getAnswerCollectionsElements(
+      { templateId: undefined },
+      userOneCtx
+    )
+    expect(collectionsUser1Alt).toHaveLength(4)
+    const collectionIdsUser1Alt = collectionsUser1Alt.map(
+      (collection) => collection.id
+    )
+    expect(collectionIdsUser1Alt).toEqual(
+      expect.arrayContaining([AC1.id, AC2.id, AC3.id, AC4.id])
+    )
+
+    const collectionsUser2Alt = await getAnswerCollectionsElements(
+      { templateId: undefined },
+      userTwoCtx
+    )
+    expect(collectionsUser2Alt).toHaveLength(3)
+    const collectionIdsUser2Alt = collectionsUser2Alt.map(
+      (collection) => collection.id
+    )
+    expect(collectionIdsUser2Alt).toEqual(
+      expect.arrayContaining([AC3.id, AC4.id, AC5.id])
+    )
+
+    // verify access to answer collections in template (user 1: 1-4, user 2: 1, 3-5)
+    const templateCollectionsUser1 = await getAnswerCollectionsElements(
+      { templateId },
+      userOneCtx
+    )
+    expect(templateCollectionsUser1).toHaveLength(4)
+    const templateCollectionIdsUser1 = templateCollectionsUser1.map(
+      (collection) => collection.id
+    )
+    expect(templateCollectionIdsUser1).toEqual(
+      expect.arrayContaining([AC1.id, AC2.id, AC3.id, AC4.id])
+    )
+
+    const templateCollectionsUser2 = await getAnswerCollectionsElements(
+      { templateId },
+      userTwoCtx
+    )
+    expect(templateCollectionsUser2).toHaveLength(4)
+    const templateCollectionIdsUser2 = templateCollectionsUser2.map(
+      (collection) => collection.id
+    )
+    expect(templateCollectionIdsUser2).toEqual(
+      expect.arrayContaining([AC1.id, AC3.id, AC4.id, AC5.id])
+    )
+
+    // cleanup; delete the created answer collections and the template
+    await prisma.liveQuiz.delete({ where: { id: activityId } })
+    await prisma.answerCollection.deleteMany({
+      where: { id: { in: [AC1.id, AC2.id, AC3.id, AC4.id, AC5.id] } },
+    })
+    const templateCount = await prisma.activityTemplate.count()
+    expect(templateCount).toBe(0)
+    const liveQuizCount = await prisma.liveQuiz.count()
+    expect(liveQuizCount).toBe(0)
+    const answerCollectionCount = await prisma.answerCollection.count()
+    expect(answerCollectionCount).toBe(0)
   })
 
   it('Cleanup: delete all created data used in this unit test', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced template accessibility by refining conditions for public access.
  - Improved activity template management with advanced creation, validation, and deletion based on user permissions.
  - Refined answer collection access control to ensure users see only the appropriate collections.

- **Tests**
  - Added comprehensive test scenarios to verify activity template behaviors and correct answer collection access across different users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->