### PR TITLE
enhance(packages/graphql): add audit log entries for implemented sharing and catalog functionalities

### DIFF
--- a/packages/graphql/src/services/resources.ts
+++ b/packages/graphql/src/services/resources.ts
@@ -567,6 +567,17 @@ export async function removeAnswerCollection(
     await ctx.prisma.$transaction(async (prisma) => {
       await prisma.permission.delete({ where: { id: permission.id } })
 
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(collectionId),
+          objectType: DB.ObjectType.ANSWER_COLLECTION,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.ANSWER_COLLECTION} (ID: ${collectionId})`,
+        },
+      })
+
       // trigger recomputation of derived permissions
       await recomputeDerivedPermissions(
         { answerCollectionId: collectionId, userId: ctx.user.sub },

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -558,6 +558,25 @@ export function getAuditLogObjectType({
   microLearningId?: string | null
   groupActivityId?: string | null
 }): { objectType: DB.ObjectType | null; objectId: string | null } {
+  // check if exactly one of the object ids is defined
+  const defined = [
+    catalogCollectionId,
+    answerCollectionId,
+    elementId,
+    courseId,
+    liveQuizId,
+    practiceQuizId,
+    microLearningId,
+    groupActivityId,
+  ].filter((v) => v != null)
+
+  if (defined.length !== 1) {
+    throw new Error(
+      `Ambiguous audit object identifiers: ${JSON.stringify(arguments[0])}`
+    )
+  }
+
+  // determine the object type and ID based on the provided parameters
   if (
     typeof catalogCollectionId !== 'undefined' &&
     catalogCollectionId !== null

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -192,29 +192,19 @@ export async function validateActivityPermissions(
 export async function verifyCatalogObjectEditPermissions(
   { assignmentId }: { assignmentId: number },
   ctx: ContextWithUser
-) {
+): Promise<{
+  sufficientPermissions: boolean
+  assignment: DB.CatalogCollectionAssignment | null
+}> {
   // fetch current assignment
   const assignment = await ctx.prisma.catalogCollectionAssignment.findUnique({
     where: {
       id: assignmentId,
     },
-    include: {
-      answerCollection: {
-        select: {
-          id: true,
-        },
-      },
-      liveQuiz: {
-        select: {
-          id: true,
-        },
-      },
-      // ... add more object types once they are supported for sharing
-    },
   })
 
   if (!assignment) {
-    return false
+    return { sufficientPermissions: false, assignment }
   }
 
   // ! Case 1: Object in Catalog Collection -> access level on catalog collection decides permissions
@@ -227,39 +217,82 @@ export async function verifyCatalogObjectEditPermissions(
       },
       ctx
     )
-    return valid
+    return { sufficientPermissions: valid, assignment }
   }
   // ! Case 2: Object in top-level collection -> access level on object decides permissions
   else {
-    if (typeof assignment.answerCollection?.id !== 'undefined') {
-      // verify that the user has access to the answer collection
-      const valid = await checkAccess(
-        [
-          {
-            answerCollectionId: assignment.answerCollection.id,
-            minimumPermissionLevel: DB.PermissionLevel.ADMIN,
-          },
-        ],
-        ctx
-      )
+    // verify that the user has sufficient permissions on the object
+    const valid = await checkAccess(
+      [
+        ...(typeof assignment.answerCollectionId !== 'undefined' &&
+        assignment.answerCollectionId !== null
+          ? [
+              {
+                answerCollectionId: assignment.answerCollectionId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+        ...(typeof assignment.elementId !== 'undefined' &&
+        assignment.elementId !== null
+          ? [
+              {
+                elementId: assignment.elementId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+        ...(typeof assignment.courseId !== 'undefined' &&
+        assignment.courseId !== null
+          ? [
+              {
+                courseId: assignment.courseId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+        ...(typeof assignment.liveQuizId !== 'undefined' &&
+        assignment.liveQuizId !== null
+          ? [
+              {
+                liveQuizId: assignment.liveQuizId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+        ...(typeof assignment.practiceQuizId !== 'undefined' &&
+        assignment.practiceQuizId !== null
+          ? [
+              {
+                practiceQuizId: assignment.practiceQuizId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+        ...(typeof assignment.microLearningId !== 'undefined' &&
+        assignment.microLearningId !== null
+          ? [
+              {
+                microLearningId: assignment.microLearningId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+        ...(typeof assignment.groupActivityId !== 'undefined' &&
+        assignment.groupActivityId !== null
+          ? [
+              {
+                groupActivityId: assignment.groupActivityId,
+                minimumPermissionLevel: DB.PermissionLevel.ADMIN,
+              },
+            ]
+          : []),
+      ],
+      ctx
+    )
 
-      return valid
-    } else if (typeof assignment.liveQuiz?.id !== 'undefined') {
-      // verify that the user has access to the live quiz / live quiz template
-      const valid = await validateActivityPermissions(
-        {
-          activityId: assignment.liveQuiz.id,
-          activityType: ActivityType.LIVE_QUIZ,
-          minimumPermissionLevel: DB.PermissionLevel.ADMIN,
-        },
-        ctx
-      )
-      return valid
-    }
-    // ... add more object types once they are supported for sharing
+    return { sufficientPermissions: valid, assignment }
   }
-
-  return false
 }
 
 /**
@@ -490,6 +523,85 @@ export async function createAccessRequestInstancesNewAdmin(
     })
   }
 }
+
+/**
+ * Determines the object type and returns the ID based on the provided ID parameters.
+ * Returns the appropriate DB.ObjectType and a stringified version of the ID,
+ * or null if no valid ID is provided.
+ *
+ * @param [params.catalogCollectionId] - ID of a catalog collection
+ * @param [params.answerCollectionId] - ID of an answer collection
+ * @param [params.elementId] - ID of an element
+ * @param [params.courseId] - ID of a course
+ * @param [params.liveQuizId] - ID of a live quiz
+ * @param [params.practiceQuizId] - ID of a practice quiz
+ * @param [params.microLearningId] - ID of a micro learning
+ * @param [params.groupActivityId] - ID of a group activity
+ * @returns {{objectType: DB.ObjectType, objectId: string}|null} Object with type and ID or null
+ */
+export function getAuditLogObjectType({
+  catalogCollectionId,
+  answerCollectionId,
+  elementId,
+  courseId,
+  liveQuizId,
+  practiceQuizId,
+  microLearningId,
+  groupActivityId,
+}: {
+  catalogCollectionId?: string | null
+  answerCollectionId?: number | null
+  elementId?: number | null
+  courseId?: string | null
+  liveQuizId?: string | null
+  practiceQuizId?: string | null
+  microLearningId?: string | null
+  groupActivityId?: string | null
+}): { objectType: DB.ObjectType | null; objectId: string | null } {
+  if (
+    typeof catalogCollectionId !== 'undefined' &&
+    catalogCollectionId !== null
+  ) {
+    return {
+      objectType: DB.ObjectType.CATALOG_COLLECTION,
+      objectId: catalogCollectionId,
+    }
+  } else if (
+    typeof answerCollectionId !== 'undefined' &&
+    answerCollectionId !== null
+  ) {
+    return {
+      objectType: DB.ObjectType.ANSWER_COLLECTION,
+      objectId: String(answerCollectionId),
+    }
+  } else if (typeof elementId !== 'undefined' && elementId !== null) {
+    return { objectType: DB.ObjectType.ELEMENT, objectId: String(elementId) }
+  } else if (typeof courseId !== 'undefined' && courseId !== null) {
+    return { objectType: DB.ObjectType.COURSE, objectId: courseId }
+  } else if (typeof liveQuizId !== 'undefined' && liveQuizId !== null) {
+    return { objectType: DB.ObjectType.LIVE_QUIZ, objectId: liveQuizId }
+  } else if (typeof practiceQuizId !== 'undefined' && practiceQuizId !== null) {
+    return { objectType: DB.ObjectType.PRACTICE_QUIZ, objectId: practiceQuizId }
+  } else if (
+    typeof microLearningId !== 'undefined' &&
+    microLearningId !== null
+  ) {
+    return {
+      objectType: DB.ObjectType.MICRO_LEARNING,
+      objectId: microLearningId,
+    }
+  } else if (
+    typeof groupActivityId !== 'undefined' &&
+    groupActivityId !== null
+  ) {
+    return {
+      objectType: DB.ObjectType.GROUP_ACTIVITY,
+      objectId: groupActivityId,
+    }
+  }
+
+  return { objectType: null, objectId: null }
+}
 // #endregion
 
 // ! Catalog Collection Operations
@@ -611,26 +723,38 @@ export async function changeCatalogCollectionObjectAccess(
   {
     catalogCollectionId,
     access,
-  }: {
-    catalogCollectionId: string
-    access: DB.ObjectAccess
-  },
+  }: { catalogCollectionId: string; access: DB.ObjectAccess },
   ctx: ContextWithUser
 ) {
-  // update the access level of the catalog collection
-  const updatedCollection = await ctx.prisma.catalogCollection.update({
-    where: { id: catalogCollectionId },
-    data: { access },
+  const collection = await ctx.prisma.$transaction(async (prisma) => {
+    // update the access level of the catalog collection
+    const updatedCollection = await prisma.catalogCollection.update({
+      where: { id: catalogCollectionId },
+      data: { access },
+    })
+
+    // create an entry in the audit log
+    await prisma.auditLogEntry.create({
+      data: {
+        type: DB.AuditLogType.CATALOG_ASSIGNMENT_MODIFIED,
+        objectType: DB.ObjectType.CATALOG_COLLECTION,
+        objectId: catalogCollectionId,
+        sourceUserId: ctx.user.sub,
+        message: `Catalog collection access level changed to ${access}`,
+      },
+    })
+
+    return updatedCollection
   })
 
-  if (!updatedCollection) {
+  if (!collection) {
     return false
   }
 
   // invalidate cache for the updated collection
   ctx.emitter.emit('invalidate', {
     typename: 'CatalogCollection',
-    id: updatedCollection.id,
+    id: collection.id,
   })
 
   // return success
@@ -665,7 +789,7 @@ export async function changeCatalogObjectAccess(
   { assignmentId, access }: { assignmentId: number; access: DB.ObjectAccess },
   ctx: ContextWithUser
 ) {
-  const sufficientPermissions = await verifyCatalogObjectEditPermissions(
+  const { sufficientPermissions } = await verifyCatalogObjectEditPermissions(
     { assignmentId },
     ctx
   )
@@ -673,13 +797,51 @@ export async function changeCatalogObjectAccess(
     return false
   }
 
-  // change the access level of the assignment
-  const updatedAssignment = await ctx.prisma.catalogCollectionAssignment.update(
-    {
+  const updatedAssignment = await ctx.prisma.$transaction(async (prisma) => {
+    // change the access level of the assignment
+    const newAssignment = await prisma.catalogCollectionAssignment.update({
       where: { id: assignmentId },
       data: { access },
+    })
+
+    // create an entry in the audit log
+    const { objectType, objectId } = getAuditLogObjectType({
+      answerCollectionId: newAssignment.answerCollectionId,
+      elementId: newAssignment.elementId,
+      courseId: newAssignment.courseId,
+      liveQuizId: newAssignment.liveQuizId,
+      practiceQuizId: newAssignment.practiceQuizId,
+      microLearningId: newAssignment.microLearningId,
+      groupActivityId: newAssignment.groupActivityId,
+    })
+    if (objectType && objectId) {
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.CATALOG_ASSIGNMENT_MODIFIED,
+          objectType,
+          objectId,
+          sourceUserId: ctx.user.sub,
+          message: `Catalog object assignment (ID ${newAssignment.id} for ${objectType} with ID ${objectId}) access level changed to ${access}`,
+        },
+      })
+    } else {
+      throw new Error(
+        `Could not determine object type or ID for audit log entry. Assignment ID: ${newAssignment.id}, Details: ${JSON.stringify(
+          {
+            answerCollectionId: newAssignment.answerCollectionId,
+            elementId: newAssignment.elementId,
+            courseId: newAssignment.courseId,
+            liveQuizId: newAssignment.liveQuizId,
+            practiceQuizId: newAssignment.practiceQuizId,
+            microLearningId: newAssignment.microLearningId,
+            groupActivityId: newAssignment.groupActivityId,
+          }
+        )}`
+      )
     }
-  )
+
+    return newAssignment
+  })
 
   // invalidate cache for the updated assignment
   ctx.emitter.emit('invalidate', {
@@ -817,14 +979,13 @@ export async function requestCatalogCollection(
     return null
   }
 
-  // TODO: upsert audit log entry (wrapped into transaction with access request upsert)
-
   // upsert access requests for all owners and admins
   const ownerAdminIds = adminOwnerPermissions.map(
     (permission) => permission.userId
   )
   await Promise.all(
     ownerAdminIds.map(async (adminOwnerId) => {
+      // create the actual access request
       await ctx.prisma.accessRequest.upsert({
         where: {
           catalogCollectionId_userId_objectAdminOrOwnerId: {
@@ -853,6 +1014,18 @@ export async function requestCatalogCollection(
         },
         update: {
           permissionLevel: requestedPermissionLevel ?? DB.PermissionLevel.READ,
+        },
+      })
+
+      // create an entry in the audit log
+      await ctx.prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.REQUEST_CREATED,
+          objectType: DB.ObjectType.CATALOG_COLLECTION,
+          objectId: catalogCollectionId,
+          sourceUserId: ctx.user.sub,
+          targetUserId: adminOwnerId,
+          message: `Access request (permission level ${requestedPermissionLevel ?? DB.PermissionLevel.READ}) created for ${DB.ObjectType.CATALOG_COLLECTION} (ID ${catalogCollectionId}) by user ${ctx.user.sub} for owner / admin ${adminOwnerId}.`,
         },
       })
     })
@@ -1111,14 +1284,13 @@ export async function requestCatalogObject(
     return false
   }
 
-  // TODO: upsert audit log entry (wrapped into transaction with access request upsert)
-
   // upsert access requests for all owners and admins
   const ownerAdminIds = adminOwnerPermissions.map(
     (permission) => permission.userId
   )
   await Promise.all(
     ownerAdminIds.map(async (adminOwnerId) => {
+      // create the actual access request
       await ctx.prisma.accessRequest.upsert({
         where: {
           answerCollectionId_userId_objectAdminOrOwnerId:
@@ -1251,17 +1423,88 @@ export async function requestCatalogObject(
           permissionLevel: requestedPermissionLevel ?? DB.PermissionLevel.READ,
         },
       })
+
+      // create an entry in the audit log
+      const { objectType, objectId } = getAuditLogObjectType({
+        answerCollectionId,
+        elementId,
+        courseId,
+        liveQuizId,
+        practiceQuizId,
+        microLearningId,
+        groupActivityId,
+      })
+      if (objectType && objectId) {
+        await ctx.prisma.auditLogEntry.create({
+          data: {
+            type: DB.AuditLogType.REQUEST_CREATED,
+            objectType,
+            objectId,
+            sourceUserId: ctx.user.sub,
+            targetUserId: adminOwnerId,
+            message: `Access request (permission level ${requestedPermissionLevel ?? DB.PermissionLevel.READ}) created for ${objectType} (ID ${objectId}) by user ${ctx.user.sub} for owner / admin ${adminOwnerId}.`,
+          },
+        })
+      } else {
+        throw new Error(
+          `Could not determine object type or ID for audit log entry. Request ID: ${answerCollectionId}, Details: ${JSON.stringify(
+            {
+              answerCollectionId,
+              elementId,
+              courseId,
+              liveQuizId,
+              practiceQuizId,
+              microLearningId,
+              groupActivityId,
+            }
+          )}`
+        )
+      }
     })
   )
 
   // invalidate cache for the imported object
-  if (typeof answerCollectionId !== 'undefined') {
+  if (typeof catalogCollectionId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'CatalogCollection',
+      id: catalogCollectionId,
+    })
+  } else if (typeof answerCollectionId !== 'undefined') {
     ctx.emitter.emit('invalidate', {
       typename: 'AnswerCollection',
       id: answerCollectionId,
     })
+  } else if (typeof elementId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'Element',
+      id: elementId,
+    })
+  } else if (typeof courseId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'Course',
+      id: courseId,
+    })
+  } else if (typeof liveQuizId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'LiveQuiz',
+      id: liveQuizId,
+    })
+  } else if (typeof practiceQuizId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'PracticeQuiz',
+      id: practiceQuizId,
+    })
+  } else if (typeof microLearningId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'MicroLearning',
+      id: microLearningId,
+    })
+  } else if (typeof groupActivityId !== 'undefined') {
+    ctx.emitter.emit('invalidate', {
+      typename: 'GroupActivity',
+      id: groupActivityId,
+    })
   }
-  // TODO: ... add more object types once they are supported for
 
   // TODO: update return value to success of transaction
   return true
@@ -1305,10 +1548,23 @@ export async function cancelObjectSharingRequest(
     return false
   }
 
-  // remove the access request
-  await ctx.prisma.accessRequest.deleteMany({
-    where: {
-      userId: ctx.user.sub,
+  await ctx.prisma.$transaction(async (prisma) => {
+    // remove the access request
+    await prisma.accessRequest.deleteMany({
+      where: {
+        userId: ctx.user.sub,
+        answerCollectionId,
+        elementId,
+        courseId,
+        liveQuizId,
+        practiceQuizId,
+        microLearningId,
+        groupActivityId,
+      },
+    })
+
+    // create an audit log entry for the deleted access request
+    const { objectType, objectId } = getAuditLogObjectType({
       answerCollectionId,
       elementId,
       courseId,
@@ -1316,7 +1572,33 @@ export async function cancelObjectSharingRequest(
       practiceQuizId,
       microLearningId,
       groupActivityId,
-    },
+    })
+
+    if (objectType !== null && objectId !== null) {
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.REQUEST_CANCELLED,
+          objectType,
+          objectId,
+          sourceUserId: ctx.user.sub,
+          message: `Access request cancelled for ${objectType} (ID ${objectId}) by user ${ctx.user.sub}.`,
+        },
+      })
+    } else {
+      throw new Error(
+        `Could not determine object type or ID for audit log entry. Request ID: ${answerCollectionId}, Details: ${JSON.stringify(
+          {
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
+          }
+        )}`
+      )
+    }
   })
 
   // invalidate all access requests that were deleted
@@ -1567,6 +1849,49 @@ export async function resolveObjectSharingRequest(
           groupActivityId: pendingRequest.groupActivityId ?? undefined,
         },
         prisma
+      )
+    }
+
+    // create an audit log entry for the resolved access request
+    const { objectType, objectId } = getAuditLogObjectType({
+      catalogCollectionId: pendingRequest.catalogCollectionId,
+      answerCollectionId: pendingRequest.answerCollectionId,
+      elementId: pendingRequest.elementId,
+      courseId: pendingRequest.courseId,
+      liveQuizId: pendingRequest.liveQuizId,
+      practiceQuizId: pendingRequest.practiceQuizId,
+      microLearningId: pendingRequest.microLearningId,
+      groupActivityId: pendingRequest.groupActivityId,
+    })
+    if (objectType && objectId) {
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.REQUEST_RESOLVED,
+          objectType,
+          objectId,
+          sourceUserId: ctx.user.sub,
+          targetUserId: userId,
+          message: `Access request ${
+            approved
+              ? `approved (with permission level ${permissionLevel})`
+              : 'declined'
+          } for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} for user ${userId}.`,
+        },
+      })
+    } else {
+      throw new Error(
+        `Could not determine object type or ID for audit log entry. Request ID: ${requestId}, Details: ${JSON.stringify(
+          {
+            catalogCollectionId: pendingRequest.catalogCollectionId,
+            answerCollectionId: pendingRequest.answerCollectionId,
+            elementId: pendingRequest.elementId,
+            courseId: pendingRequest.courseId,
+            liveQuizId: pendingRequest.liveQuizId,
+            practiceQuizId: pendingRequest.practiceQuizId,
+            microLearningId: pendingRequest.microLearningId,
+            groupActivityId: pendingRequest.groupActivityId,
+          }
+        )}`
       )
     }
 
@@ -1882,6 +2207,7 @@ export async function changeObjectPermissionLevel(
           })
         )
       }
+
       // if ADMIN permissions were revoked, make sure that the user does not have any access request instances assigned anymore
       else if (
         previousPermission.permissionLevel === DB.PermissionLevel.ADMIN &&
@@ -1903,6 +2229,46 @@ export async function changeObjectPermissionLevel(
           },
         })
       }
+    }
+
+    // create an audit log entry for the updated permission
+    const { objectType, objectId } = getAuditLogObjectType({
+      catalogCollectionId,
+      answerCollectionId,
+      elementId,
+      courseId,
+      liveQuizId,
+      practiceQuizId,
+      microLearningId,
+      groupActivityId,
+    })
+    if (objectType && objectId) {
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_MODIFIED,
+          objectType,
+          objectId,
+          sourceUserId: ctx.user.sub,
+          targetUserId: updatedPermission.userId ?? undefined,
+          targetUserGroupId: updatedPermission.userGroupId ?? undefined,
+          message: `Permission level changed from ${previousPermission.permissionLevel} to ${permissionLevel} for ${objectType} (ID ${objectId}) through owner / admin ${ctx.user.sub} for ${updatedPermission.userId ? `user ${updatedPermission.userId}` : `user group ${updatedPermission.userGroupId}`}.`,
+        },
+      })
+    } else {
+      throw new Error(
+        `Could not determine object type or ID for audit log entry. Permission ID: ${permissionId}, Details: ${JSON.stringify(
+          {
+            catalogCollectionId,
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
+          }
+        )}`
+      )
     }
 
     return updatedPermission
@@ -1985,6 +2351,47 @@ export async function revokeObjectAccess(
       where: { id: permissionId },
     })
 
+    // add an audit log entry for the revoked permission
+    const { objectType, objectId } = getAuditLogObjectType({
+      catalogCollectionId,
+      answerCollectionId,
+      elementId,
+      courseId,
+      liveQuizId,
+      practiceQuizId,
+      microLearningId,
+      groupActivityId,
+    })
+    if (objectType && objectId) {
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REVOKED,
+          objectType,
+          objectId,
+          sourceUserId: ctx.user.sub,
+          targetUserId: permission.userId ?? undefined,
+          targetUserGroupId: permission.userGroupId ?? undefined,
+          message: `Permission revoked for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} for ${permission.user?.id ? `user ${permission.user?.id}` : `user group ${permission.userGroupId}`}.`,
+        },
+      })
+    } else {
+      throw new Error(
+        `Could not determine object type or ID for audit log entry. Permission ID: ${permissionId}, Details: ${JSON.stringify(
+          {
+            catalogCollectionId,
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
+          }
+        )}`
+      )
+    }
+
+    // compute the users affected by this permission revocation
     const affectedUserIds = permission.userId
       ? [permission.userId]
       : userGroup
@@ -1992,7 +2399,7 @@ export async function revokeObjectAccess(
         : []
 
     for (const affectedUserId of affectedUserIds) {
-      // if the new revoked permission level had ADMIN level, remove any access requests linked to this user as an object owner or admin
+      // if the new revoked permission level had ADMIN level, remove any access requests linked to this user (group) as an object owner or admin
       await prisma.accessRequest.deleteMany({
         where: {
           objectAdminOrOwnerId: affectedUserId,
@@ -2165,6 +2572,18 @@ export async function transferCatalogCollectionOwnership(
       })
     }
 
+    // create an audit log entry for the ownership transfer
+    await prisma.auditLogEntry.create({
+      data: {
+        type: DB.AuditLogType.OWNER_TRANSFERRED,
+        objectType: DB.ObjectType.CATALOG_COLLECTION,
+        objectId: id,
+        sourceUserId: ctx.user.sub,
+        targetUserId: newOwner.id,
+        message: `Ownership of ${DB.ObjectType.CATALOG_COLLECTION} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+      },
+    })
+
     // trigger recomputation of derived permissions for the catalog collection for both users
     await recomputeDerivedPermissions(
       { catalogCollectionId: id, userId: newOwner.id },
@@ -2302,6 +2721,18 @@ export async function transferAnswerCollectionOwnership(
         },
       })
     }
