### PR TITLE
chore(cypress): extend e2e testing with validation of access request duplication on sharing with ADMIN permissions

### DIFF
--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
@@ -85,7 +85,7 @@ function ElementEditForm({
   return (
     <Formik
       validateOnMount
-      enableReinitialize
+      enableReinitialize={!isTemplate}
       initialValues={initialValues}
       validationSchema={questionManipulationSchema}
       onSubmit={async (values, { setSubmitting }) => {

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -41,7 +41,6 @@ export default defineConfig({
   projectId: 'y436dx',
   trashAssetsBeforeRuns: true,
   video: true,
-  videoCompression: 10,
   env: {
     URL_STUDENT: 'http://127.0.0.1:3001',
     URL_STUDENT_LOGIN: 'http://127.0.0.1:3001/login',

--- a/cypress/cypress/e2e/K-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/K-resources-workflow.cy.ts
@@ -552,6 +552,101 @@ describe('Create, edit and share answer collections', function () {
     ).should('exist')
   })
 
+  it('Temporarily award ADMIN permissions to user pro3 and verify that the access requests are visible as well', function () {
+    // grant ADMIN permissions to user pro3 through direct sharing
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.restricted.name}"]`
+    ).click()
+    cy.get('[data-cy="share-answer-collection"]').click()
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_INST2_SHORTNAME')
+    )
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
+    cy.logoutLecturer()
+
+    // verify that access requests are visible to user pro3
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="sharing-request-${this.data.restricted.name}-pro1"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.restricted.name}-pro1"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.restricted.name}-pro1"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="sharing-request-${this.data.restricted.name}-pro2"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.restricted.name}-pro2"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.restricted.name}-pro2"]`
+    ).should('exist')
+    cy.logoutLecturer()
+
+    // revoke direct ADMIN permissions again
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.restricted.name}"]`
+    ).click()
+    cy.get('[data-cy="share-answer-collection"]').click()
+    cy.get(
+      `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).click()
+    cy.get(
+      `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).should('not.exist')
+    cy.logoutLecturer()
+
+    // verify that the access requests are not visible anymore to user pro3
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="sharing-request-${this.data.restricted.name}-pro1"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.restricted.name}-pro1"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.restricted.name}-pro1"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="sharing-request-${this.data.restricted.name}-pro2"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.restricted.name}-pro2"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.restricted.name}-pro2"]`
+    ).should('not.exist')
+  })
+
   it('Verify that answer collection cannot be integrated into question by user pro1', function () {
     cy.loginIndividualCatalyst()
     cy.get('[data-cy="library"]').click()

--- a/cypress/cypress/e2e/M-template-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-template-workflow.cy.ts
@@ -1278,7 +1278,6 @@ describe('Test all functionalities related to the creation, management, sharing 
           'have.value',
           oldTitle
         )
-        cy.wait(2000) // wait for form to be fully populated to avoid overlapping inputs
 
         cy.get('[data-cy="insert-question-title"]')
           .click()
@@ -1288,7 +1287,6 @@ describe('Test all functionalities related to the creation, management, sharing 
           .realClick()
           .clear()
           .type(newContent)
-        cy.wait(500) // wait for state to be updated for sure
         cy.get('[data-cy="save-new-question"]').click()
         cy.wait(500) // wait for element to be properly saved and UI to update
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new end-to-end test to verify that users with temporary ADMIN permissions can view access requests on restricted answer collections, and that these requests are hidden once permissions are revoked.
  - Improved test efficiency by removing unnecessary wait times in template workflow tests.
- **Bug Fixes**
  - Adjusted form behavior to prevent unnecessary reinitialization when editing templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->