### PR TITLE
fix(packages/graphql): make sure that graphql test suite runs sequentially

### DIFF
--- a/packages/graphql/run-tests.sh
+++ b/packages/graphql/run-tests.sh
@@ -9,8 +9,8 @@ echo "Building test containers..."
 docker compose -f test/docker/docker-compose.test.yml build 
 
 # run the test container and capture its exit code directly
-echo "Running test containers..."
-docker compose -f test/docker/docker-compose.test.yml up --abort-on-container-exit
+echo "Running test containers with sequential test execution..."
+TEST_ARGS="--runInBand" docker compose -f test/docker/docker-compose.test.yml up --abort-on-container-exit
 
 # after container runs, find the exit code from docker-compose ps output
 TEST_EXIT_CODE=$(docker compose -f test/docker/docker-compose.test.yml ps -a --format json | grep -o '"ExitCode":[0-9]*' | grep -o '[0-9]*' | head -1)

--- a/packages/graphql/run-tests.sh
+++ b/packages/graphql/run-tests.sh
@@ -9,8 +9,8 @@ echo "Building test containers..."
 docker compose -f test/docker/docker-compose.test.yml build 
 
 # run the test container and capture its exit code directly
-echo "Running test containers with sequential test execution..."
-TEST_ARGS="--runInBand" docker compose -f test/docker/docker-compose.test.yml up --abort-on-container-exit
+echo "Running test containers..."
+docker compose -f test/docker/docker-compose.test.yml up --abort-on-container-exit
 
 # after container runs, find the exit code from docker-compose ps output
 TEST_EXIT_CODE=$(docker compose -f test/docker/docker-compose.test.yml ps -a --format json | grep -o '"ExitCode":[0-9]*' | grep -o '[0-9]*' | head -1)