+
+    // create an audit log entry for the ownership transfer
+    await prisma.auditLogEntry.create({
+      data: {
+        type: DB.AuditLogType.OWNER_TRANSFERRED,
+        objectType: DB.ObjectType.ANSWER_COLLECTION,
+        objectId: String(id),
+        sourceUserId: ctx.user.sub,
+        targetUserId: newOwner.id,
+        message: `Ownership of ${DB.ObjectType.ANSWER_COLLECTION} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+      },
+    })
 
     // trigger recomputation of derived permissions for the answer collection for both users
     await recomputeDerivedPermissions(
@@ -2571,6 +3002,45 @@ export async function shareObject(
         )
       }
 
+      // create an audit log entry for the newly created permission
+      const { objectType, objectId } = getAuditLogObjectType({
+        catalogCollectionId,
+        answerCollectionId,
+        elementId,
+        courseId,
+        liveQuizId,
+        practiceQuizId,
+        microLearningId,
+        groupActivityId,
+      })
+      if (objectType && objectId) {
+        await prisma.auditLogEntry.create({
+          data: {
+            type: DB.AuditLogType.PERMISSION_GRANTED,
+            objectType,
+            objectId,
+            sourceUserId: ctx.user.sub,
+            targetUserId: userId,
+            message: `Direct permission with level ${permissionLevel} granted for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} to user ${userId}.`,
+          },
+        })
+      } else {
+        throw new Error(
+          `Could not determine object type or ID for audit log entry. Permission ID: ${newPermission.id}, Details: ${JSON.stringify(
+            {
+              catalogCollectionId,
+              answerCollectionId,
+              elementId,
+              courseId,
+              liveQuizId,
+              practiceQuizId,
+              microLearningId,
+              groupActivityId,
+            }
+          )}`
+        )
+      }
+
       return newPermission
     })
 
@@ -2607,7 +3077,6 @@ export async function importAnswerCollection(
   }: { collectionId: number; catalogCollectionId?: string | null },
   ctx: ContextWithUser
 ) {
-  // TODO: move access control to pothos level (if possible)
   // verify that the user has access to the catalog collection the answer collection is contained in
   const validAccess = catalogCollectionId
     ? await verifyCatalogCollectionBrowsable(
@@ -2783,7 +3252,7 @@ export async function getCatalogObjects(
       objectAssignments: {
         include: {
           answerCollection: {
-            where: { ownerId: { not: null } },
+            where: { isDeleted: false },
             select: {
               id: true,
               name: true,
@@ -2794,6 +3263,7 @@ export async function getCatalogObjects(
             },
           },
           liveQuiz: {
+            where: { isDeleted: false },
             select: {
               id: true,
               name: true,
@@ -2869,12 +3339,10 @@ export async function removeCatalogObjectAssignment(
   { assignmentId }: { assignmentId: number },
   ctx: ContextWithUser
 ) {
-  const sufficientPermissions = await verifyCatalogObjectEditPermissions(
-    { assignmentId },
-    ctx
-  )
+  const { sufficientPermissions, assignment } =
+    await verifyCatalogObjectEditPermissions({ assignmentId }, ctx)
 
-  if (!sufficientPermissions) {
+  if (!sufficientPermissions || !assignment) {
     return false
   }
 
@@ -2882,6 +3350,42 @@ export async function removeCatalogObjectAssignment(
   const updatedAssignment = await ctx.prisma.catalogCollectionAssignment.delete(
     { where: { id: assignmentId } }
   )
+
+  // create an audit log entry for the assignment removal
+  const { objectType, objectId } = getAuditLogObjectType({
+    answerCollectionId: assignment.answerCollectionId,
+    elementId: assignment.elementId,
+    courseId: assignment.courseId,
+    liveQuizId: assignment.liveQuizId,
+    practiceQuizId: assignment.practiceQuizId,
+    microLearningId: assignment.microLearningId,
+    groupActivityId: assignment.groupActivityId,
+  })
+  if (objectType && objectId) {
+    await ctx.prisma.auditLogEntry.create({
+      data: {
+        type: DB.AuditLogType.CATALOG_ASSIGNMENT_DELETED,
+        objectType,
+        objectId,
+        sourceUserId: ctx.user.sub,
+        message: `${objectType} (ID ${objectId}) removed from catalog collection (ID ${assignment.catalogCollectionId}) by user ${ctx.user.sub}.`,
+      },
+    })
+  } else {
+    throw new Error(
+      `Could not determine object type or ID for audit log entry. Assignment ID: ${assignmentId}, Details: ${JSON.stringify(
+        {
+          answerCollectionId: assignment.answerCollectionId,
+          elementId: assignment.elementId,
+          courseId: assignment.courseId,
+          liveQuizId: assignment.liveQuizId,
+          practiceQuizId: assignment.practiceQuizId,
+          microLearningId: assignment.microLearningId,
+          groupActivityId: assignment.groupActivityId,
+        }
+      )}`
+    )
+  }
 
   return (
     updatedAssignment.id !== null && typeof updatedAssignment.id !== 'undefined'
@@ -2892,7 +3396,7 @@ export async function getCatalogAnswerCollections(ctx: ContextWithUser) {
   // fetch all answer collections, where the user is the owner or has been granted admin access
   const collections = await ctx.prisma.answerCollection.findMany({
     where: {
-      ownerId: { not: null }, // soft deleted answer collections cannot be added to the catalog
+      isDeleted: false, // soft deleted answer collections cannot be added to the catalog
       permissions: {
         some: {
           userId: ctx.user.sub,
@@ -3067,133 +3571,173 @@ export async function addObjectToCatalog(
     return null
   }
 
-  // upsert the assignemnt of the answer collection to the catalog collection
-  const assignment = await ctx.prisma.catalogCollectionAssignment.upsert({
-    where: {
-      answerCollectionId_catalogCollectionId:
-        typeof answerCollectionId !== 'undefined'
-          ? {
-              answerCollectionId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-      elementId_catalogCollectionId:
-        typeof elementId !== 'undefined'
-          ? {
-              elementId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-      courseId_catalogCollectionId:
-        typeof courseId !== 'undefined'
-          ? {
-              courseId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-      liveQuizId_catalogCollectionId:
-        typeof liveQuizId !== 'undefined'
-          ? {
-              liveQuizId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-      practiceQuizId_catalogCollectionId:
-        typeof practiceQuizId !== 'undefined'
-          ? {
-              practiceQuizId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-      microLearningId_catalogCollectionId:
-        typeof microLearningId !== 'undefined'
-          ? {
-              microLearningId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-      groupActivityId_catalogCollectionId:
-        typeof groupActivityId !== 'undefined'
-          ? {
-              groupActivityId,
-              catalogCollectionId:
-                catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-            }
-          : undefined,
-    },
-    create: {
-      access,
-      catalogCollection: {
-        connect: {
-          id: catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
-        },
+  const assignment = await ctx.prisma.$transaction(async (prisma) => {
+    // upsert the assignemnt of the answer collection to the catalog collection
+    const newAssignment = await prisma.catalogCollectionAssignment.upsert({
+      where: {
+        answerCollectionId_catalogCollectionId:
+          typeof answerCollectionId !== 'undefined'
+            ? {
+                answerCollectionId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
+        elementId_catalogCollectionId:
+          typeof elementId !== 'undefined'
+            ? {
+                elementId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
+        courseId_catalogCollectionId:
+          typeof courseId !== 'undefined'
+            ? {
+                courseId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
+        liveQuizId_catalogCollectionId:
+          typeof liveQuizId !== 'undefined'
+            ? {
+                liveQuizId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
+        practiceQuizId_catalogCollectionId:
+          typeof practiceQuizId !== 'undefined'
+            ? {
+                practiceQuizId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
+        microLearningId_catalogCollectionId:
+          typeof microLearningId !== 'undefined'
+            ? {
+                microLearningId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
+        groupActivityId_catalogCollectionId:
+          typeof groupActivityId !== 'undefined'
+            ? {
+                groupActivityId,
+                catalogCollectionId:
+                  catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+              }
+            : undefined,
       },
-      answerCollection:
-        typeof answerCollectionId !== 'undefined'
-          ? {
-              connect: {
-                id: answerCollectionId,
-              },
-            }
-          : undefined,
-      element:
-        typeof elementId !== 'undefined'
-          ? {
-              connect: {
-                id: elementId,
-              },
-            }
-          : undefined,
-      course:
-        typeof courseId !== 'undefined'
-          ? {
-              connect: {
-                id: courseId,
-              },
-            }
-          : undefined,
-      liveQuiz:
-        typeof liveQuizId !== 'undefined'
-          ? {
-              connect: {
-                id: liveQuizId,
-              },
-            }
-          : undefined,
-      practiceQuiz:
-        typeof practiceQuizId !== 'undefined'
-          ? {
-              connect: {
-                id: practiceQuizId,
-              },
-            }
-          : undefined,
-      microLearning:
-        typeof microLearningId !== 'undefined'
-          ? {
-              connect: {
-                id: microLearningId,
-              },
-            }
-          : undefined,
-      groupActivity:
-        typeof groupActivityId !== 'undefined'
-          ? {
-              connect: {
-                id: groupActivityId,
-              },
-            }
-          : undefined,
-    },
-    update: {
-      access,
-    },
+      create: {
+        access,
+        catalogCollection: {
+          connect: {
+            id: catalogCollectionId ?? MISSING_CATALOG_COLLECTION_ID,
+          },
+        },
+        answerCollection:
+          typeof answerCollectionId !== 'undefined'
+            ? {
+                connect: {
+                  id: answerCollectionId,
+                },
+              }
+            : undefined,
+        element:
+          typeof elementId !== 'undefined'
+            ? {
+                connect: {
+                  id: elementId,
+                },
+              }
+            : undefined,
+        course:
+          typeof courseId !== 'undefined'
+            ? {
+                connect: {
+                  id: courseId,
+                },
+              }
+            : undefined,
+        liveQuiz:
+          typeof liveQuizId !== 'undefined'
+            ? {
+                connect: {
+                  id: liveQuizId,
+                },
+              }
+            : undefined,
+        practiceQuiz:
+          typeof practiceQuizId !== 'undefined'
+            ? {
+                connect: {
+                  id: practiceQuizId,
+                },
+              }
+            : undefined,
+        microLearning:
+          typeof microLearningId !== 'undefined'
+            ? {
+                connect: {
+                  id: microLearningId,
+                },
+              }
+            : undefined,
+        groupActivity:
+          typeof groupActivityId !== 'undefined'
+            ? {
+                connect: {
+                  id: groupActivityId,
+                },
+              }
+            : undefined,
+      },
+      update: {
+        access,
+      },
+    })
+
+    // create an audit log entry for the assignment creation
+    const { objectType, objectId } = getAuditLogObjectType({
+      answerCollectionId,
+      elementId,
+      courseId,
+      liveQuizId,
+      practiceQuizId,
+      microLearningId,
+      groupActivityId,
+    })
+    if (objectType && objectId) {
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+          objectType,
+          objectId,
+          sourceUserId: ctx.user.sub,
+          message: `${objectType} (ID ${objectId}) added to catalog collection (ID ${catalogCollectionId}) by user ${ctx.user.sub}.`,
+        },
+      })
+    } else {
+      throw new Error(
+        `Could not determine object type or ID for audit log entry. Assignment ID: ${newAssignment.id}, Details: ${JSON.stringify(
+          {
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
+          }
+        )}`
+      )
+    }
+
+    return newAssignment
   })
 
   // return the updated catalog object

--- a/packages/graphql/test/access.test.ts
+++ b/packages/graphql/test/access.test.ts
@@ -1,6 +1,8 @@
 import {
+  AuditLogType,
   ElementType,
   ObjectAccess,
+  ObjectType,
   PermissionLevel,
   PrismaClient,
   PublicationStatus,
@@ -1819,6 +1821,21 @@ describe('Unit tests for object access validation', () => {
         catalogCollectionId: publicCatalog.id,
       },
       userOneCtx
+    )
+
+    // verify that a correct audit log entry has been created
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_MODIFIED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: userGroup.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.ADMIN} for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) through owner / admin ${userOne.id} for user group ${userGroup.id}.`
     )
 
     // verify that the access request for user 4 has been duplicated for users 2 and 3

--- a/packages/graphql/test/activitySharing.test.ts
+++ b/packages/graphql/test/activitySharing.test.ts
@@ -1,5 +1,7 @@
 import {
+  AuditLogType,
   ObjectAccess,
+  ObjectType,
   PermissionLevel,
   PrismaClient,
 } from '@klicker-uzh/prisma'
@@ -102,34 +104,39 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     })
 
     // verify that only users 1 and 4 have sufficient permissions to modify this assignment
