### PR TITLE
fix(packages/graphql): refine logic for access request removal to be limited to cases where users do not retain ADMIN object access through other paths

### DIFF
--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -2103,125 +2103,61 @@ export async function changeObjectPermissionLevel(
       },
     })
 
-    // if the permission exists, trigger recomputation of derived permissions
-    if (updatedPermission) {
-      const affectedUserIds = updatedPermission.userId
-        ? [updatedPermission.userId]
-        : userGroup
-          ? userGroup.members.flatMap((member) =>
-              member.id ? [member.id] : []
-            )
-          : []
-
-      for (const affectedUserId of affectedUserIds) {
-        if (typeof catalogCollectionId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { catalogCollectionId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof answerCollectionId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { answerCollectionId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof elementId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { elementId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof courseId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { courseId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof liveQuizId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { liveQuizId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof practiceQuizId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { practiceQuizId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof microLearningId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { microLearningId, userId: affectedUserId },
-            prisma
-          )
-        } else if (typeof groupActivityId !== 'undefined') {
-          await recomputeDerivedPermissions(
-            { groupActivityId, userId: affectedUserId },
-            prisma
-          )
-        }
-      }
+    // if the permission does not exist, return early
+    if (!updatedPermission) {
+      return false
     }
 
-    // fetch the user ids of all admin users of the object (after the permission level modification)
-    const adminOwnerPermissions = await prisma.derivedPermission.findMany({
-      where: {
-        permissionLevel: {
-          in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
-        },
-        catalogCollectionId,
-        answerCollectionId,
-        elementId,
-        courseId,
-        liveQuizId,
-        practiceQuizId,
-        microLearningId,
-        groupActivityId,
-      },
-      select: { userId: true },
-    })
-    const adminOwnerIds = adminOwnerPermissions.map(
-      (permission) => permission.userId
-    )
+    // if the permission exists, trigger recomputation of derived permissions, potentially update the access requests and log the change
+    const affectedUserIds = updatedPermission.userId
+      ? [updatedPermission.userId]
+      : userGroup
+        ? userGroup.members.flatMap((member) => (member.id ? [member.id] : []))
+        : []
 
-    if (updatedPermission.userId) {
-      // if ADMIN permissions were granted, make sure the user also gets access request instances assigned
-      if (
-        previousPermission.permissionLevel !== DB.PermissionLevel.ADMIN &&
-        permissionLevel === DB.PermissionLevel.ADMIN
-      ) {
-        await createAccessRequestInstancesNewAdmin(
-          {
-            newAdminId: updatedPermission.userId,
-            existingAdminOwnerId: ctx.user.sub,
-            catalogCollectionId,
-            answerCollectionId,
-            elementId,
-            courseId,
-            liveQuizId,
-            practiceQuizId,
-            microLearningId,
-            groupActivityId,
-          },
+    for (const affectedUserId of affectedUserIds) {
+      if (typeof catalogCollectionId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { catalogCollectionId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof answerCollectionId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { answerCollectionId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof elementId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { elementId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof courseId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { courseId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof liveQuizId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { liveQuizId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof practiceQuizId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { practiceQuizId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof microLearningId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { microLearningId, userId: affectedUserId },
+          prisma
+        )
+      } else if (typeof groupActivityId !== 'undefined') {
+        await recomputeDerivedPermissions(
+          { groupActivityId, userId: affectedUserId },
           prisma
         )
       }
-      // if ADMIN permissions were revoked, make sure that the user does not have any access request instances assigned anymore
-      else if (
-        previousPermission.permissionLevel === DB.PermissionLevel.ADMIN &&
-        permissionLevel !== DB.PermissionLevel.ADMIN &&
-        !adminOwnerIds.includes(updatedPermission.userId) // user might retain ADMIN / OWNER rights through different direct permission
-      ) {
-        await prisma.accessRequest.deleteMany({
-          where: {
-            objectAdminOrOwnerId: updatedPermission.userId,
-            catalogCollectionId,
-            answerCollectionId,
-            elementId,
-            courseId,
-            liveQuizId,
-            practiceQuizId,
-            microLearningId,
-            groupActivityId,
-          },
-        })
-      }
-    } else if (userGroup) {
+
       // if ADMIN permissions were granted, make sure all group members also get access request instances assigned
       if (
         previousPermission.permissionLevel !== DB.PermissionLevel.ADMIN &&
@@ -2229,10 +2165,10 @@ export async function changeObjectPermissionLevel(
       ) {
         // create access request instances for all members of the user group
         await Promise.all(
-          userGroup.members.map(async (member) => {
+          affectedUserIds.map(async (userId) => {
             await createAccessRequestInstancesNewAdmin(
               {
-                newAdminId: member.id,
+                newAdminId: userId,
                 existingAdminOwnerId: ctx.user.sub,
                 catalogCollectionId,
                 answerCollectionId,
@@ -2254,12 +2190,36 @@ export async function changeObjectPermissionLevel(
         previousPermission.permissionLevel === DB.PermissionLevel.ADMIN &&
         permissionLevel !== DB.PermissionLevel.ADMIN
       ) {
+        // fetch the user ids of all admin users of the object (after the permission level modification)
+        const adminOwnerPermissions = await prisma.derivedPermission.findMany({
+          where: {
+            permissionLevel: {
+              in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
+            },
+            catalogCollectionId,
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
+          },
+          select: { userId: true },
+        })
+        const adminOwnerIds = adminOwnerPermissions.map(
+          (permission) => permission.userId
+        )
+
+        // identify users with revoked ADMIN permissions
+        const usersRevokedAdminPermissions = affectedUserIds.filter(
+          (userId) => !adminOwnerIds.includes(userId)
+        )
+
         await prisma.accessRequest.deleteMany({
           where: {
             objectAdminOrOwnerId: {
-              in: userGroup.members
-                .map((member) => member.id)
-                .filter((memberId) => !adminOwnerIds.includes(memberId)), // user might retain ADMIN / OWNER rights through different direct permission
+              in: usersRevokedAdminPermissions, // user might retain ADMIN / OWNER rights through different direct permission
             },
             catalogCollectionId,
             answerCollectionId,

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -2158,6 +2158,27 @@ export async function changeObjectPermissionLevel(
       }
     }
 
+    // fetch the user ids of all admin users of the object (after the permission level modification)
+    const adminOwnerPermissions = await prisma.derivedPermission.findMany({
+      where: {
+        permissionLevel: {
+          in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
+        },
+        catalogCollectionId,
+        answerCollectionId,
+        elementId,
+        courseId,
+        liveQuizId,
+        practiceQuizId,
+        microLearningId,
+        groupActivityId,
+      },
+      select: { userId: true },
+    })
+    const adminOwnerIds = adminOwnerPermissions.map(
+      (permission) => permission.userId
+    )
+
     if (updatedPermission.userId) {
       // if ADMIN permissions were granted, make sure the user also gets access request instances assigned
       if (
@@ -2183,7 +2204,8 @@ export async function changeObjectPermissionLevel(
       // if ADMIN permissions were revoked, make sure that the user does not have any access request instances assigned anymore
       else if (
         previousPermission.permissionLevel === DB.PermissionLevel.ADMIN &&
-        permissionLevel !== DB.PermissionLevel.ADMIN
+        permissionLevel !== DB.PermissionLevel.ADMIN &&
+        !adminOwnerIds.includes(updatedPermission.userId) // user might retain ADMIN / OWNER rights through different direct permission
       ) {
         await prisma.accessRequest.deleteMany({
           where: {
@@ -2235,7 +2257,9 @@ export async function changeObjectPermissionLevel(
         await prisma.accessRequest.deleteMany({
           where: {
             objectAdminOrOwnerId: {
-              in: userGroup.members.map((member) => member.id),
+              in: userGroup.members
+                .map((member) => member.id)
+                .filter((memberId) => !adminOwnerIds.includes(memberId)), // user might retain ADMIN / OWNER rights through different direct permission
             },
             catalogCollectionId,
             answerCollectionId,
@@ -2418,21 +2442,6 @@ export async function revokeObjectAccess(
         : []
 
     for (const affectedUserId of affectedUserIds) {
-      // if the new revoked permission level had ADMIN level, remove any access requests linked to this user (group) as an object owner or admin
-      await prisma.accessRequest.deleteMany({
-        where: {
-          objectAdminOrOwnerId: affectedUserId,
-          catalogCollectionId,
-          answerCollectionId,
-          elementId,
-          courseId,
-          liveQuizId,
-          practiceQuizId,
-          microLearningId,
-          groupActivityId,
-        },
-      })
-
       // update the derived permissions of all affected users
       if (typeof catalogCollectionId !== 'undefined') {
         await recomputeDerivedPermissions(
@@ -2475,6 +2484,52 @@ export async function revokeObjectAccess(
           prisma
         )
       }
+    }
+
+    // if the revoked permission was at ADMIN level, remove any access requests linked to ADMINS using this permission
+    if (permission.permissionLevel === DB.PermissionLevel.ADMIN) {
+      // fetch the user ids of all admin users of the object (after the permission level modification)
+      const adminOwnerPermissions = await prisma.derivedPermission.findMany({
+        where: {
+          permissionLevel: {
+            in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
+          },
+          catalogCollectionId,
+          answerCollectionId,
+          elementId,
+          courseId,
+          liveQuizId,
+          practiceQuizId,
+          microLearningId,
+          groupActivityId,
+        },
+        select: { userId: true },
+      })
+      const adminOwnerIds = adminOwnerPermissions.map(
+        (permission) => permission.userId
+      )
+
+      // identify users with revoked ADMIN permissions
+      const usersRevokedAdminPermissions = affectedUserIds.filter(
+        (userId) => !adminOwnerIds.includes(userId)
+      )
+
+      // remove any access requests linked to users that lost their ADMIN access to the object
+      await prisma.accessRequest.deleteMany({
+        where: {
+          objectAdminOrOwnerId: {
+            in: usersRevokedAdminPermissions,
+          },
+          catalogCollectionId,
+          answerCollectionId,
+          elementId,
+          courseId,
+          liveQuizId,
+          practiceQuizId,
+          microLearningId,
+          groupActivityId,
+        },
+      })
     }
 
     return deleted

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -2216,21 +2216,23 @@ export async function changeObjectPermissionLevel(
           (userId) => !adminOwnerIds.includes(userId)
         )
 
-        await prisma.accessRequest.deleteMany({
-          where: {
-            objectAdminOrOwnerId: {
-              in: usersRevokedAdminPermissions, // user might retain ADMIN / OWNER rights through different direct permission
+        if (usersRevokedAdminPermissions.length > 0) {
+          await prisma.accessRequest.deleteMany({
+            where: {
+              objectAdminOrOwnerId: {
+                in: usersRevokedAdminPermissions, // user might retain ADMIN / OWNER rights through different direct permission
+              },
+              catalogCollectionId,
+              answerCollectionId,
+              elementId,
+              courseId,
+              liveQuizId,
+              practiceQuizId,
+              microLearningId,
+              groupActivityId,
             },
-            catalogCollectionId,
-            answerCollectionId,
-            elementId,
-            courseId,
-            liveQuizId,
-            practiceQuizId,
-            microLearningId,
-            groupActivityId,
-          },
-        })
+          })
+        }
       }
     }
 
@@ -2475,21 +2477,23 @@ export async function revokeObjectAccess(
       )
 
       // remove any access requests linked to users that lost their ADMIN access to the object
-      await prisma.accessRequest.deleteMany({
-        where: {
-          objectAdminOrOwnerId: {
-            in: usersRevokedAdminPermissions,
+      if (usersRevokedAdminPermissions.length > 0) {
+        await prisma.accessRequest.deleteMany({
+          where: {
+            objectAdminOrOwnerId: {
+              in: usersRevokedAdminPermissions,
+            },
+            catalogCollectionId,
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
           },
-          catalogCollectionId,
-          answerCollectionId,
-          elementId,
-          courseId,
-          liveQuizId,
-          practiceQuizId,
-          microLearningId,
-          groupActivityId,
-        },
-      })
+        })
+      }
     }
 
     return deleted

--- a/packages/graphql/test/access.test.ts
+++ b/packages/graphql/test/access.test.ts
@@ -2223,7 +2223,7 @@ describe('Unit tests for object access validation', () => {
     expect(catalogRequest5Removed2).toBeNull()
   })
 
-  it('Test that reduction the level of existing mixed permissions from ADMIN level results in a removal of all pending access requests for users without other access', async () => {
+  it('Test that reducing the level of existing mixed permissions from ADMIN level results in the removal of pending access requests for users without other access', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
 
     // grant individual ADMIN access to users 2, 4, and 5

--- a/packages/graphql/test/access.test.ts
+++ b/packages/graphql/test/access.test.ts
@@ -31,7 +31,14 @@ import {
   testCleanup,
   testInitialization,
 } from './helpers.js'
-import { userFive, userFour, userOne, userThree, userTwo } from './userData.js'
+import {
+  userFive,
+  userFour,
+  userOne,
+  userSix,
+  userThree,
+  userTwo,
+} from './userData.js'
 
 describe('Unit tests for object access validation', () => {
   // shared resources used across tests
@@ -42,6 +49,7 @@ describe('Unit tests for object access validation', () => {
   let userThreeCtx: ContextWithUser
   let userFourCtx: ContextWithUser
   let userFiveCtx: ContextWithUser
+  let userSixCtx: ContextWithUser
 
   beforeAll(async () => {
     const { prisma: newPrisma, emitter: newEmitter } = await initializePrisma()
@@ -61,6 +69,7 @@ describe('Unit tests for object access validation', () => {
       userThreeCtx: ctx3,
       userFourCtx: ctx4,
       userFiveCtx: ctx5,
+      userSixCtx: ctx6,
     } = await testInitialization(prisma, emitter)
 
     userOneCtx = ctx1
@@ -68,6 +77,7 @@ describe('Unit tests for object access validation', () => {
     userThreeCtx = ctx3
     userFourCtx = ctx4
     userFiveCtx = ctx5
+    userSixCtx = ctx6
   })
 
   afterEach(async () => {
@@ -2213,6 +2223,187 @@ describe('Unit tests for object access validation', () => {
     expect(catalogRequest5Removed2).toBeNull()
   })
 
+  it('Test that reduction the level of existing mixed permissions from ADMIN level results in a removal of all pending access requests for users without other access', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+
+    // grant individual ADMIN access to users 2, 4, and 5
+    const permission2 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userTwo.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const permission4 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userFour.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const permission5 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userFive.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // create a user group with users 3 and 4 and a single participant group for user 5
+    const userGroup1 = await prisma.userGroup.create({
+      data: {
+        name: 'Test User Group 1',
+        members: {
+          connect: [{ id: userThree.id }, { id: userFour.id }],
+        },
+        ownerId: userOne.id,
+      },
+    })
+    const userGroup2 = await prisma.userGroup.create({
+      data: {
+        name: 'Test User Group 2',
+        members: {
+          connect: [{ id: userFive.id }],
+        },
+        ownerId: userOne.id,
+      },
+    })
+
+    // grant group ADMIN permissions to the user groups
+    const groupPermission1 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userGroupId: userGroup1.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const groupPermission2 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userGroupId: userGroup2.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+
+    // create an access request for user 6 with instances for all ADMINS
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userTwo.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+      ],
+    })
+    const accessRequestCount1 = await prisma.accessRequest.count()
+    expect(accessRequestCount1).toBe(4)
+
+    // lower the individual permission of user 2 -> access request for user 2 should be removed
+    await changeObjectPermissionLevel(
+      {
+        permissionId: permission2.id,
+        permissionLevel: PermissionLevel.WRITE,
+        catalogCollectionId: publicCatalog.id,
+      },
+      userOneCtx
+    )
+    const accessRequestCount2 = await prisma.accessRequest.count()
+    expect(accessRequestCount2).toBe(3)
+
+    const removedAccessRequest2 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userTwo.id,
+        },
+      },
+    })
+    expect(removedAccessRequest2).toBeNull()
+
+    // lower the group permission of user group 1 (users 3 and 4)
+    // access request for user 3 should be removed, but not for user 4 (retains individual ADMIN access)
+    await changeObjectPermissionLevel(
+      {
+        permissionId: groupPermission1.id,
+        permissionLevel: PermissionLevel.WRITE,
+        catalogCollectionId: publicCatalog.id,
+      },
+      userOneCtx
+    )
+    const accessRequestCount3 = await prisma.accessRequest.count()
+    expect(accessRequestCount3).toBe(2)
+    const removedAccessRequest3 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(removedAccessRequest3).toBeNull()
+
+    const retainedAccessRequest4 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(retainedAccessRequest4).toBeTruthy()
+    expect(retainedAccessRequest4!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    // lower the individual permission for user 5 -> access request for user 5 should persist (group ADMIN access)
+    await changeObjectPermissionLevel(
+      {
+        permissionId: permission5.id,
+        permissionLevel: PermissionLevel.WRITE,
+        catalogCollectionId: publicCatalog.id,
+      },
+      userOneCtx
+    )
+    const accessRequestCount4 = await prisma.accessRequest.count()
+    expect(accessRequestCount4).toBe(2)
+
+    const retainedAccessRequest5 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(retainedAccessRequest5).toBeTruthy()
+    expect(retainedAccessRequest5!.permissionLevel).toBe(PermissionLevel.WRITE)
+  })
+
   it('Verify that on revocation of individual ADMIN object permissions, access request instances are removed for the previous ADMIN', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
     const [AC1] = await seedAnswerCollections(userOneCtx)
@@ -2566,6 +2757,184 @@ describe('Unit tests for object access validation', () => {
       },
     })
     expect(catalogRequest5Removed2).toBeNull()
+  })
+
+  it('Verify that on revocation of mixed ADMIN object permissions, access request instances are removed only for users without other access', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+
+    // grant individual ADMIN access to users 2, 4, and 5
+    const permission2 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userTwo.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const permission4 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userFour.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const permission5 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userFive.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // create a user group with users 3 and 4 and a single participant group for user 5
+    const userGroup1 = await prisma.userGroup.create({
+      data: {
+        name: 'Test User Group 1',
+        members: {
+          connect: [{ id: userThree.id }, { id: userFour.id }],
+        },
+        ownerId: userOne.id,
+      },
+    })
+    const userGroup2 = await prisma.userGroup.create({
+      data: {
+        name: 'Test User Group 2',
+        members: {
+          connect: [{ id: userFive.id }],
+        },
+        ownerId: userOne.id,
+      },
+    })
+
+    // grant group ADMIN permissions to the user groups
+    const groupPermission1 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userGroupId: userGroup1.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const groupPermission2 = await prisma.permission.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userGroupId: userGroup2.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+
+    // create an access request for user 6 with instances for all ADMINS
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userTwo.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+      ],
+    })
+    const accessRequestCount1 = await prisma.accessRequest.count()
+    expect(accessRequestCount1).toBe(4)
+
+    // revoke the individual permission of user 2 -> access request for user 2 should be removed
+    await revokeObjectAccess(
+      {
+        permissionId: permission2.id,
+        catalogCollectionId: publicCatalog.id,
+      },
+      userOneCtx
+    )
+    const accessRequestCount2 = await prisma.accessRequest.count()
+    expect(accessRequestCount2).toBe(3)
+
+    const removedAccessRequest2 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userTwo.id,
+        },
+      },
+    })
+    expect(removedAccessRequest2).toBeNull()
+
+    // revoke the group permission of user group 1 (users 3 and 4)
+    // access request for user 3 should be removed, but not for user 4 (retains individual ADMIN access)
+    await revokeObjectAccess(
+      {
+        permissionId: groupPermission1.id,
+        catalogCollectionId: publicCatalog.id,
+      },
+      userOneCtx
+    )
+    const accessRequestCount3 = await prisma.accessRequest.count()
+    expect(accessRequestCount3).toBe(2)
+    const removedAccessRequest3 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(removedAccessRequest3).toBeNull()
+
+    const retainedAccessRequest4 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(retainedAccessRequest4).toBeTruthy()
+    expect(retainedAccessRequest4!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    // revoke the individual permission for user 5 -> access request for user 5 should persist (group ADMIN access)
+    await revokeObjectAccess(
+      {
+        permissionId: permission5.id,
+        catalogCollectionId: publicCatalog.id,
+      },
+      userOneCtx
+    )
+    const accessRequestCount4 = await prisma.accessRequest.count()
+    expect(accessRequestCount4).toBe(2)
+
+    const retainedAccessRequest5 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userSix.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(retainedAccessRequest5).toBeTruthy()
+    expect(retainedAccessRequest5!.permissionLevel).toBe(PermissionLevel.WRITE)
   })
 
   it('Verify that any pending access requests are also assigned to new owner on catalog collection ownership transfer', async () => {

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -22,14 +22,21 @@ import {
   catalogCollection1,
   catalogCollection2,
 } from './testData.js'
-import { userFive, userFour, userOne, userThree, userTwo } from './userData.js'
+import {
+  userFive,
+  userFour,
+  userOne,
+  userSix,
+  userThree,
+  userTwo,
+} from './userData.js'
 
 // ! General Test Suite Helpers (general setup, user seeding, database connections, cleanup, etc.)
 // #region
 export async function testInitialization(prisma: PrismaClient, emitter) {
   // upsert all users in the database
   await Promise.all(
-    [userOne, userTwo, userThree, userFour, userFive].map(
+    [userOne, userTwo, userThree, userFour, userFive, userSix].map(
       async (user) =>
         await prisma.user.upsert({
           where: { id: user.id },
@@ -45,7 +52,7 @@ export async function testInitialization(prisma: PrismaClient, emitter) {
 
   // verify that users have been created correctly in the database
   const dbUsers = await prisma.user.findMany()
-  expect(dbUsers).toHaveLength(5)
+  expect(dbUsers).toHaveLength(6)
   const actualEmails = dbUsers.map((user) => user.email)
   expect(actualEmails).toEqual(
     expect.arrayContaining([
@@ -54,9 +61,10 @@ export async function testInitialization(prisma: PrismaClient, emitter) {
       userThree.email,
       userFour.email,
       userFive.email,
+      userSix.email,
     ])
   )
-  expect(actualEmails).toHaveLength(5)
+  expect(actualEmails).toHaveLength(6)
 
   // seed the top-level catalog collection with fixed ID
   await prisma.catalogCollection.upsert({
@@ -103,6 +111,10 @@ export async function testInitialization(prisma: PrismaClient, emitter) {
     ...userOneCtx,
     user: { ...userOneCtx.user, sub: userFive.sub },
   }
+  const userSixCtx = {
+    ...userOneCtx,
+    user: { ...userOneCtx.user, sub: userSix.sub },
+  }
 
   return {
     userOneCtx,
@@ -110,6 +122,7 @@ export async function testInitialization(prisma: PrismaClient, emitter) {
     userThreeCtx,
     userFourCtx,
     userFiveCtx,
+    userSixCtx,
   }
 }
 

--- a/packages/graphql/test/userData.ts
+++ b/packages/graphql/test/userData.ts
@@ -37,3 +37,11 @@ export const userFive = {
   email: 'fifth@example.com',
   shortname: 'fifthuser',
 }
+
+// mock user 6
+export const userSix = {
+  id: '8ee6a86a-9ef6-4b8a-b7aa-9893111ea9be',
+  sub: '8ee6a86a-9ef6-4b8a-b7aa-9893111ea9be',
+  email: 'sixth@example.com',
+  shortname: 'sixthuser',
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of access requests so they are only removed for users who fully lose ADMIN or OWNER permissions, ensuring access is retained if users still have such rights via other permissions.

- **Tests**
  - Added comprehensive tests to verify correct behavior of access requests when ADMIN permissions are reduced or revoked, especially in scenarios involving both individual and group permissions.
  - Expanded test data and setup to include an additional mock user for more robust coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->