### PR TITLE
feat(apps/frontend-manage): add evaluation view for flashcard elements

### DIFF
--- a/apps/frontend-manage/src/components/courses/QRCodePopover.tsx
+++ b/apps/frontend-manage/src/components/courses/QRCodePopover.tsx
@@ -28,13 +28,21 @@ function QRCodePopover({
   return (
     <Popover>
       {triggerStyle === 'basic' && (
-        <PopoverTrigger className="hover:bg-accent text-primary-100 mb-1 flex flex-row items-center gap-2.5 rounded px-2 py-0 text-sm">
+        <PopoverTrigger
+          className="hover:bg-accent text-primary-100 mb-1 flex flex-row items-center gap-2.5 rounded px-2 py-0 text-sm"
+          data-cy={data?.cy}
+          data-test={data?.test}
+        >
           <FontAwesomeIcon icon={faQrcode} />
           <div>{triggerText}</div>
         </PopoverTrigger>
       )}
       {triggerStyle === 'button' && (
-        <PopoverTrigger className="hover:bg-accent border-input flex h-8 flex-row items-center gap-2.5 rounded-md border px-3 py-0">
+        <PopoverTrigger
+          className="hover:bg-accent border-input flex h-8 flex-row items-center gap-2.5 rounded-md border px-3 py-0"
+          data-cy={data?.cy}
+          data-test={data?.test}
+        >
           <FontAwesomeIcon icon={faQrcode} />
           <div>{triggerText}</div>
         </PopoverTrigger>
@@ -50,7 +58,7 @@ function QRCodePopover({
           width={100}
         />
         <Link passHref href={`/qr${relHref}`} target="_blank">
-          <Button fluid primary className={{ root: 'mt-2' }} data={data}>
+          <Button fluid primary className={{ root: 'mt-2' }}>
             <Button.Label>{t('manage.general.presentQrCode')}</Button.Label>
           </Button>
         </Link>

--- a/apps/frontend-manage/src/components/evaluation/ElementEvaluation.tsx
+++ b/apps/frontend-manage/src/components/evaluation/ElementEvaluation.tsx
@@ -36,7 +36,8 @@ function ElementEvaluation({
   return (
     <div className={twMerge('flex h-full flex-col', className)}>
       {currentInstance.__typename !== 'CaseStudyActivityEvaluationData' &&
-        currentInstance.__typename !== 'ContentActivityEvaluationData' && (
+        currentInstance.__typename !== 'ContentActivityEvaluationData' &&
+        currentInstance.__typename !== 'FlashcardActivityEvaluationData' && (
           <div className="flex-none">
             <QuestionCollapsible
               activeInstance={activeInstance}
@@ -97,7 +98,11 @@ function ElementEvaluation({
           />
         )}
         {currentInstance.__typename === 'FlashcardActivityEvaluationData' && (
-          <FCEvaluation evaluation={currentInstance} />
+          <FCEvaluation
+            evaluation={currentInstance}
+            textSize={textSize}
+            chartType={chartType}
+          />
         )}
         {currentInstance.__typename === 'ContentActivityEvaluationData' && (
           <CTEvaluation evaluation={currentInstance} textSize={textSize} />

--- a/apps/frontend-manage/src/components/evaluation/EvaluationFooter.tsx
+++ b/apps/frontend-manage/src/components/evaluation/EvaluationFooter.tsx
@@ -1,6 +1,9 @@
 import { faFont, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { ElementInstanceEvaluation } from '@klicker-uzh/graphql/dist/ops'
+import {
+  ElementInstanceEvaluation,
+  ElementType,
+} from '@klicker-uzh/graphql/dist/ops'
 import Footer from '@klicker-uzh/shared-components/src/Footer'
 import {
   ACTIVE_CHART_TYPES,
@@ -107,24 +110,25 @@ function EvaluationFooter({
                   }}
                 />
               )}
-              {hasExplanation && (
-                <Switch
-                  size={hasSolutionAndExplanation ? 'sm' : undefined}
-                  checked={showExplanation}
-                  label={t('manage.evaluation.showExplanation')}
-                  onCheckedChange={(newValue) => setShowExplanation(newValue)}
-                  className={{
-                    label: twMerge(hasSolutionAndExplanation && 'text-sm'),
-                  }}
-                />
-              )}
+              {hasExplanation &&
+                currentInstance.type !== ElementType.Flashcard && (
+                  <Switch
+                    size={hasSolutionAndExplanation ? 'sm' : undefined}
+                    checked={showExplanation}
+                    label={t('manage.evaluation.showExplanation')}
+                    onCheckedChange={(newValue) => setShowExplanation(newValue)}
+                    className={{
+                      label: twMerge(hasSolutionAndExplanation && 'text-sm'),
+                    }}
+                  />
+                )}
             </div>
             {currentInstance?.type &&
             ACTIVE_CHART_TYPES[currentInstance.type].length > 1 ? (
               <Select
                 contentPosition="popper"
                 className={{
-                  trigger: 'w-36 border-slate-400',
+                  trigger: 'w-44 border-slate-400',
                 }}
                 items={ACTIVE_CHART_TYPES[currentInstance.type].map((item) => {
                   return {

--- a/apps/frontend-manage/src/components/evaluation/elements/FCEvaluation.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/FCEvaluation.tsx
@@ -1,18 +1,36 @@
 import { FlashcardActivityEvaluationData } from '@klicker-uzh/graphql/dist/ops'
-import { UserNotification } from '@uzh-bf/design-system'
-import { useTranslations } from 'next-intl'
+import ElementChart from '../ElementChart'
+
+import { ChartType } from '@klicker-uzh/shared-components/src/constants'
+import { TextSizeType } from '../textSizes'
+import FlashcardContentCollapsible from './FlashcardContentCollapsible'
 
 interface FCEvaluationProps {
   evaluation: FlashcardActivityEvaluationData
+  textSize: TextSizeType
+  chartType: ChartType
 }
 
-function FCEvaluation({ evaluation }: FCEvaluationProps) {
-  const t = useTranslations()
-
+function FCEvaluation({ evaluation, textSize, chartType }: FCEvaluationProps) {
   return (
-    <UserNotification type="info" className={{ root: 'm-3 h-max w-full' }}>
-      {t('manage.evaluation.noFlashcardEvaluation')}
-    </UserNotification>
+    <div className="flex h-full w-full flex-col">
+      <div className="flex-none">
+        <FlashcardContentCollapsible
+          content={evaluation.content}
+          explanation={evaluation.explanation!}
+          proseSize={textSize.prose}
+        />
+      </div>
+      <div className="min-h-0 flex-1 px-4 py-2">
+        <ElementChart
+          chartType={chartType}
+          instanceEvaluation={evaluation}
+          showSolution={false}
+          showExplanation={false}
+          textSize={textSize}
+        />
+      </div>
+    </div>
   )
 }
 

--- a/apps/frontend-manage/src/components/evaluation/elements/FlashcardContentCollapsible.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/FlashcardContentCollapsible.tsx
@@ -1,0 +1,122 @@
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import { Markdown } from '@klicker-uzh/markdown'
+import { Button, Prose } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
+import { useEffect, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+function FlashcardContentCollapsible({
+  content,
+  explanation,
+  proseSize,
+}: {
+  content: string
+  explanation?: string
+  proseSize: string
+}) {
+  const t = useTranslations()
+  const [contentElem, setContentElem] = useState<HTMLDivElement | null>(null)
+  const [contentCollapsed, setContentCollapsed] = useState<boolean>(true)
+  const [showExtensibleButton, setShowExtensibleButton] =
+    useState<boolean>(false)
+
+  useEffect(() => {
+    if (!contentElem) return
+
+    // if the element height is larger than what is shown or the content was opened, show the extension button
+    if (
+      contentElem?.scrollHeight > contentElem?.clientHeight ||
+      !contentCollapsed
+    ) {
+      setShowExtensibleButton(true)
+    } else {
+      setShowExtensibleButton(false)
+    }
+
+    return () => setContentElem(null)
+  }, [contentCollapsed, contentElem])
+
+  return (
+    <div>
+      <div className="grid grid-cols-2 bg-slate-50">
+        <div className="border-r border-slate-200 px-4 py-2 text-lg font-semibold">
+          {t('manage.evaluation.frontSide')}
+        </div>
+        {explanation && (
+          <div className="px-4 py-2 text-lg font-semibold">
+            {t('manage.evaluation.backSide')}
+          </div>
+        )}
+      </div>
+
+      <div
+        ref={(ref) => setContentElem(ref)}
+        className={twMerge(
+          contentCollapsed
+            ? 'max-h-[7rem]'
+            : 'max-h-[calc(100vh-11rem)] overflow-auto',
+          showExtensibleButton &&
+            contentCollapsed &&
+            'overflow-y-hidden bg-gradient-to-b from-black via-black to-white bg-clip-text',
+          !showExtensibleButton && 'border-uzh-grey-80 border-b',
+          'w-full px-4'
+        )}
+      >
+        <div className="grid grid-cols-2">
+          <div className="border-r py-2 pr-4">
+            <Prose className={{ root: 'max-w-full' }}>
+              <Markdown
+                className={{
+                  root: twMerge(
+                    'prose-p:m-0 prose-lg prose-img:m-0 leading-8',
+                    proseSize
+                  ),
+                }}
+                content={content}
+              />
+            </Prose>
+          </div>
+
+          {explanation && (
+            <div className="py-2 pl-4">
+              <Prose className={{ root: 'max-w-full' }}>
+                <Markdown
+                  className={{
+                    root: twMerge(
+                      'prose-p:m-0 prose-lg prose-img:m-0 leading-8',
+                      proseSize
+                    ),
+                  }}
+                  content={explanation}
+                />
+              </Prose>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showExtensibleButton && (
+        <Button
+          className={{
+            root: twMerge(
+              'border-uzh-grey-80 h-6 w-full rounded-none border-0 border-b text-xs shadow-none print:hidden',
+              contentCollapsed && 'bg-gradient-to-b from-white to-slate-100'
+            ),
+          }}
+          onClick={() => setContentCollapsed(!contentCollapsed)}
+          data={{ cy: 'toggle-flashcard-collapse-evaluation' }}
+        >
+          <Button.Icon
+            withoutLabel
+            icon={contentCollapsed ? faChevronDown : faChevronUp}
+            className={{
+              root: 'h-5 w-5',
+            }}
+          />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default FlashcardContentCollapsible

--- a/apps/frontend-manage/src/components/evaluation/textSizes.ts
+++ b/apps/frontend-manage/src/components/evaluation/textSizes.ts
@@ -7,6 +7,7 @@ export interface TextSizeType {
   text2Xl: string
   text3Xl: string
   legend: string
+  legendMd: string
   min: number
   max: number
 }
@@ -21,6 +22,7 @@ export const TextSizes = {
     text2Xl: 'text-4xl',
     text3Xl: 'text-5xl',
     legend: '3rem',
+    legendMd: '2rem',
     min: 60,
     max: 80,
   },
@@ -33,6 +35,7 @@ export const TextSizes = {
     text2Xl: 'text-3xl',
     text3Xl: 'text-4xl',
     legend: '2.5rem',
+    legendMd: '1.5rem',
     min: 50,
     max: 70,
   },
@@ -45,6 +48,7 @@ export const TextSizes = {
     text2Xl: 'text-2xl',
     text3Xl: 'text-3xl',
     legend: '2rem',
+    legendMd: '1.25rem',
     min: 40,
     max: 60,
   },
@@ -57,6 +61,7 @@ export const TextSizes = {
     text2Xl: 'text-xl',
     text3Xl: 'text-2xl',
     legend: '1.5rem',
+    legendMd: '1rem',
     min: 30,
     max: 40,
   },

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1973,10 +1973,6 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       microLearningEvaluation: 'Microlearning Evaluation',
       chartTypeNotSupported:
         'Derzeit wird der ausgewählte Diagrammtyp für diesen Elementtyp nicht unterstützt.',
-      noFlashcardEvaluation:
-        'Derzeit ist keine Auswertungsansicht für Flashcards in KlickerUZH-Aktivitäten verfügbar.',
-      noContentEvaluation:
-        'Derzeit ist keine Auswertungsansicht für Inhaltselemente in KlickerUZH-Aktivitäten verfügbar.',
       histogramNotSupported:
         'Histogramme werden für diesen Fragetyp nicht unterstützt.',
       criterionXAxis: 'Kriterium X-Achse',
@@ -1988,6 +1984,11 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Sie können entweder mehrere Fälle oder mehrere Fallstudien-Elemente auswählen, um die entsprechenden Resultate zu vergleichen. Eine Kombination von mehreren Fällen und mehreren Fallstudien-Elementen kann nicht dargestellt werden.',
       caseStudySelectCasesItemsCriteria:
         'Bitte wählen Sie mindestens einen Fall, ein Fallstudien-Element und Kriterien aus, um eine Auswertung anzuzeigen.',
+      answerNotRemembered: 'Antwort nicht bekannt',
+      answerPartiallyRemembered: 'Antwort teilweise bekannt',
+      answerRemembered: 'Antwort bekannt',
+      frontSide: 'Vorderseite',
+      backSide: 'Rückseite',
     },
     lecturer: {
       noDataAvailable: 'Keine Daten verfügbar...',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1942,10 +1942,6 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       microLearningEvaluation: 'Microlearning Evaluation',
       chartTypeNotSupported:
         'At the moment, the selected chart type is not supported for this element type.',
-      noFlashcardEvaluation:
-        'Currently, no evaluation view is available for flashcards in KlickerUZH activities.',
-      noContentEvaluation:
-        'Currently, no evaluation view is available for content elements in KlickerUZH activities.',
       histogramNotSupported:
         'Histograms are not supported for this question type.',
       criterionXAxis: 'Criterion X-Axis',
@@ -1957,6 +1953,11 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         'You can either select multiple cases or multiple case study elements to compare the corresponding results. A combination of multiple cases and multiple case study elements cannot be displayed.',
       caseStudySelectCasesItemsCriteria:
         'Please select at least one case, one case study item and criteria to display the evaluation.',
+      answerNotRemembered: 'Answer not remembered',
+      answerPartiallyRemembered: 'Answer partially remembered',
+      answerRemembered: 'Answer remembered',
+      frontSide: 'Front Side',
+      backSide: 'Back Side',
     },
     lecturer: {
       noDataAvailable: 'No data available...',

--- a/packages/shared-components/src/charts/ElementBarChart.tsx
+++ b/packages/shared-components/src/charts/ElementBarChart.tsx
@@ -28,6 +28,7 @@ interface ElementBarChartProps {
   showExplanation: boolean
   textSize: {
     legend: string
+    legendMd: string
     text: string
     textLg: string
     textXl: string
@@ -47,6 +48,7 @@ function ElementBarChart({
     ElementType.Mc,
     ElementType.Kprim,
     ElementType.Numerical,
+    ElementType.Flashcard,
   ]
 
   const labeledData = useEvaluationBarChartData({ instance })
@@ -84,7 +86,12 @@ function ElementBarChart({
                 fill: 'black',
                 offset: 30,
                 stroke: 'black',
-                style: { fontSize: textSize.legend },
+                style: {
+                  fontSize:
+                    instance.__typename === 'FlashcardActivityEvaluationData'
+                      ? textSize.legendMd
+                      : textSize.legend,
+                },
               }}
             />
             <YAxis
@@ -142,6 +149,13 @@ function ElementBarChart({
                     key={index}
                   />
                 ))}
+              {instance.__typename === 'FlashcardActivityEvaluationData' && (
+                <>
+                  <Cell fill="#cc0000" key={0} />
+                  <Cell fill="#ff9900" key={1} />
+                  <Cell fill="#00b20a" key={2} />
+                </>
+              )}
             </Bar>
           </BarChartRecharts>
         </ResponsiveContainer>

--- a/packages/shared-components/src/charts/ElementTableChart.tsx
+++ b/packages/shared-components/src/charts/ElementTableChart.tsx
@@ -42,6 +42,7 @@ function ElementTableChart({
     ElementType.Numerical,
     ElementType.FreeText,
     ElementType.Selection,
+    ElementType.Flashcard,
   ]
 
   const columns = useEvaluationTableColumns({

--- a/packages/shared-components/src/constants.ts
+++ b/packages/shared-components/src/constants.ts
@@ -131,7 +131,8 @@ export const ACTIVE_CHART_TYPES: Record<
     },
   ],
   [ElementType.Flashcard]: [
-    { label: 'manage.evaluation.unset', value: ChartType.UNSET },
+    { label: 'manage.evaluation.barChart', value: ChartType.BAR_CHART },
+    { label: 'manage.evaluation.table', value: ChartType.TABLE },
   ],
   [ElementType.Content]: [
     { label: 'manage.evaluation.unset', value: ChartType.UNSET },

--- a/packages/shared-components/src/hooks/useEvaluationBarChartData.ts
+++ b/packages/shared-components/src/hooks/useEvaluationBarChartData.ts
@@ -1,5 +1,6 @@
 import type { ElementInstanceEvaluation } from '@klicker-uzh/graphql/dist/ops'
 import { SMALL_BAR_THRESHOLD } from '@klicker-uzh/shared-components/src/constants'
+import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 
 interface UseEvaluationBarChartDataProps {
@@ -9,6 +10,8 @@ interface UseEvaluationBarChartDataProps {
 function useEvaluationBarChartData({
   instance,
 }: UseEvaluationBarChartDataProps) {
+  const t = useTranslations()
+
   const labeledData = useMemo(() => {
     if (instance.__typename === 'ChoicesActivityEvaluationData') {
       const results = instance.results
@@ -24,6 +27,46 @@ function useEvaluationBarChartData({
             : undefined,
         xLabel: String.fromCharCode(Number(idx) + 65),
       }))
+    } else if (instance.__typename === 'FlashcardActivityEvaluationData') {
+      const results = instance.results
+      return [
+        {
+          count: results.incorrectCount,
+          labelIn:
+            results.incorrectCount / results.totalAnswers > SMALL_BAR_THRESHOLD
+              ? results.incorrectCount
+              : undefined,
+          labelOut:
+            results.incorrectCount / results.totalAnswers <= SMALL_BAR_THRESHOLD
+              ? results.incorrectCount
+              : undefined,
+          xLabel: t('manage.evaluation.answerNotRemembered'),
+        },
+        {
+          count: results.incorrectCount,
+          labelIn:
+            results.incorrectCount / results.totalAnswers > SMALL_BAR_THRESHOLD
+              ? results.incorrectCount
+              : undefined,
+          labelOut:
+            results.incorrectCount / results.totalAnswers <= SMALL_BAR_THRESHOLD
+              ? results.incorrectCount
+              : undefined,
+          xLabel: t('manage.evaluation.answerPartiallyRemembered'),
+        },
+        {
+          count: results.correctCount,
+          labelIn:
+            results.correctCount / results.totalAnswers > SMALL_BAR_THRESHOLD
+              ? results.correctCount
+              : undefined,
+          labelOut:
+            results.correctCount / results.totalAnswers <= SMALL_BAR_THRESHOLD
+              ? results.correctCount
+              : undefined,
+          xLabel: t('manage.evaluation.answerRemembered'),
+        },
+      ]
     } else {
       return []
     }

--- a/packages/shared-components/src/hooks/useEvaluationBarChartData.ts
+++ b/packages/shared-components/src/hooks/useEvaluationBarChartData.ts
@@ -43,14 +43,14 @@ function useEvaluationBarChartData({
           xLabel: t('manage.evaluation.answerNotRemembered'),
         },
         {
-          count: results.incorrectCount,
+          count: results.partialCount,
           labelIn:
-            results.incorrectCount / results.totalAnswers > SMALL_BAR_THRESHOLD
-              ? results.incorrectCount
+            results.partialCount / results.totalAnswers > SMALL_BAR_THRESHOLD
+              ? results.partialCount
               : undefined,
           labelOut:
-            results.incorrectCount / results.totalAnswers <= SMALL_BAR_THRESHOLD
-              ? results.incorrectCount
+            results.partialCount / results.totalAnswers <= SMALL_BAR_THRESHOLD
+              ? results.partialCount
               : undefined,
           xLabel: t('manage.evaluation.answerPartiallyRemembered'),
         },

--- a/packages/shared-components/src/hooks/useEvaluationTableData.ts
+++ b/packages/shared-components/src/hooks/useEvaluationTableData.ts
@@ -1,4 +1,5 @@
 import { type ElementInstanceEvaluation } from '@klicker-uzh/graphql/dist/ops'
+import { useTranslations } from 'next-intl'
 import { type EvaluationTableRowType } from '../charts/ElementTableChart'
 
 interface UseEvaluationTableColumnsProps {
@@ -8,58 +9,74 @@ interface UseEvaluationTableColumnsProps {
 function useEvaluationTableData({
   instance,
 }: UseEvaluationTableColumnsProps): EvaluationTableRowType[] {
+  const t = useTranslations()
+
   if (instance.__typename === 'ChoicesActivityEvaluationData') {
     const results = instance.results
-    return results.choices.map((choice) => {
-      return {
-        count: choice.count,
-        value: choice.value,
-        correct: choice.correct ?? false,
-        percentage:
-          results.totalAnswers > 0 ? choice.count / results.totalAnswers : 0,
-      }
-    })
+    return results.choices.map((choice) => ({
+      count: choice.count,
+      value: choice.value,
+      correct: choice.correct ?? false,
+      percentage:
+        results.totalAnswers > 0 ? choice.count / results.totalAnswers : 0,
+    }))
   } else if (instance.__typename === 'NumericalActivityEvaluationData') {
     // TODO: check why multiple identical numbers are treated as different values - e.g. 70 for Excel question
     const results = instance.results
 
-    return results.responseValues.map((response) => {
-      return {
-        count: response.count,
-        value: response.value,
-        correct: response.correct ?? false,
-        percentage:
-          results.totalAnswers > 0 ? response.count / results.totalAnswers : 0,
-      }
-    })
+    return results.responseValues.map((response) => ({
+      count: response.count,
+      value: response.value,
+      correct: response.correct ?? false,
+      percentage:
+        results.totalAnswers > 0 ? response.count / results.totalAnswers : 0,
+    }))
   } else if (instance.__typename === 'FreeTextActivityEvaluationData') {
     const results = instance.results
-    return results.responses.map((response) => {
-      return {
-        count: response.count,
-        value: response.value,
-        correct: response.correct ?? false,
-        percentage:
-          results.totalAnswers > 0 ? response.count / results.totalAnswers : 0,
-      }
-    })
+    return results.responses.map((response) => ({
+      count: response.count,
+      value: response.value,
+      correct: response.correct ?? false,
+      percentage:
+        results.totalAnswers > 0 ? response.count / results.totalAnswers : 0,
+    }))
   } else if (instance.__typename === 'SelectionActivityEvaluationData') {
     const results = instance.results
     const solutionIds = instance.results.answerSolutionIds
 
-    return results.selectionResponses.map((response) => {
-      return {
-        count: response.count,
-        value: response.value,
-        correct: solutionIds?.includes(response.answerId) ?? false,
-        percentage:
-          results.totalAnswers > 0 ? response.count / results.totalAnswers : 0,
-        selectionRate:
-          results.totalAnswers > 0
-            ? (response.count / results.totalAnswers) * 100
-            : 0,
-      }
-    })
+    return results.selectionResponses.map((response) => ({
+      count: response.count,
+      value: response.value,
+      correct: solutionIds?.includes(response.answerId) ?? false,
+      percentage:
+        results.totalAnswers > 0 ? response.count / results.totalAnswers : 0,
+      selectionRate:
+        results.totalAnswers > 0
+          ? (response.count / results.totalAnswers) * 100
+          : 0,
+    }))
+  } else if (instance.__typename === 'FlashcardActivityEvaluationData') {
+    const results = instance.results
+    return [
+      {
+        count: results.incorrectCount,
+        value: t('manage.evaluation.answerNotRemembered'),
+        percentage: results.incorrectCount / results.totalAnswers,
+        correct: false,
+      },
+      {
+        count: results.partialCount,
+        value: t('manage.evaluation.answerPartiallyRemembered'),
+        percentage: results.partialCount / results.totalAnswers,
+        correct: false,
+      },
+      {
+        count: results.correctCount,
+        value: t('manage.evaluation.answerRemembered'),
+        percentage: results.correctCount / results.totalAnswers,
+        correct: false,
+      },
+    ]
   }
 
   return []


### PR DESCRIPTION
![Screenshot 2025-04-03 at 16 37 55](https://github.com/user-attachments/assets/5a1ffe84-29d6-4cf0-a576-cffac19b7f3a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a collapsible view for flashcard content with a clean dual-column presentation.
  - Expanded evaluation displays with new visualization options for flashcards, including bar and table charts.
  - Added new data attributes for enhanced testability in the QRCodePopover component.

- **Bug Fixes**
  - Improved conditional rendering logic in evaluation components to refine user experience.

- **Chores**
  - Updated user feedback texts to clearly indicate answer recall status for a more informative evaluation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->