-    const res1 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userOneCtx
-    )
+    const { sufficientPermissions: res1 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userOneCtx
+      )
     expect(res1).toBe(true)
 
-    const res2 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userTwoCtx
-    )
+    const { sufficientPermissions: res2 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userTwoCtx
+      )
     expect(res2).toBe(false)
 
-    const res3 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userThreeCtx
-    )
+    const { sufficientPermissions: res3 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userThreeCtx
+      )
     expect(res3).toBe(false)
 
-    const res4 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userFourCtx
-    )
+    const { sufficientPermissions: res4 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userFourCtx
+      )
     expect(res4).toBe(true)
 
-    const res5 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userFiveCtx
-    )
+    const { sufficientPermissions: res5 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userFiveCtx
+      )
     expect(res5).toBe(false)
   })
 
@@ -252,6 +259,33 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     expect(res2!.isRequested).toBe(false)
     expect(res2!.isShared).toBe(false)
 
+    // verify that a proper catalog assignment was created
+    const catalogAssignment1 =
+      await prisma.catalogCollectionAssignment.findUnique({
+        where: {
+          liveQuizId_catalogCollectionId: {
+            liveQuizId: activityId1,
+            catalogCollectionId: MISSING_CATALOG_COLLECTION_ID,
+          },
+        },
+      })
+    expect(catalogAssignment1).toBeTruthy()
+    expect(catalogAssignment1!.access).toEqual(ObjectAccess.PUBLIC)
+
+    // verify that an audit log entry was created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId1,
+        sourceUserId: userOne.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId1}) added to catalog collection (ID ${MISSING_CATALOG_COLLECTION_ID}) by user ${userOne.id}.`
+    )
+
     // verify that user 3 has sufficient permissions to add the second activity to the top-level catalog collection
     const res3 = await addObjectToCatalog(
       {
@@ -271,6 +305,33 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     expect(res3!.isManager).toBe(true)
     expect(res3!.isRequested).toBe(false)
     expect(res3!.isShared).toBe(true)
+
+    // verify that a proper catalog assignment was created
+    const catalogAssignment2 =
+      await prisma.catalogCollectionAssignment.findUnique({
+        where: {
+          liveQuizId_catalogCollectionId: {
+            liveQuizId: activityId2,
+            catalogCollectionId: MISSING_CATALOG_COLLECTION_ID,
+          },
+        },
+      })
+    expect(catalogAssignment2).toBeTruthy()
+    expect(catalogAssignment2!.access).toEqual(ObjectAccess.RESTRICTED)
+
+    // verify that an audit log entry was created
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId2,
+        sourceUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId2}) added to catalog collection (ID ${MISSING_CATALOG_COLLECTION_ID}) by user ${userThree.id}.`
+    )
 
     // verify that user 4 has sufficient permissions to add the second activity to the restricted catalog collection
     // -> >= WRITE permissions are required and satisfied