--- a/packages/graphql/src/services/resources.ts
+++ b/packages/graphql/src/services/resources.ts
@@ -202,31 +202,31 @@ export async function getAnswerCollectionsElements(
   if (templateId) {
     // verify that the user has access to the template activity
     const { accessible } = await validateTemplateAccessible({ templateId }, ctx)
-    if (!accessible) {
-      return []
-    }
-
-    const template = await ctx.prisma.activityTemplate.findUnique({
-      where: {
-        id: templateId,
-      },
-      include: {
-        answerCollections: {
-          include: {
-            entries: {
-              orderBy: {
-                value: 'asc',
+    if (accessible) {
+      const template = await ctx.prisma.activityTemplate.findUnique({
+        where: {
+          id: templateId,
+        },
+        include: {
+          answerCollections: {
+            include: {
+              entries: {
+                orderBy: {
+                  value: 'asc',
+                },
               },
             },
-          },
-          orderBy: {
-            name: 'asc',
+            orderBy: {
+              name: 'asc',
+            },
           },
         },
-      },
-    })
+      })
 
-    templateAnswerCollections = template?.answerCollections ?? []
+      templateAnswerCollections = template?.answerCollections ?? []
+    } else {
+      templateAnswerCollections = []
+    }
   }
 
   const combinedAnswerCollections = [

--- a/packages/graphql/test/docker/Dockerfile.test
+++ b/packages/graphql/test/docker/Dockerfile.test
@@ -45,7 +45,7 @@ pnpm run prisma:reset:raw -f\n\
 # Run tests\n\
 echo "Running tests..."\n\
 cd /usr/src/app/packages/graphql\n\
-DATABASE_URL=$DATABASE_URL pnpm jest --verbose\n\
+DATABASE_URL=$DATABASE_URL pnpm jest --verbose --runInBand\n\
 \n\
 TEST_EXIT=$?\n\
 echo "Tests completed with exit code: $TEST_EXIT"\n\

--- a/packages/graphql/test/sharing.test.ts
+++ b/packages/graphql/test/sharing.test.ts
@@ -2821,27 +2821,27 @@ describe('Unit tests for sharing service', () => {
     })
 
     // check accessible for everyone
-    const res1 = await validateTemplateAccessible(
+    const { accessible: res1 } = await validateTemplateAccessible(
       { templateId: templateId1 },
       userOneCtx
     )
     expect(res1).toBeTruthy()
-    const res2 = await validateTemplateAccessible(
+    const { accessible: res2 } = await validateTemplateAccessible(
       { templateId: templateId1 },
       userTwoCtx
     )
     expect(res2).toBeTruthy()
-    const res3 = await validateTemplateAccessible(
+    const { accessible: res3 } = await validateTemplateAccessible(
       { templateId: templateId1 },
       userThreeCtx
     )
     expect(res3).toBeTruthy()
-    const res4 = await validateTemplateAccessible(
+    const { accessible: res4 } = await validateTemplateAccessible(
       { templateId: templateId1 },
       userFourCtx
     )
     expect(res4).toBeTruthy()
-    const res5 = await validateTemplateAccessible(
+    const { accessible: res5 } = await validateTemplateAccessible(
       { templateId: templateId1 },
       userFiveCtx
     )
@@ -2874,27 +2874,27 @@ describe('Unit tests for sharing service', () => {
     })
 
     // check accessible for everyone
-    const res6 = await validateTemplateAccessible(
+    const { accessible: res6 } = await validateTemplateAccessible(
       { templateId: templateId2 },
       userOneCtx
     )
     expect(res6).toBeTruthy()
-    const res7 = await validateTemplateAccessible(
+    const { accessible: res7 } = await validateTemplateAccessible(
       { templateId: templateId2 },
       userTwoCtx
     )
     expect(res7).toBeTruthy()
-    const res8 = await validateTemplateAccessible(
+    const { accessible: res8 } = await validateTemplateAccessible(
       { templateId: templateId2 },
       userThreeCtx
     )
     expect(res8).toBeTruthy()
-    const res9 = await validateTemplateAccessible(
+    const { accessible: res9 } = await validateTemplateAccessible(
       { templateId: templateId2 },
       userFourCtx
     )
     expect(res9).toBeTruthy()
-    const res10 = await validateTemplateAccessible(
+    const { accessible: res10 } = await validateTemplateAccessible(
       { templateId: templateId2 },
       userFiveCtx
     )
@@ -2927,31 +2927,31 @@ describe('Unit tests for sharing service', () => {
     })
 
     // check accessilbe only to users with access to restricted catalog collection
-    const res11 = await validateTemplateAccessible(
+    const { accessible: res11 } = await validateTemplateAccessible(
       { templateId: templateId3 },
       userOneCtx
     )
     expect(res11).toBeTruthy() // owner of restricted catalog collection
-    const res12 = await validateTemplateAccessible(
+    const { accessible: res12 } = await validateTemplateAccessible(
       { templateId: templateId3 },
       userTwoCtx
     )
     expect(res12).toBeTruthy() // read permissions on restricted catalog collection
-    const res13 = await validateTemplateAccessible(
+    const { accessible: res13 } = await validateTemplateAccessible(
       { templateId: templateId3 },
       userThreeCtx
     )
     expect(res13).toBeTruthy() // write permissions on restricted catalog collection
-    const res14 = await validateTemplateAccessible(
+    const { accessible: res14 } = await validateTemplateAccessible(
       { templateId: templateId3 },
       userFourCtx
     )
     expect(res14).toBeTruthy() // admin permissions on restricted catalog collection
-    const res115 = await validateTemplateAccessible(
+    const { accessible: res15 } = await validateTemplateAccessible(
       { templateId: templateId3 },
       userFiveCtx
     )
-    expect(res115).toBeFalsy() // no permissions on restricted catalog collection
+    expect(res15).toBeFalsy() // no permissions on restricted catalog collection
   })
 
   // TODO: extend this test to verify that also users with admin permissions on an activity / activity template can delete these
@@ -3114,13 +3114,9 @@ describe('Unit tests for sharing service', () => {
     // delete all users that have been created for the test and validate that they have been removed
     await prisma.user.deleteMany({
       where: {
-        OR: [
-          { email: userOne.email },
-          { email: userTwo.email },
-          { email: userThree.email },
-          { email: userFour.email },
-          { email: userFive.email },
-        ],
+        id: {
+          in: [userOne.id, userTwo.id, userThree.id, userFour.id, userFive.id],
+        },
       },
     })
     const dbUsers = await prisma.user.count()

--- a/packages/graphql/test/template.test.ts
+++ b/packages/graphql/test/template.test.ts
@@ -1,5 +1,6 @@
 import {
   ElementType,
+  ObjectAccess,
   PermissionLevel,
   PermissionStatus,
   PrismaClient,
@@ -12,6 +13,7 @@ import {
   getAnswerCollectionsElements,
   getAnswerCollectionsInfo,
 } from '../src/services/resources.js'
+import { MISSING_CATALOG_COLLECTION_ID } from '../src/services/sharing.js'
 import { getMatchingUserElementsTemplate } from '../src/services/templates.js'
 import { questionsSLAF, userOne, userTwo } from './templateData.js'
 
@@ -637,6 +639,24 @@ describe('Unit tests for sharing service', () => {
       },
     })
 
+    // add template to the top-level catalog collection (accessible to everyone)
+    await prisma.catalogCollectionAssignment.upsert({
+      where: {
+        liveQuizId_catalogCollectionId: {
+          liveQuizId: activityId,
+          catalogCollectionId: MISSING_CATALOG_COLLECTION_ID,
+        },
+      },
+      create: {
+        access: ObjectAccess.PUBLIC,
+        liveQuiz: { connect: { id: activityId } },
+        catalogCollection: { connect: { id: MISSING_CATALOG_COLLECTION_ID } },
+      },
+      update: {
+        access: ObjectAccess.PUBLIC,
+      },
+    })
+
     // queries not related to the template should still only return owned or directly shared answer collections
     const collectionsUser1Alt = await getAnswerCollectionsElements(
       { templateId: undefined },
@@ -708,7 +728,7 @@ describe('Unit tests for sharing service', () => {
     // delete all users that have been created for the test and validate that they have been removed
     await prisma.user.deleteMany({
       where: {
-        OR: [{ id: userOne.id }, { id: userTwo.id }],
+        id: { in: [userOne.id, userTwo.id] },
       },
     })
     const dbUsers = await prisma.user.count()

--- a/packages/graphql/test/template.test.ts
+++ b/packages/graphql/test/template.test.ts
@@ -28,7 +28,7 @@ const getDatabaseUrl = () => {
   return 'postgresql://klicker:klicker@localhost:5432/klicker'
 }
 
-describe('Unit tests for sharing service', () => {
+describe('Unit tests for template service', () => {
   // shared resources used across tests
   let prisma: PrismaClient
   let emitter: EventEmitter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Eligible templates are now automatically added to the public catalog, ensuring they’re easily accessible for all users and enhancing discoverability.

- **Refactor**
  - The process for confirming template access has been streamlined to promote smoother, more consistent operations and improved system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->