### PR TITLE
fix(packages/graphql): ensure that all required derived permissions are recomputed on object manipulation with dependencies

### DIFF
--- a/packages/graphql/src/services/groups.ts
+++ b/packages/graphql/src/services/groups.ts
@@ -996,6 +996,7 @@ export async function manipulateGroupActivity(
 
   // in EDIT mode - check which instances and stacks should be removed
   let instancesToDelete: number[] = []
+  let unlinkedElementIds: number[] = [] // ids of all elements, which will no longer require a derived permissions link to the activity
   let stacksToDelete: number[] = []
   if (id) {
     const instances = await ctx.prisma.elementInstance.findMany({
@@ -1014,6 +1015,7 @@ export async function manipulateGroupActivity(
     })
 
     instancesToDelete = instances.map((instance) => instance.id)
+    unlinkedElementIds = instances.map((instance) => instance.elementId)
     stacksToDelete = stacks.map((stack) => stack.id)
   }
 
@@ -1124,6 +1126,13 @@ export async function manipulateGroupActivity(
       create: createOrUpdateJSON,
       update: createOrUpdateJSON,
     })
+
+    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+    if (unlinkedElementIds.length > 0) {
+      for (const elementId of unlinkedElementIds) {
+        await recomputeDerivedPermissions({ elementId }, prisma)
+      }
+    }
 
     // update all permissions linked to this group activity (since course might have changed on edit as well --> new derived permissions)
     await recomputeDerivedPermissions(

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -547,6 +547,7 @@ export async function manipulateLiveQuiz(
 
   // in EDIT mode - check which instances and blocks should be removed
   let instancesToDelete: number[] = []
+  let unlinkedElementIds: number[] = [] // ids of all elements, which will no longer require a derived permissions link to the activity
   let blocksToDelete: number[] = []
   if (id) {
     const instances = await ctx.prisma.elementInstance.findMany({
@@ -565,6 +566,7 @@ export async function manipulateLiveQuiz(
     })
 
     instancesToDelete = instances.map((instance) => instance.id)
+    unlinkedElementIds = instances.map((instance) => instance.elementId)
     blocksToDelete = blocks.map((block) => block.id)
   }
 
@@ -682,13 +684,14 @@ export async function manipulateLiveQuiz(
       },
     })
 
-    await recomputeDerivedPermissions(
-      {
-        liveQuizId: upsertedQuiz.id,
-      },
-      prisma
-    )
+    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+    if (unlinkedElementIds.length > 0) {
+      for (const elementId of unlinkedElementIds) {
+        await recomputeDerivedPermissions({ elementId }, prisma)
+      }
+    }
 
+    await recomputeDerivedPermissions({ liveQuizId: upsertedQuiz.id }, prisma)
     return upsertedQuiz
   })
 

--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -238,6 +238,7 @@ export async function manipulateMicroLearning(
 
   // in EDIT mode - check which instances and stacks should be removed
   let instancesToDelete: number[] = []
+  let unlinkedElementIds: number[] = [] // ids of all elements, which will no longer require a derived permissions link to the activity
   let stacksToDelete: number[] = []
   if (id) {
     const instances = await ctx.prisma.elementInstance.findMany({
@@ -256,6 +257,7 @@ export async function manipulateMicroLearning(
     })
 
     instancesToDelete = instances.map((instance) => instance.id)
+    unlinkedElementIds = instances.map((instance) => instance.elementId)
     stacksToDelete = stacks.map((stack) => stack.id)
   }
 
@@ -355,10 +357,15 @@ export async function manipulateMicroLearning(
       },
     })
 