@@ -292,6 +353,33 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     expect(res5!.isManager).toBe(true)
     expect(res5!.isRequested).toBe(false)
     expect(res5!.isShared).toBe(true)
+
+    // verify that a proper catalog assignment was created
+    const catalogAssignment3 =
+      await prisma.catalogCollectionAssignment.findUnique({
+        where: {
+          liveQuizId_catalogCollectionId: {
+            liveQuizId: activityId2,
+            catalogCollectionId: restrictedCatalog.id,
+          },
+        },
+      })
+    expect(catalogAssignment3).toBeTruthy()
+    expect(catalogAssignment3!.access).toEqual(ObjectAccess.RESTRICTED)
+
+    // verify that an audit log entry was created
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId2,
+        sourceUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId2}) added to catalog collection (ID ${restrictedCatalog.id}) by user ${userFour.id}.`
+    )
   })
 
   it('Test that objects can be removed from the catalog collections with appropriate permissions', async () => {
@@ -416,6 +504,20 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       })
     expect(assignment1Removed).toBeNull()
 
+    // verify that an audit log entry was created for the removal of the object from the catalog collection
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_DELETED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId1,
+        sourceUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId1}) removed from catalog collection (ID ${MISSING_CATALOG_COLLECTION_ID}) by user ${userThree.id}.`
+    )
+
     // verify that user 1 can remove the second activity from the top-level catalog collection (OWNER)
     const res3 = await removeCatalogObjectAssignment(
       { assignmentId: assignment2.id },
@@ -431,6 +533,20 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       })
     expect(assignment2Removed).toBeNull()
 
+    // verify that an audit log entry was created for the removal of the object from the catalog collection
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_DELETED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId2,
+        sourceUserId: userOne.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId2}) removed from catalog collection (ID ${MISSING_CATALOG_COLLECTION_ID}) by user ${userOne.id}.`
+    )
+
     // verify that user 1 can remove the first activity from the restricted catalog collection (OWNER on both)
     const res4 = await removeCatalogObjectAssignment(
       { assignmentId: assignment4.id },
@@ -445,6 +561,20 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
         },
       })
     expect(assignment4Removed).toBeNull()
+
+    // verify that an audit log entry was created for the removal of the object from the catalog collection
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_DELETED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId1,
+        sourceUserId: userOne.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId1}) removed from catalog collection (ID ${restrictedCatalog.id}) by user ${userOne.id}.`
+    )
 
     // verify that user 4 cannot remove the second activity from the restricted catalog collection (ADMIN object permissions)
     const res5 = await removeCatalogObjectAssignment(
@@ -475,6 +605,20 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
         },
       })
     expect(assignment5Removed).toBeNull()
+
+    // verify that an audit log entry was created for the removal of the object from the catalog collection
+    const auditLogEntry4 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_DELETED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: activityId2,
+        sourceUserId: userFive.id,
+      },
+    })
+    expect(auditLogEntry4).toBeTruthy()
+    expect(auditLogEntry4!.message).toBe(
+      `${ObjectType.LIVE_QUIZ} (ID ${activityId2}) removed from catalog collection (ID ${restrictedCatalog.id}) by user ${userFive.id}.`
+    )
   })
   // #endregion
 