+    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+    if (unlinkedElementIds.length > 0) {
+      for (const elementId of unlinkedElementIds) {
+        await recomputeDerivedPermissions({ elementId }, prisma)
+      }
+    }
+
     await recomputeDerivedPermissions(
-      {
-        microLearningId: upsertedMicrolearning.id,
-      },
+      { microLearningId: upsertedMicrolearning.id },
       prisma
     )
 

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -250,6 +250,7 @@ export async function manipulatePracticeQuiz(
 
   // in EDIT mode - check which instances and stacks should be removed
   let instancesToDelete: number[] = []
+  let unlinkedElementIds: number[] = [] // ids of all elements, which will no longer require a derived permissions link to the activity
   let stacksToDelete: number[] = []
   if (id) {
     const instances = await ctx.prisma.elementInstance.findMany({
@@ -268,6 +269,7 @@ export async function manipulatePracticeQuiz(
     })
 
     instancesToDelete = instances.map((instance) => instance.id)
+    unlinkedElementIds = instances.map((instance) => instance.elementId)
     stacksToDelete = stacks.map((stack) => stack.id)
   }
 
@@ -367,10 +369,15 @@ export async function manipulatePracticeQuiz(
       },
     })
 
+    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+    if (unlinkedElementIds.length > 0) {
+      for (const elementId of unlinkedElementIds) {
+        await recomputeDerivedPermissions({ elementId }, prisma)
+      }
+    }
+
     await recomputeDerivedPermissions(
-      {
-        practiceQuizId: upsertedQuiz.id,
-      },
+      { practiceQuizId: upsertedQuiz.id },
       prisma
     )
 

--- a/packages/graphql/src/services/questions.ts
+++ b/packages/graphql/src/services/questions.ts
@@ -371,6 +371,18 @@ export async function manipulateQuestion(
     ctx.prisma
   )
 
+  // if the answer collection linked to the question has changed, recompute the derived permissions for the removed answer collection
+  if (
+    questionPrev?.answerCollectionId !== null &&
+    typeof questionPrev?.answerCollectionId !== 'undefined' &&
+    question.answerCollectionId !== questionPrev.answerCollectionId
+  ) {
+    await recomputeDerivedPermissions(
+      { answerCollectionId: questionPrev.answerCollectionId },
+      ctx.prisma
+    )
+  }
+
   ctx.emitter.emit('invalidate', {
     typename: 'Element',
     id: question.id,
@@ -984,6 +996,11 @@ export async function updateElementInstances(
     return acc
   }, [])
 
+  // keep track of answer collections for which the assignment / link to a template was modified
+  // --> update of derived permissions is required
+  let touchedAnswerCollectionIds: number[] = []
+
+  // execute the instance updates
   const updatedInstances = (
     await Promise.allSettled(
       Object.values(instanceData).map(
@@ -1099,6 +1116,12 @@ export async function updateElementInstances(
               (id) => !templateCollectionIds.includes(id)
             )
 
+            // add all answer collections that were added or removed to the touched ones for a derived permissions update
+            touchedAnswerCollectionIds = touchedAnswerCollectionIds.concat([
+              ...collectionsToDisconnect,
+              ...collectionsToConnect,
+            ])
+
             // check if the list of answer collection ids in the template and the ones used in the instance coincide, otherwise update these links
             if (
               collectionsToConnect.length > 0 ||
@@ -1165,6 +1188,18 @@ export async function updateElementInstances(
     if (result.status !== 'fulfilled' || !result.value) return []
     return result.value
   })
+
+  if (includeTemplates) {
+    // reduce the list of touched answer collections to unique values
+    const uniqueTouchedAnswerCollectionIds = [
+      ...new Set(touchedAnswerCollectionIds),
+    ]
+
+    // recompute the derived permissions for all touched answer collections
+    for (const id of uniqueTouchedAnswerCollectionIds) {
+      await recomputeDerivedPermissions({ answerCollectionId: id }, ctx.prisma)
+    }
+  }
 
   return updatedInstances
 }


### PR DESCRIPTION
This pull request addresses the following potential issues where derived permissions for dependencies need to be updated, while the dependencies might have been actually disconnected (and would therefore not be affected by the propagation of permission updates):
- change of an answer collection linked to an element
- change of answer collections linked to a template when updating the contained elements through element instance updates
- change of elements in an activity where sufficiently high permissions required the propagation (ADMIN level)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the system’s handling of permissions to ensure they update accurately when associated collections change.
  - Enhanced the process for tracking and applying updates, resulting in more consistent data integrity.
  - Updated derived permissions dynamically for elements that are unlinked from various activities, ensuring accurate permission management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->