--- a/packages/graphql/test/catalogSharing.test.ts
+++ b/packages/graphql/test/catalogSharing.test.ts
@@ -1,5 +1,7 @@
 import {
+  AuditLogType,
   ObjectAccess,
+  ObjectType,
   PermissionLevel,
   PrismaClient,
 } from '@klicker-uzh/prisma'
@@ -357,34 +359,39 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     )
 
     // verify that users 1, 4, and 5 have sufficient permissions on the catalog collection, to make modifications to the assignment
-    const res1 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userOneCtx
-    )
+    const { sufficientPermissions: res1 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userOneCtx
+      )
     expect(res1).toBe(true)
 
-    const res2 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userTwoCtx
-    )
+    const { sufficientPermissions: res2 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userTwoCtx
+      )
     expect(res2).toBe(false)
 
-    const res3 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userThreeCtx
-    )
+    const { sufficientPermissions: res3 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userThreeCtx
+      )
     expect(res3).toBe(false)
 
-    const res4 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userFourCtx
-    )
+    const { sufficientPermissions: res4 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userFourCtx
+      )
     expect(res4).toBe(true)
 
-    const res5 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userFiveCtx
-    )
+    const { sufficientPermissions: res5 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userFiveCtx
+      )
     expect(res5).toBe(true)
   })
   // #endregion
@@ -615,11 +622,26 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     )
     expect(success).toBe(true)
 
+    // verify that the catalog collection access has been changed in the database
     const updatedCatalog = await prisma.catalogCollection.findUnique({
       where: { id: publicCatalog.id },
     })
     expect(updatedCatalog).toBeDefined()
     expect(updatedCatalog?.access).toBe(ObjectAccess.RESTRICTED)
+
+    // verify that an audit log entry has been created successfully
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_MODIFIED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry?.sourceUserId).toBe(userOne.id)
+    expect(auditLogEntry?.message).toBe(
+      `Catalog collection access level changed to ${ObjectAccess.RESTRICTED}`
+    )
   })
 
   it('Verify that the catalog collection name can be modified', async () => {
@@ -825,6 +847,35 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     })
     expect(adminAccessRequest).toBeDefined()
     expect(adminAccessRequest?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    // verify that the corresponding audit log entries have been created successfully
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CREATED,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        objectId: publicCatalog.id,
+        sourceUserId: userThree.id,
+        targetUserId: userOne.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1?.message).toBe(
+      `Access request (permission level ${PermissionLevel.WRITE}) created for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by user ${userThree.id} for owner / admin ${userOne.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CREATED,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        objectId: publicCatalog.id,
+        sourceUserId: userThree.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2?.message).toBe(
+      `Access request (permission level ${PermissionLevel.WRITE}) created for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by user ${userThree.id} for owner / admin ${userTwo.id}.`
+    )
 
     // verify that requesting access to the collection for user 3 again does fail (if the same permission level is used)
     const requestFail = await requestCatalogCollection(
@@ -1107,12 +1158,28 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     )
     expect(success1).toBe(true)
 
+    // verify that the access request has been removed from the database
     const dbRequest2 = await prisma.accessRequest.findUnique({
       where: {
         id: request1.id,
       },
     })
     expect(dbRequest2).toBeNull()
+
+    // verify that the audit log entry has been created successfully
+    const auditLogEntryDecline = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_RESOLVED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntryDecline).toBeTruthy()
+    expect(auditLogEntryDecline?.message).toBe(
+      `Access request declined for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} for user ${userThree.id}.`
+    )
 
     // approve the access request and verify the creation of a proper direct permission (and derived one)
     const success2 = await resolveObjectSharingRequest(
@@ -1127,6 +1194,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     )
     expect(success2).toBe(true)
 
+    // verify that the access request has been removed from the database
     const dbRequest3 = await prisma.accessRequest.findUnique({
       where: {
         id: request2.id,
@@ -1140,6 +1208,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     })
     expect(dbRequest4).toBeNull()
 
+    // verify that the direct and derived permission have been created correctly
     const directPermission = await prisma.permission.findUnique({
       where: {
         answerCollectionId_userId: {
@@ -1153,7 +1222,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(directPermission?.answerCollectionId).toBe(AC1!.id)
     expect(directPermission?.userId).toBe(userFour.id)
 
-    const derivedPermission = await prisma.permission.findUnique({
+    const derivedPermission = await prisma.derivedPermission.findUnique({
       where: {
         answerCollectionId_userId: {
           answerCollectionId: AC1!.id,
@@ -1165,6 +1234,21 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(derivedPermission?.permissionLevel).toBe(PermissionLevel.READ)
     expect(derivedPermission?.answerCollectionId).toBe(AC1!.id)
     expect(derivedPermission?.userId).toBe(userFour.id)
+
+    // verify that the audit log entry has been created successfully
+    const auditLogEntryApprove = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_RESOLVED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntryApprove).toBeTruthy()
+    expect(auditLogEntryApprove?.message).toBe(
+      `Access request approved (with permission level ${PermissionLevel.READ}) for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} for user ${userFour.id}.`
+    )
   })
 
   it('Make sure that objects in the catalog are queried correctly', async () => {
@@ -1291,6 +1375,21 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(updatedPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(updatedPermission?.catalogCollectionId).toBe(publicCatalog.id)
     expect(updatedPermission?.userId).toBe(userTwo.id)
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_MODIFIED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) through owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
   })
 
   it('Verify that direct permissions on the catalog collection can be revoked without conditions', async () => {
@@ -1345,6 +1444,21 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       },
     })
     expect(deletedPermission2).toBeNull()
+
+    // verify that an audit log entry has been created for this permission revocation
+    const audigLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_REVOKED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(audigLogEntry).toBeTruthy()
+    expect(audigLogEntry!.message).toBe(
+      `Permission revoked for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
   })
 
   it('Verify that direct permissions on the answer collection are loaded correctly', async () => {
@@ -1510,6 +1624,21 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     })
     expect(updatedCatalogCollection).toBeTruthy()
     expect(updatedCatalogCollection!.ownerId).toBe(userFour.id)
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.OWNER_TRANSFERRED,
+        objectId: restrictedCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Ownership of ${ObjectType.CATALOG_COLLECTION} (ID ${restrictedCatalog.id}) transferred from user ${userOne.id} to user ${userFour.id}.`
+    )
   })
 
   it('Verify that catalog collections can be directly shared with other users and user groups', async () => {
@@ -1618,6 +1747,49 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     })
     expect(derivedPermission1).toBeDefined()
     expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.READ)
+
+    // verify that the correct audit log entries have been created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.READ} granted for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} to user ${userTwo.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} to user ${userThree.id}.`
+    )
+
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} to user ${userFour.id}.`
+    )
 
     // TODO: as soon as user groups are available, extend the corresponding coverage of this unit test
   })
@@ -1799,6 +1971,20 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(updatedAssignment2?.access).toBe(ObjectAccess.PUBLIC)
     expect(updatedAssignment2?.answerCollectionId).toBe(AC1!.id)
     expect(updatedAssignment2?.catalogCollectionId).toBe(publicCatalog.id)
+
+    // verify that audit log entries have been created for these changes
+    const auditLog1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_MODIFIED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+      },
+    })
+    expect(auditLog1).toBeTruthy()
+    expect(auditLog1?.sourceUserId).toBe(userOne.id)
+    expect(auditLog1?.message).toBe(
+      `Catalog object assignment (ID ${updatedAssignment1!.id} for ${ObjectType.ANSWER_COLLECTION} with ID ${AC1!.id}) access level changed to ${ObjectAccess.RESTRICTED}`
+    )
   })
   // #endregion
 })

--- a/packages/graphql/test/resourceSharing.test.ts
+++ b/packages/graphql/test/resourceSharing.test.ts
@@ -1,6 +1,8 @@
 import {
+  AuditLogType,
   ElementType,
   ObjectAccess,
+  ObjectType,
   PermissionLevel,
   PrismaClient,
 } from '@klicker-uzh/prisma'
@@ -214,34 +216,39 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     })
 
     // verify that only users 1 and 4 have sufficient permissions to modify this assignment
-    const res1 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userOneCtx
-    )
+    const { sufficientPermissions: res1 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userOneCtx
+      )
     expect(res1).toBe(true)
 
-    const res2 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userTwoCtx
-    )
+    const { sufficientPermissions: res2 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userTwoCtx
+      )
     expect(res2).toBe(false)
 
-    const res3 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userThreeCtx
-    )
+    const { sufficientPermissions: res3 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userThreeCtx
+      )
     expect(res3).toBe(false)
 
-    const res4 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userFourCtx
-    )
+    const { sufficientPermissions: res4 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userFourCtx
+      )
     expect(res4).toBe(true)
 
-    const res5 = await verifyCatalogObjectEditPermissions(
-      { assignmentId: assignment.id },
-      userFiveCtx
-    )
+    const { sufficientPermissions: res5 } =
+      await verifyCatalogObjectEditPermissions(
+        { assignmentId: assignment.id },
+        userFiveCtx
+      )
     expect(res5).toBe(false)
   })
 
@@ -426,11 +433,13 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       {
         catalogCollectionId: publicCatalog.id,
         answerCollectionId: AC2!.id,
+        requestedPermissionLevel: PermissionLevel.WRITE,
       },
       userFiveCtx
     )
     expect(success2).toBeTruthy()
 
+    // verify that the access requests have been created correctly
     const pendingAccessRequest2 = await prisma.accessRequest.findMany({
       where: { userId: userFive.id },
     })
@@ -438,6 +447,63 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     expect(
       pendingAccessRequest2.map((permission) => permission.answerCollectionId)
     ).toEqual(expect.arrayContaining([AC1!.id, AC2!.id]))
+
+    // verify that proper audit log entries have been created for both access requests
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+        sourceUserId: userFive.id,
+        targetUserId: userOne.id, // owner
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Access request (permission level ${PermissionLevel.READ}) created for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by user ${userFive.id} for owner / admin ${userOne.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+        sourceUserId: userFive.id,
+        targetUserId: userTwo.id, // admin
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Access request (permission level ${PermissionLevel.READ}) created for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by user ${userFive.id} for owner / admin ${userTwo.id}.`
+    )
+
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC2!.id),
+        sourceUserId: userFive.id,
+        targetUserId: userOne.id, // owner
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `Access request (permission level ${PermissionLevel.WRITE}) created for ${ObjectType.ANSWER_COLLECTION} (ID ${AC2!.id}) by user ${userFive.id} for owner / admin ${userOne.id}.`
+    )
+
+    const auditLogEntry4 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC2!.id),
+        sourceUserId: userFive.id,
+        targetUserId: userTwo.id, // admin
+      },
+    })
+    expect(auditLogEntry4).toBeTruthy()
+    expect(auditLogEntry4!.message).toBe(
+      `Access request (permission level ${PermissionLevel.WRITE}) created for ${ObjectType.ANSWER_COLLECTION} (ID ${AC2!.id}) by user ${userFive.id} for owner / admin ${userTwo.id}.`
+    )
 
     // import public AC and verify that importing restricted AC does not work
     const failure3 = await importAnswerCollection(
@@ -535,6 +601,20 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       where: { id: request.id },
     })
     expect(cancelledRequest).toBeNull()
+
+    // verify that a corresponding audit log entry has been created
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.REQUEST_CANCELLED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+        sourceUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Access request cancelled for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by user ${userTwo.id}.`
+    )
   })
 
   it('Test that answer collections can be added to a catalog collection by users with sufficient permissions', async () => {
@@ -611,6 +691,33 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     expect(res2!.isRequested).toBe(false)
     expect(res2!.isShared).toBe(false)
 
+    // verify that a proper catalog assignment was created
+    const catalogAssignment2 =
+      await prisma.catalogCollectionAssignment.findUnique({
+        where: {
+          answerCollectionId_catalogCollectionId: {
+            answerCollectionId: AC1!.id,
+            catalogCollectionId: MISSING_CATALOG_COLLECTION_ID,
+          },
+        },
+      })
+    expect(catalogAssignment2).toBeTruthy()
+    expect(catalogAssignment2!.access).toEqual(ObjectAccess.PUBLIC)
+
+    // verify that an audit log entry was created
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+        sourceUserId: userOne.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) added to catalog collection (ID ${MISSING_CATALOG_COLLECTION_ID}) by user ${userOne.id}.`
+    )
+
     // verify that user 3 has sufficient permissions to add the second answer collection to the top-level catalog collection
     const res3 = await addObjectToCatalog(
       {
@@ -630,9 +737,36 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     expect(res3!.isRequested).toBe(false)
     expect(res3!.isShared).toBe(true)
 
+    // verify that a proper catalog assignment was created
+    const catalogAssignment3 =
+      await prisma.catalogCollectionAssignment.findUnique({
+        where: {
+          answerCollectionId_catalogCollectionId: {
+            answerCollectionId: AC2!.id,
+            catalogCollectionId: MISSING_CATALOG_COLLECTION_ID,
+          },
+        },
+      })
+    expect(catalogAssignment3).toBeTruthy()
+    expect(catalogAssignment3!.access).toEqual(ObjectAccess.RESTRICTED)
+
+    // verify that an audit log entry was created
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC2!.id),
+        sourceUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `${ObjectType.ANSWER_COLLECTION} (ID ${AC2!.id}) added to catalog collection (ID ${MISSING_CATALOG_COLLECTION_ID}) by user ${userThree.id}.`
+    )
+
     // verify that user 4 has sufficient permissions to add the second answer collection to the restricted catalog collection
     // -> >= WRITE permissions are required and satisfied
-    const res5 = await addObjectToCatalog(
+    const res4 = await addObjectToCatalog(
       {
         catalogCollectionId: restrictedCatalog.id,
         answerCollectionId: AC2!.id,
@@ -640,15 +774,42 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       },
       userFourCtx
     )
-    expect(res5).toBeTruthy()
-    expect(res5!.id).toEqual(AC2!.id)
-    expect(res5!.objectType).toEqual(CatalogObjectType.ANSWER_COLLECTION)
-    expect(res5!.access).toEqual(ObjectAccess.RESTRICTED)
-    expect(res5!.ownerShortname).toEqual(userOne.shortname)
-    expect(res5!.isOwner).toBe(false)
-    expect(res5!.isManager).toBe(true)
-    expect(res5!.isRequested).toBe(false)
-    expect(res5!.isShared).toBe(true)
+    expect(res4).toBeTruthy()
+    expect(res4!.id).toEqual(AC2!.id)
+    expect(res4!.objectType).toEqual(CatalogObjectType.ANSWER_COLLECTION)
+    expect(res4!.access).toEqual(ObjectAccess.RESTRICTED)
+    expect(res4!.ownerShortname).toEqual(userOne.shortname)
+    expect(res4!.isOwner).toBe(false)
+    expect(res4!.isManager).toBe(true)
+    expect(res4!.isRequested).toBe(false)
+    expect(res4!.isShared).toBe(true)
+
+    // verify that a proper catalog assignment was created
+    const catalogAssignment4 =
+      await prisma.catalogCollectionAssignment.findUnique({
+        where: {
+          answerCollectionId_catalogCollectionId: {
+            answerCollectionId: AC2!.id,
+            catalogCollectionId: restrictedCatalog.id,
+          },
+        },
+      })
+    expect(catalogAssignment4).toBeTruthy()
+    expect(catalogAssignment4!.access).toEqual(ObjectAccess.RESTRICTED)
+
+    // verify that an audit log entry was created
+    const auditLogEntry4 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.CATALOG_ASSIGNMENT_CREATED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC2!.id),
+        sourceUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry4).toBeTruthy()
+    expect(auditLogEntry4!.message).toBe(
+      `${ObjectType.ANSWER_COLLECTION} (ID ${AC2!.id}) added to catalog collection (ID ${restrictedCatalog.id}) by user ${userFour.id}.`
+    )
   })
 
   it('Verify that the correct information is extracted for public / restricted answer collections in the catalog', async () => {
@@ -785,10 +946,11 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         permissionLevel: PermissionLevel.WRITE,
         answerCollectionId: AC1!.id,
       },
-      userTwoCtx
+      userOneCtx
     )
     expect(success).toBe(true)
 
+    // verify that the direct and derived permissions have been updated correctly
     const permission2 = await prisma.permission.findUnique({
       where: {
         answerCollectionId_userId: {
@@ -810,6 +972,21 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     })
     expect(derivedPermission2).toBeDefined()
     expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_MODIFIED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+        sourceUserId: userOne.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) through owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
   })
 
   it('Verify that direct permissions to an answer collection can be revoked, but might be replaced with derived permissions', async () => {
@@ -850,6 +1027,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     )
     expect(deletedPermissionId1).toBe(permission1.id)
 
+    // verify that the direct permission has been deleted
     const dbPermission1 = await prisma.permission.findUnique({
       where: {
         answerCollectionId_userId: {
@@ -859,6 +1037,21 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       },
     })
     expect(dbPermission1).toBeNull()
+
+    // verify that an audit log entry has been created for this permission revocation
+    const audigLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_REVOKED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userFive.id,
+      },
+    })
+    expect(audigLogEntry).toBeTruthy()
+    expect(audigLogEntry!.message).toBe(
+      `Permission revoked for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} for user ${userFive.id}.`
+    )
 
     // create a new direct WRITE permission for user 5 on AC1
     const permission2 = await prisma.permission.upsert({
@@ -894,6 +1087,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     )
     expect(deletedPermissionId2).toBe(permission2.id)
 
+    // verify that the direct permission has been deleted
     const dbPermission2 = await prisma.permission.findUnique({
       where: {
         answerCollectionId_userId: {
@@ -1247,6 +1441,21 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     })
     expect(updatedAnswerCollection).toBeTruthy()
     expect(updatedAnswerCollection!.ownerId).toBe(userFour.id)
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.OWNER_TRANSFERRED,
+        objectType: ObjectType.ANSWER_COLLECTION,
+        objectId: String(AC1!.id),
+        sourceUserId: userOne.id,
+        targetUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Ownership of ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) transferred from user ${userOne.id} to user ${userFour.id}.`
+    )
   })
 
   it('Test the sharing functionality for answer collections with different permission levels', async () => {
@@ -1375,6 +1584,49 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     })
     expect(derivedPermission3).toBeTruthy()
     expect(derivedPermission3!.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct audit log entries have been created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.READ} granted for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} to user ${userTwo.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} to user ${userThree.id}.`
+    )
+
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} to user ${userFour.id}.`
+    )
   })
   // #endregion
 })

--- a/packages/graphql/test/resources.test.ts
+++ b/packages/graphql/test/resources.test.ts
@@ -1,6 +1,8 @@
 import {
+  AuditLogType,
   ElementType,
   ObjectAccess,
+  ObjectType,
   PermissionLevel,
   PrismaClient,
 } from '@klicker-uzh/prisma'
@@ -842,6 +844,20 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
       userTwoCtx
     )
     expect(removalId).toBe(AC1!.id)
+
+    // verify that an audit log entry has been created for the removal
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_REMOVED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `User ${userTwo.id} removed own permission on ${ObjectType.ANSWER_COLLECTION} (ID: ${AC1!.id})`
+    )
 
     // verify that the user has no derived access to the answer collection anymore
     const derivedPermission = await prisma.derivedPermission.findUnique({

--- a/packages/prisma/src/prisma/migrations/20250421195126_extended_audit_log_types/migration.sql
+++ b/packages/prisma/src/prisma/migrations/20250421195126_extended_audit_log_types/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - The values [PERMISSION_REQUESTED,PERMISSION_DENIED,PERMISSION_CONVERTED] on the enum `AuditLogType` will be removed. If these variants are still used in the database, this will fail.
+  - Made the column `ownerId` on table `AnswerCollection` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "AuditLogType_new" AS ENUM ('PERMISSION_GRANTED', 'PERMISSION_REVOKED', 'PERMISSION_REMOVED', 'PERMISSION_MODIFIED', 'OWNER_TRANSFERRED', 'REQUEST_CREATED', 'REQUEST_CANCELLED', 'REQUEST_RESOLVED', 'CATALOG_ASSIGNMENT_CREATED', 'CATALOG_ASSIGNMENT_DELETED', 'CATALOG_ASSIGNMENT_MODIFIED');
+ALTER TABLE "AuditLogEntry" ALTER COLUMN "type" TYPE "AuditLogType_new" USING ("type"::text::"AuditLogType_new");
+ALTER TYPE "AuditLogType" RENAME TO "AuditLogType_old";
+ALTER TYPE "AuditLogType_new" RENAME TO "AuditLogType";
+DROP TYPE "AuditLogType_old";
+COMMIT;
+
+-- DropForeignKey
+ALTER TABLE "AnswerCollection" DROP CONSTRAINT "AnswerCollection_ownerId_fkey";
+
+-- AlterTable
+ALTER TABLE "AnswerCollection" ALTER COLUMN "ownerId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "AnswerCollection" ADD CONSTRAINT "AnswerCollection_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/src/prisma/schema/resources.prisma
+++ b/packages/prisma/src/prisma/schema/resources.prisma
@@ -23,8 +23,8 @@ model AnswerCollection {
     permissions       DerivedPermission[]
     accessRequests    AccessRequest[]
 
-    owner   User?   @relation(fields: [ownerId], references: [id], onDelete: SetNull, onUpdate: SetNull)
-    ownerId String? @db.Uuid
+    owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+    ownerId String @db.Uuid
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt

--- a/packages/prisma/src/prisma/schema/sharing.prisma
+++ b/packages/prisma/src/prisma/schema/sharing.prisma
@@ -334,6 +334,7 @@ model CatalogCollection {
     // link to the join-table containing all associated objects
     objectAssignments CatalogCollectionAssignment[]
 
+    // owner connection needs to remain optional for the top-level catalog collection to work as expected
     owner   User?   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
     ownerId String? @db.Uuid
 
@@ -347,10 +348,16 @@ model CatalogCollection {
 // #region
 enum AuditLogType {
     PERMISSION_GRANTED // granted direct permission
-    PERMISSION_REVOKED // revoked direct permission
-    PERMISSION_REQUESTED // requested direct permission
-    PERMISSION_DENIED // denied direct permission
-    PERMISSION_CONVERTED // converted derived permission to direct permission (through re-use of a corresponding object)
+    PERMISSION_REVOKED // revoked direct permission (by owner / admin)
+    PERMISSION_REMOVED // removed direct permission (by user himself)
+    PERMISSION_MODIFIED // modified direct permission
+    OWNER_TRANSFERRED // ownership of an object was transferred
+    REQUEST_CREATED // created object access request
+    REQUEST_CANCELLED // cancelled object access request
+    REQUEST_RESOLVED // resolved object access request
+    CATALOG_ASSIGNMENT_CREATED // created catalog assignment
+    CATALOG_ASSIGNMENT_DELETED // deleted catalog assignment
+    CATALOG_ASSIGNMENT_MODIFIED // created catalog collection
 }
 
 enum ObjectType {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Comprehensive audit logging added for all permission and sharing changes, including permission modifications, ownership transfers, access requests, and catalog assignments.
  - Audit log entries now provide detailed descriptions and metadata for each action.

- **Bug Fixes**
  - Soft-deleted answer collections and live quizzes are now excluded from catalog object queries.

- **Refactor**
  - Improved permission verification and cache invalidation logic for sharing operations.

- **Tests**
  - Enhanced test coverage to verify audit log creation and correct catalog assignment behavior after sharing-related actions.

- **Chores**
  - Database schema updated to require non-null owners for answer collections and to expand audit log event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->