### PR TITLE
chore(packages/graphql): add unit test coverage for user group manipulation functionalities

### DIFF
--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -4516,7 +4516,6 @@ export async function getUserGroupsUser(ctx: ContextWithUser) {
   ]
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function leaveUserGroup(
   { groupId }: { groupId: number },
@@ -4568,7 +4567,6 @@ export async function leaveUserGroup(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function deleteUserGroup(
   { groupId }: { groupId: number },
@@ -4639,7 +4637,6 @@ export async function deleteUserGroup(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function promoteGroupMemberToAdmin(
   { groupId, memberId }: { groupId: number; memberId: string },
@@ -4674,7 +4671,6 @@ export async function promoteGroupMemberToAdmin(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function demoteGroupAdminToMember(
   { groupId, adminId }: { groupId: number; adminId: string },
@@ -4709,7 +4705,6 @@ export async function demoteGroupAdminToMember(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function removeUserFromGroup(
   { groupId, userId }: { groupId: number; userId: string },
@@ -4764,7 +4759,6 @@ export async function removeUserFromGroup(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function changeUserGroupName(
   { id, name }: { id: number; name: string },
@@ -4794,7 +4788,6 @@ export async function changeUserGroupName(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function transferGroupOwnership(
   { id, newOwnerId }: { id: number; newOwnerId: string },
@@ -4831,7 +4824,6 @@ export async function transferGroupOwnership(
   return true
 }
 
-// TODO: add unit testing for this function
 // TODO: add audit log entries
 export async function addUserToUserGroup(
   {
@@ -4877,13 +4869,22 @@ export async function addUserToUserGroup(
   }
 
   // add the user to the group
-  await ctx.prisma.userGroup.update({
+  const updatedUserGroup = await ctx.prisma.userGroup.update({
     where: { id: groupId },
     data: {
       members: !asAdmin ? { connect: { id: userId } } : undefined,
       admins: asAdmin ? { connect: { id: userId } } : undefined,
     },
+    include: {
+      permissions: true,
+    },
   })
+
+  // recompute all permissions for the newly added user for objects shared with the group
+  await recomputePermissionsUserGroupMember(
+    { permissions: updatedUserGroup.permissions, userId },
+    ctx.prisma
+  )
 
   return {
     id: user.id,

--- a/packages/graphql/test/userGroups.test.ts
+++ b/packages/graphql/test/userGroups.test.ts
@@ -1,8 +1,24 @@
-import { PrismaClient } from '@klicker-uzh/prisma'
+import { ElementType, PermissionLevel, PrismaClient } from '@klicker-uzh/prisma'
+import { recomputeDerivedPermissions } from '@klicker-uzh/util'
 import { EventEmitter } from 'events'
 import type { ContextWithUser } from '../src/lib/context.js'
-import { createUserGroup } from '../src/services/sharing.js'
-import { initializePrisma, testCleanup, testInitialization } from './helpers.js'
+import {
+  addUserToUserGroup,
+  changeUserGroupName,
+  createUserGroup,
+  deleteUserGroup,
+  demoteGroupAdminToMember,
+  leaveUserGroup,
+  promoteGroupMemberToAdmin,
+  removeUserFromGroup,
+  transferGroupOwnership,
+} from '../src/services/sharing.js'
+import {
+  initializePrisma,
+  seedAnswerCollections,
+  testCleanup,
+  testInitialization,
+} from './helpers.js'
 import { userFour, userOne, userThree, userTwo } from './userData.js'
 
 describe('Unit tests for user group management', () => {
@@ -74,7 +90,7 @@ describe('Unit tests for user group management', () => {
       expect(memberIds).toContain(userThree.id)
     })
 
-    test('Providing members and admins should result in a successful group creation and correct links', async () => {
+    it('Providing members and admins should result in a successful group creation and correct links', async () => {
       // create a group with one regular member and two admins
       const groupName = 'Mixed Group'
       const result = await createUserGroup(
@@ -104,7 +120,7 @@ describe('Unit tests for user group management', () => {
       expect(adminIds).toContain(userFour.id)
     })
 
-    test('Test that the creation of a ', async () => {
+    it('Test that the creation of a user group with duplicated name fails', async () => {
       // create a valid user group
       const groupName = 'Duplicate Group'
       await createUserGroup(
@@ -127,7 +143,7 @@ describe('Unit tests for user group management', () => {
       ).rejects.toThrow('User group with this name already exists')
     })
 
-    test('User group creation should fail if no valid members were found', async () => {
+    it('User group creation should fail if no valid members were found', async () => {
       await expect(
         createUserGroup(
           {
@@ -139,7 +155,7 @@ describe('Unit tests for user group management', () => {
       ).rejects.toThrow('No members found')
     })
 
-    test('User group creation should success if at least one valid member was provided, other users should be ignored', async () => {
+    it('User group creation should success if at least one valid member was provided, other users should be ignored', async () => {
       // create a group with one valid member and one invalid member
       const groupName = 'Partial Group'
       const result = await createUserGroup(
@@ -160,7 +176,7 @@ describe('Unit tests for user group management', () => {
       expect(result.members[0]!.id).toBe(userTwo.id)
     })
 
-    test('Duplicate members and the owner should be filtered from the member / admin lists', async () => {
+    it('Duplicate members and the owner should be filtered from the member / admin lists', async () => {
       // create a group where one of the members is the owner and other members are included twice
       const groupName = 'Owner Included Group'
       const result = await createUserGroup(
@@ -187,6 +203,1646 @@ describe('Unit tests for user group management', () => {
       // owner should not appear in members list
       const memberIds = result.members.map((member) => member.id)
       expect(memberIds).not.toContain(userOneCtx.user.sub)
+    })
+
+    it('Members of the group should be able to leave the group successfully', async () => {
+      // create a group with a regular member
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // have a member leave the group
+      const result = await leaveUserGroup({ groupId: group.id }, userTwoCtx)
+      expect(result).toBe(true)
+
+      // verify the user is no longer in the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(0)
+    })
+
+    it('Admins of the group should be able to leave the group successfully', async () => {
+      // create a group with an admin member
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Test Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // have a member leave the group
+      const result = await leaveUserGroup({ groupId: group.id }, userTwoCtx)
+      expect(result).toBe(true)
+
+      // verify the user is no longer in the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup?.admins.length).toBe(0)
+    })
+
+    it('Users that are not part of the group should not be able to trigger the leave group mutation', async () => {
+      // Create a group with one member
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // user three tries to leave the group -> should be handled gracefully
+      const result = await leaveUserGroup({ groupId: group.id }, userThreeCtx)
+      expect(result).toBe(false)
+    })
+
+    it('Trying to leave a group that does not exist should fail gracefully', async () => {
+      const result = await leaveUserGroup(
+        { groupId: 99999 }, // Non-existent group ID
+        userTwoCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Owners should not be able to leave user groups using the leave function (can only delete them)', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Owner Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // try to trigger the leaveUserGroup function as owner
+      const result = await leaveUserGroup({ groupId: group.id }, userOneCtx)
+      expect(result).toBe(false)
+
+      // verify the group still exists with the owner
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroup).toBeDefined()
+      expect(updatedGroup?.ownerId).toBe(userOne.id)
+    })
+
+    it('Verify that permissions granted to the user group are no longer applied to users that left the group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Permission Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // create an answer collection and grant permissions to the group
+      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          answerCollectionId: AC1!.id,
+        },
+      })
+      await recomputeDerivedPermissions({ answerCollectionId: AC1!.id }, prisma)
+
+      // create an element using the second answer collection and grant permissions to the group
+      const element = await prisma.element.create({
+        data: {
+          type: ElementType.SELECTION,
+          name: 'Element',
+          content: 'Content',
+          options: {},
+          ownerId: userOne.id,
+          answerCollectionId: AC2!.id,
+        },
+      })
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          elementId: element.id,
+        },
+      })
+      await recomputeDerivedPermissions({ elementId: element.id }, prisma)
+
+      // verify that derived permissions on AC1 were created for both users
+      const derivedPermission1 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission1).toBeTruthy()
+      expect(derivedPermission1!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission1!.derived).toBe(false)
+
+      const derivedPermission2 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(derivedPermission2).toBeTruthy()
+      expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission2!.derived).toBe(false)
+
+      // verify that derived permissions on AC2 were created for both users (derived from element)
+      const derivedPermission3 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission3).toBeTruthy()
+      expect(derivedPermission3!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission3!.derived).toBe(true)
+
+      const derivedPermission4 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(derivedPermission4).toBeTruthy()
+      expect(derivedPermission4!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission4!.derived).toBe(true)
+
+      // have user two leave the group
+      await leaveUserGroup({ groupId: group.id }, userTwoCtx)
+
+      // verify that user two no longer has the derived permission
+      const updatedDerivedPermission1 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC1!.id,
+              userId: userTwo.id,
+            },
+          },
+        })
+      expect(updatedDerivedPermission1).toBeNull()
+
+      const updatedDerivedPermission3 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC2!.id,
+              userId: userTwo.id,
+            },
+          },
+        })
+      expect(updatedDerivedPermission3).toBeNull()
+
+      // verify that user three still has the derived permission
+      const persistentDerivedPermission2 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC1!.id,
+              userId: userThree.id,
+            },
+          },
+        })
+      expect(persistentDerivedPermission2).toBeTruthy()
+      expect(persistentDerivedPermission2!.permissionLevel).toBe(
+        PermissionLevel.WRITE
+      )
+      expect(persistentDerivedPermission2!.derived).toBe(false)
+
+      const persistentDerivedPermission4 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC2!.id,
+              userId: userThree.id,
+            },
+          },
+        })
+      expect(persistentDerivedPermission4).toBeTruthy()
+      expect(persistentDerivedPermission4!.permissionLevel).toBe(
+        PermissionLevel.READ
+      )
+      expect(persistentDerivedPermission4!.derived).toBe(true)
+    })
+
+    it('The group owner should be able to delete a user group successfully', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Group to Delete',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // owner should be able to delete the user group
+      const result = await deleteUserGroup({ groupId: group.id }, userOneCtx)
+      expect(result).toBe(true)
+
+      // verify the group no longer exists
+      const deletedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(deletedGroup).toBeNull()
+    })
+
+    it('Non-owners should not be able to delete a user group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Non-owner Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // members are not able to delete the group
+      const memberResult = await deleteUserGroup(
+        { groupId: group.id },
+        userTwoCtx
+      )
+      expect(memberResult).toBe(false)
+
+      // admins are not able to delete the group
+      const adminResult = await deleteUserGroup(
+        { groupId: group.id },
+        userThreeCtx
+      )
+      expect(adminResult).toBe(false)
+
+      // verify the group still exists
+      const existingGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(existingGroup).not.toBeNull()
+    })
+
+    it('Attempting to delete a non-existent group should fail gracefully', async () => {
+      const result = await deleteUserGroup({ groupId: 99999 }, userOneCtx)
+      expect(result).toBe(false)
+    })
+
+    it('Deleting a user group should remove all associated permissions', async () => {
+      // Create a user group
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Permission Group To Delete',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // create an answer collection and grant permissions to the group
+      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          answerCollectionId: AC1!.id,
+        },
+      })
+      await recomputeDerivedPermissions({ answerCollectionId: AC1!.id }, prisma)
+
+      // create an element using the second answer collection and grant permissions to the group
+      const element = await prisma.element.create({
+        data: {
+          type: ElementType.SELECTION,
+          name: 'Element',
+          content: 'Content',
+          options: {},
+          ownerId: userOne.id,
+          answerCollectionId: AC2!.id,
+        },
+      })
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          elementId: element.id,
+        },
+      })
+      await recomputeDerivedPermissions({ elementId: element.id }, prisma)
+
+      // verify that derived permissions on AC1 were created for both users
+      const derivedPermission1 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission1).toBeTruthy()
+      expect(derivedPermission1!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission1!.derived).toBe(false)
+
+      const derivedPermission2 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(derivedPermission2).toBeTruthy()
+      expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission2!.derived).toBe(false)
+
+      // verify that derived permissions on AC2 were created for both users (derived from element)
+      const derivedPermission3 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission3).toBeTruthy()
+      expect(derivedPermission3!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission3!.derived).toBe(true)
+
+      const derivedPermission4 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(derivedPermission4).toBeTruthy()
+      expect(derivedPermission4!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission4!.derived).toBe(true)
+
+      // delete the user group
+      const result = await deleteUserGroup({ groupId: group.id }, userOneCtx)
+      expect(result).toBe(true)
+
+      // verify that all permissions associated with the group are removed
+      const deletedPermission1 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(deletedPermission1).toBeNull()
+
+      const deletedPermission2 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(deletedPermission2).toBeNull()
+
+      const deletedPermission3 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(deletedPermission3).toBeNull()
+
+      const deletedPermission4 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(deletedPermission4).toBeNull()
+    })
+
+    it('Group owner should be able to promote a member to admin', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Promotion Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // owner promotes the member to admin
+      const result = await promoteGroupMemberToAdmin(
+        { groupId: group.id, memberId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(true)
+
+      // verify the user is now an admin and not a regular member
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.members.length).toBe(0)
+      expect(updatedGroup!.admins.length).toBe(1)
+      expect(updatedGroup!.admins[0]?.id).toBe(userTwo.id)
+    })
+
+    it('Group admin should be able to promote a member to admin', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Admin Promotion Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // admin promotes the member to admin
+      const result = await promoteGroupMemberToAdmin(
+        { groupId: group.id, memberId: userTwo.id },
+        userThreeCtx
+      )
+      expect(result).toBe(true)
+
+      // verify the user is now an admin and not a regular member
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.members.length).toBe(0)
+      expect(updatedGroup!.admins.length).toBe(1)
+      expect(updatedGroup!.admins[0]?.id).toBe(userTwo.id)
+    })
+
+    it('Regular members should not be able to promote another member to admin', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Member Promotion Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }, { id: userThree.id }],
+          },
+        },
+      })
+
+      // regular member tries to promote another member to admin
+      const result = await promoteGroupMemberToAdmin(
+        { groupId: group.id, memberId: userThree.id },
+        userTwoCtx
+      )
+      expect(result).toBe(false)
+
+      // verify that the group was not modified
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userThree.id } },
+          admins: { where: { id: userThree.id } },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.members.length).toBe(1)
+      expect(updatedGroup!.admins.length).toBe(0)
+    })
+
+    it('Promoting a user that is not a member of the group should fail gracefully', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Non-existent Member Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // try to promote a user who is not in the group
+      const result = await promoteGroupMemberToAdmin(
+        { groupId: group.id, memberId: userThree.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Trying to promote a member in a non-existent group should fail gracefully', async () => {
+      const result = await promoteGroupMemberToAdmin(
+        { groupId: 99999, memberId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('If a user is already an admin of the group, the promotion should fail', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Double Admin Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }, { id: userThree.id }],
+          },
+        },
+      })
+
+      // admin tries to promote another admin
+      const result = await promoteGroupMemberToAdmin(
+        { groupId: group.id, memberId: userThree.id },
+        userTwoCtx
+      )
+      expect(result).toBe(false)
+
+      // verify that the user group has not changed
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          _count: {
+            select: {
+              admins: true,
+            },
+          },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!._count.admins).toBe(2)
+    })
+
+    it('The group owner should be able to demote an admin to a regular member', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Demotion Test Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // owner demotes the admin to a member
+      const result = await demoteGroupAdminToMember(
+        { groupId: group.id, adminId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(true)
+
+      // verify the user is now a regular member and not an admin
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.members.length).toBe(1)
+      expect(updatedGroup!.members[0]?.id).toBe(userTwo.id)
+      expect(updatedGroup!.admins.length).toBe(0)
+    })
+
+    it('Any group admin should be able to demote another admin to a regular member', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Admin Demotion Test Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }, { id: userThree.id }],
+          },
+        },
+      })
+
+      // one of the admin demotes another admin to a member
+      const result = await demoteGroupAdminToMember(
+        { groupId: group.id, adminId: userThree.id },
+        userTwoCtx
+      )
+      expect(result).toBe(true)
+
+      // verify the user is now a regular member and not an admin
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userThree.id } },
+          admins: { where: { id: userThree.id } },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.members.length).toBe(1)
+      expect(updatedGroup!.members[0]?.id).toBe(userThree.id)
+      expect(updatedGroup!.admins.length).toBe(0)
+    })
+
+    it('Regular members should not be able to demote an admin to a member', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Member Cannot Demote Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+          members: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // regular member tries to demote an admin
+      const result = await demoteGroupAdminToMember(
+        { groupId: group.id, adminId: userTwo.id },
+        userThreeCtx
+      )
+      expect(result).toBe(false)
+
+      // verify no changes were made to the user group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: true,
+          admins: true,
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.admins.length).toBe(1)
+      expect(updatedGroup!.admins[0]?.id).toBe(userTwo.id)
+      expect(updatedGroup!.members.length).toBe(1)
+      expect(updatedGroup!.members[0]?.id).toBe(userThree.id)
+    })
+
+    it('Trying to demote a non-existing admin of the user group should fail gracefully', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Non-existent Admin Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // try to demote a user who is not an admin
+      const result = await demoteGroupAdminToMember(
+        { groupId: group.id, adminId: userThree.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Trying to demote a user in a group that does not exist should fail gracefully', async () => {
+      const result = await demoteGroupAdminToMember(
+        { groupId: 99999, adminId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Verify that the group owner can remove regular members and admins from the group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Remove Member Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // owner removes the member
+      const result = await removeUserFromGroup(
+        { groupId: group.id, userId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(true)
+
+      // owner removes the admin
+      const resultAdmin = await removeUserFromGroup(
+        { groupId: group.id, userId: userThree.id },
+        userOneCtx
+      )
+      expect(resultAdmin).toBe(true)
+
+      // verify that both users were removed from the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userThree.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(0)
+      expect(updatedGroup?.admins.length).toBe(0)
+    })
+
+    it('Verify that group admins are able to remove regular and admin members from the group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Admin Removes Member Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }, { id: userThree.id }],
+          },
+          members: {
+            connect: [{ id: userFour.id }],
+          },
+        },
+      })
+
+      // admin removes the regular member
+      const result = await removeUserFromGroup(
+        { groupId: group.id, userId: userFour.id },
+        userTwoCtx
+      )
+      expect(result).toBe(true)
+
+      // admin removes the other admin
+      const resultAdmin = await removeUserFromGroup(
+        { groupId: group.id, userId: userThree.id },
+        userTwoCtx
+      )
+      expect(resultAdmin).toBe(true)
+
+      // Verify the member was removed from the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userFour.id } },
+          admins: { where: { id: userThree.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(0)
+      expect(updatedGroup?.admins.length).toBe(0)
+    })
+
+    it('Verify that regular members cannot remove other members from the group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Member Cannot Remove Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+          members: {
+            connect: [{ id: userThree.id }, { id: userFour.id }],
+          },
+        },
+      })
+
+      // regular member tries to remove another member
+      const result = await removeUserFromGroup(
+        { groupId: group.id, userId: userFour.id },
+        userThreeCtx
+      )
+      expect(result).toBe(false)
+
+      // regular member tries to remove admin from the group
+      const resultAdmin = await removeUserFromGroup(
+        { groupId: group.id, userId: userTwo.id },
+        userThreeCtx
+      )
+      expect(resultAdmin).toBe(false)
+
+      // verify no changes were made to the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: true,
+          admins: true,
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(2)
+      expect(updatedGroup?.admins.length).toBe(1)
+    })
+
+    it('Users should not be able to remove themselves using the user removal function', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Self Remove Test Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // User tries to remove themselves
+      const result = await removeUserFromGroup(
+        { groupId: group.id, userId: userTwo.id },
+        userTwoCtx
+      )
+      expect(result).toBe(false)
+
+      // verify no changes were made
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(1)
+    })
+
+    it('Trying to remove a non-existent user from a group should fail gracefully', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Non-existent User Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      const result = await removeUserFromGroup(
+        { groupId: group.id, userId: userThree.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Trying to remove a user from a non-existent group should fail gracefully', async () => {
+      const result = await removeUserFromGroup(
+        { groupId: 99999, userId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('When a user is removed from a group, their permissions granted through the group should be revoked', async () => {
+      // create a group with two members
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Permission Revocation Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }, { id: userThree.id }],
+          },
+        },
+      })
+
+      // create an answer collection and grant permissions to the group
+      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          answerCollectionId: AC1!.id,
+        },
+      })
+      await recomputeDerivedPermissions({ answerCollectionId: AC1!.id }, prisma)
+
+      // create an element using the second answer collection and grant permissions to the group
+      const element = await prisma.element.create({
+        data: {
+          type: ElementType.SELECTION,
+          name: 'Element',
+          content: 'Content',
+          options: {},
+          ownerId: userOne.id,
+          answerCollectionId: AC2!.id,
+        },
+      })
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          elementId: element.id,
+        },
+      })
+      await recomputeDerivedPermissions({ elementId: element.id }, prisma)
+
+      // verify that derived permissions on AC1 were created for both users
+      const derivedPermission1 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission1).toBeTruthy()
+      expect(derivedPermission1!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission1!.derived).toBe(false)
+
+      const derivedPermission2 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(derivedPermission2).toBeTruthy()
+      expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission2!.derived).toBe(false)
+
+      // verify that derived permissions on AC2 were created for both users (derived from element)
+      const derivedPermission3 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission3).toBeTruthy()
+      expect(derivedPermission3!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission3!.derived).toBe(true)
+
+      const derivedPermission4 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+      expect(derivedPermission4).toBeTruthy()
+      expect(derivedPermission4!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission4!.derived).toBe(true)
+
+      // remove one user from the group
+      const result = await removeUserFromGroup(
+        { groupId: group.id, userId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(true)
+
+      // verify that user two no longer has the derived permission
+      const updatedDerivedPermission1 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC1!.id,
+              userId: userTwo.id,
+            },
+          },
+        })
+      expect(updatedDerivedPermission1).toBeNull()
+
+      const updatedDerivedPermission3 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC2!.id,
+              userId: userTwo.id,
+            },
+          },
+        })
+      expect(updatedDerivedPermission3).toBeNull()
+
+      // verify that user three still has the derived permission
+      const persistentDerivedPermission2 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC1!.id,
+              userId: userThree.id,
+            },
+          },
+        })
+      expect(persistentDerivedPermission2).toBeTruthy()
+      expect(persistentDerivedPermission2!.permissionLevel).toBe(
+        PermissionLevel.WRITE
+      )
+      expect(persistentDerivedPermission2!.derived).toBe(false)
+
+      const persistentDerivedPermission4 =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC2!.id,
+              userId: userThree.id,
+            },
+          },
+        })
+      expect(persistentDerivedPermission4).toBeTruthy()
+      expect(persistentDerivedPermission4!.permissionLevel).toBe(
+        PermissionLevel.READ
+      )
+      expect(persistentDerivedPermission4!.derived).toBe(true)
+    })
+
+    it('Verify that group owners and admins can update the user group name, regular users cannot', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Original Group Name',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+          admins: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // owner changes the group name
+      const newName = 'Updated Group Name'
+      const result = await changeUserGroupName(
+        { id: group.id, name: newName },
+        userOneCtx
+      )
+      expect(result).toBe(true)
+
+      // verify the group name was updated
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroup?.name).toBe(newName)
+
+      // admin changes the group name
+      const newNameAdmin = 'Updated Group Name by Admin'
+      const resultAdmin = await changeUserGroupName(
+        { id: group.id, name: newNameAdmin },
+        userThreeCtx
+      )
+      expect(resultAdmin).toBe(true)
+
+      // verify the group name was updated
+      const updatedGroupAdmin = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroupAdmin?.name).toBe(newNameAdmin)
+
+      // regular member tries to change the group name
+      const newNameMember = 'Updated Group Name by Member'
+      const resultMember = await changeUserGroupName(
+        { id: group.id, name: newNameMember },
+        userTwoCtx
+      )
+      expect(resultMember).toBe(false)
+
+      // verify the group name was not updated
+      const updatedGroupMember = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroupMember?.name).toBe(newNameAdmin)
+
+      // non-member tries to change the group name
+      const newNameNonMember = 'Updated Group Name by Non-Member'
+      const resultNonMember = await changeUserGroupName(
+        { id: group.id, name: newNameNonMember },
+        userFourCtx
+      )
+      expect(resultNonMember).toBe(false)
+
+      // verify the group name was not updated
+      const updatedGroupNonMember = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroupNonMember?.name).toBe(newNameAdmin)
+    })
+
+    it('Verify that trying to update the name of a non-existent group fails gracefully', async () => {
+      const result = await changeUserGroupName(
+        { id: 99999, name: 'New Name' },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Test the successful transfer of a user group ownership from owner to admin', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Transfer Ownership Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // transfer ownership to the admin
+      const result = await transferGroupOwnership(
+        { id: group.id, newOwnerId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(true)
+
+      // verify the group ownership was updated
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          admins: true,
+        },
+      })
+      expect(updatedGroup?.ownerId).toBe(userTwo.id)
+
+      // verify that the previous owner is now an admin and that the previous admin was removed
+      const admins = updatedGroup?.admins.map((admin) => admin.id) || []
+      expect(admins).toContain(userOne.id)
+      expect(admins).not.toContain(userTwo.id)
+    })
+
+    it('Admins and regular members should not be allowed to trigger ownership transfer', async () => {
+      // Create a group with two admins
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Non-owner Transfer Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }, { id: userThree.id }],
+          },
+          members: {
+            connect: [{ id: userFour.id }],
+          },
+        },
+      })
+
+      // admin tries to transfer ownership
+      const result = await transferGroupOwnership(
+        { id: group.id, newOwnerId: userThree.id },
+        userTwoCtx
+      )
+      expect(result).toBe(false)
+
+      // verify the group ownership was not changed
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroup?.ownerId).toBe(userOne.id)
+
+      // regular member tries to transfer ownership
+      const resultMember = await transferGroupOwnership(
+        { id: group.id, newOwnerId: userFour.id },
+        userFourCtx
+      )
+      expect(resultMember).toBe(false)
+
+      // verify the group ownership was not changed
+      const updatedGroupMember = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroupMember?.ownerId).toBe(userOne.id)
+    })
+
+    it('Verify that the ownership cannot be transferred to a regular user or a non-member', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Transfer To Member Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+          members: {
+            connect: [{ id: userThree.id }],
+          },
+        },
+      })
+
+      // owner tries to transfer ownership to regular member
+      const result = await transferGroupOwnership(
+        { id: group.id, newOwnerId: userThree.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+
+      // verify the group ownership was not changed
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroup?.ownerId).toBe(userOne.id)
+
+      // owner tries to transfer ownership to non-member
+      const resultNonMember = await transferGroupOwnership(
+        { id: group.id, newOwnerId: userFour.id },
+        userOneCtx
+      )
+      expect(resultNonMember).toBe(false)
+
+      // verify the group ownership was not changed
+      const updatedGroupNonMember = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+      })
+      expect(updatedGroupNonMember?.ownerId).toBe(userOne.id)
+    })
+
+    it('Verify that trying to transfer the ownership of a non-existent group should fail gracefully', async () => {
+      const result = await transferGroupOwnership(
+        { id: 99999, newOwnerId: userTwo.id },
+        userOneCtx
+      )
+      expect(result).toBe(false)
+    })
+
+    it('Verify that group owner can add a user as a regular or admin member', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Add Member Test Group',
+          ownerId: userOne.id,
+        },
+      })
+
+      // owner adds a new user as a regular member
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userTwo.shortname,
+          asAdmin: false,
+        },
+        userOneCtx
+      )
+      expect(result).toBeTruthy()
+      expect(result?.id).toBe(userTwo.id)
+      expect(result?.shortname).toBe(userTwo.shortname)
+      expect(result?.email).toBe(userTwo.email)
+      expect(result?.isSelf).toBe(false)
+
+      // verify the user was added to the group as a member
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(1)
+      expect(updatedGroup?.members[0]?.id).toBe(userTwo.id)
+      expect(updatedGroup?.admins.length).toBe(0)
+
+      // owner adds another user as an admin
+      const resultAdmin = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userThree.shortname,
+          asAdmin: true,
+        },
+        userOneCtx
+      )
+      expect(resultAdmin).toBeTruthy()
+      expect(resultAdmin?.id).toBe(userThree.id)
+      expect(resultAdmin?.shortname).toBe(userThree.shortname)
+      expect(resultAdmin?.email).toBe(userThree.email)
+
+      // verify the user was added to the group as an admin
+      const updatedGroupAdmin = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userThree.id } },
+          admins: { where: { id: userThree.id } },
+        },
+      })
+      expect(updatedGroupAdmin?.members.length).toBe(0)
+      expect(updatedGroupAdmin?.admins.length).toBe(1)
+      expect(updatedGroupAdmin?.admins[0]?.id).toBe(userThree.id)
+    })
+
+    it('Verify that group admins are able to add regular users and admins to the group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Admin Adding Test Group',
+          ownerId: userOne.id,
+          admins: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // admin adds a new user as a regular member
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userThree.shortname,
+          asAdmin: false,
+        },
+        userTwoCtx
+      )
+      expect(result).toBeTruthy()
+      expect(result?.id).toBe(userThree.id)
+      expect(result?.shortname).toBe(userThree.shortname)
+
+      // verify the user was added to the group as a member
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userThree.id } },
+          admins: { where: { id: userThree.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(1)
+      expect(updatedGroup?.members[0]?.id).toBe(userThree.id)
+      expect(updatedGroup?.admins.length).toBe(0)
+
+      // admin adds another user as an admin
+      const resultAdmin = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userFour.shortname,
+          asAdmin: true,
+        },
+        userTwoCtx
+      )
+      expect(resultAdmin).toBeTruthy()
+      expect(resultAdmin?.id).toBe(userFour.id)
+      expect(resultAdmin?.shortname).toBe(userFour.shortname)
+      expect(resultAdmin?.email).toBe(userFour.email)
+      expect(resultAdmin?.isSelf).toBe(false)
+
+      // verify the user was added to the group as an admin
+      const updatedGroupAdmin = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userFour.id } },
+          admins: { where: { id: userFour.id } },
+        },
+      })
+      expect(updatedGroupAdmin?.members.length).toBe(0)
+      expect(updatedGroupAdmin?.admins.length).toBe(1)
+      expect(updatedGroupAdmin?.admins[0]?.id).toBe(userFour.id)
+    })
+
+    it('Regular members should not be able to add other users to the group', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Member Cannot Add Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // regular member tries to add another user
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userThree.shortname,
+          asAdmin: false,
+        },
+        userTwoCtx
+      )
+      expect(result).toBeNull()
+
+      // verify no changes were made to the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: true,
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(1)
+      expect(updatedGroup?.members[0]?.id).toBe(userTwo.id)
+    })
+
+    it('Verify that users can also be added to the group with their email address', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Add By Email Group',
+          ownerId: userOne.id,
+        },
+      })
+
+      // add a user using their email address
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userTwo.email,
+          asAdmin: false,
+        },
+        userOneCtx
+      )
+      expect(result).toBeTruthy()
+      expect(result?.id).toBe(userTwo.id)
+      expect(result?.email).toBe(userTwo.email)
+
+      // verify the user was added to the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(1)
+      expect(updatedGroup?.members[0]?.id).toBe(userTwo.id)
+      expect(updatedGroup?.admins.length).toBe(0)
+    })
+
+    it('Verify that trying to add a non-existent user fails gracefully', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Non-existent User Add Group',
+          ownerId: userOne.id,
+        },
+      })
+
+      // try to add a non-existent user
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: 'nonexistent-user',
+          asAdmin: false,
+        },
+        userOneCtx
+      )
+      expect(result).toBeNull()
+
+      // verify no changes were made to the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: true,
+          admins: true,
+        },
+      })
+      expect(updatedGroup?.members.length).toBe(0)
+      expect(updatedGroup?.admins.length).toBe(0)
+    })
+
+    it('Verify that trying to add a user to a non-existent group fails gracefully', async () => {
+      const result = await addUserToUserGroup(
+        {
+          groupId: 99999,
+          shortnameOrEmail: userTwo.shortname,
+          asAdmin: false,
+        },
+        userOneCtx
+      )
+      expect(result).toBeNull()
+    })
+
+    it('Verify that adding a user who is already a member of the group fails gracefully', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Duplicate Member Group',
+          ownerId: userOne.id,
+          members: {
+            connect: [{ id: userTwo.id }],
+          },
+        },
+      })
+
+      // try to add the same user again
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userTwo.shortname,
+          asAdmin: false,
+        },
+        userOneCtx
+      )
+      expect(result).toBeNull()
+
+      // verify no changes were made to the group
+      const updatedGroup = await prisma.userGroup.findUnique({
+        where: { id: group.id },
+        include: {
+          members: { where: { id: userTwo.id } },
+          admins: { where: { id: userTwo.id } },
+        },
+      })
+      expect(updatedGroup).toBeTruthy()
+      expect(updatedGroup!.members.length).toBe(1)
+      expect(updatedGroup!.members[0]?.id).toBe(userTwo.id)
+      expect(updatedGroup!.admins.length).toBe(0)
+    })
+
+    it('Verify that the correct derived permissions are created for the new group member on addition', async () => {
+      const group = await prisma.userGroup.create({
+        data: {
+          name: 'Permission Inheritance Group',
+          ownerId: userOne.id,
+        },
+      })
+
+      // create an answer collection and grant permissions to the group
+      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.WRITE,
+          userGroupId: group.id,
+          answerCollectionId: AC1!.id,
+        },
+      })
+      await recomputeDerivedPermissions({ answerCollectionId: AC1!.id }, prisma)
+
+      // create an element using the second answer collection and grant permissions to the group
+      const element = await prisma.element.create({
+        data: {
+          type: ElementType.SELECTION,
+          name: 'Element',
+          content: 'Content',
+          options: {},
+          ownerId: userOne.id,
+          answerCollectionId: AC2!.id,
+        },
+      })
+      await prisma.permission.create({
+        data: {
+          permissionLevel: PermissionLevel.ADMIN,
+          userGroupId: group.id,
+          elementId: element.id,
+        },
+      })
+      await recomputeDerivedPermissions({ elementId: element.id }, prisma)
+
+      // add a new user to the group
+      const result = await addUserToUserGroup(
+        {
+          groupId: group.id,
+          shortnameOrEmail: userTwo.shortname,
+          asAdmin: false,
+        },
+        userOneCtx
+      )
+      expect(result).toBeTruthy()
+      expect(result?.id).toBe(userTwo.id)
+      expect(result?.shortname).toBe(userTwo.shortname)
+      expect(result?.email).toBe(userTwo.email)
+
+      // verify that the user was granted the correct derived permissions
+      const derivedPermission1 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC1!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission1).toBeTruthy()
+      expect(derivedPermission1!.permissionLevel).toBe(PermissionLevel.WRITE)
+      expect(derivedPermission1!.derived).toBe(false)
+
+      const derivedPermission2 = await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: element.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission2).toBeTruthy()
+      expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.ADMIN)
+      expect(derivedPermission2!.derived).toBe(false)
+
+      const derivedPermission3 = await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC2!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+      expect(derivedPermission3).toBeTruthy()
+      expect(derivedPermission3!.permissionLevel).toBe(PermissionLevel.READ)
+      expect(derivedPermission3!.derived).toBe(true)
     })
   })
 })

--- a/packages/util/src/permissions.ts
+++ b/packages/util/src/permissions.ts
@@ -199,7 +199,14 @@ async function recomputeCatalogCollectionPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -271,6 +278,7 @@ async function recomputeCatalogCollectionPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -358,7 +366,14 @@ async function recomputeAnswerCollectionPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -529,6 +544,7 @@ async function recomputeAnswerCollectionPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -695,7 +711,14 @@ async function recomputeElementPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -944,6 +967,7 @@ async function recomputeElementPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -1154,7 +1178,14 @@ async function recomputeLiveQuizPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -1264,6 +1295,7 @@ async function recomputeLiveQuizPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -1375,7 +1407,14 @@ async function recomputePracticeQuizPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -1485,6 +1524,7 @@ async function recomputePracticeQuizPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -1598,7 +1638,14 @@ async function recomputeMicroLearningPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -1708,6 +1755,7 @@ async function recomputeMicroLearningPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -1821,7 +1869,14 @@ async function recomputeGroupActivityPermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -1931,6 +1986,7 @@ async function recomputeGroupActivityPermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -2044,7 +2100,14 @@ async function recomputeCoursePermissionsUser(
         where: {
           OR: [
             { userId },
-            { userGroup: { members: { some: { id: userId } } } },
+            {
+              userGroup: {
+                OR: [
+                  { members: { some: { id: userId } } },
+                  { admins: { some: { id: userId } } },
+                ],
+              },
+            },
           ],
         },
       },
@@ -2145,6 +2208,7 @@ async function recomputeCoursePermissionsObject(
           userGroup: {
             include: {
               members: true,
+              admins: true,
             },
           },
         },
@@ -2247,7 +2311,9 @@ function getMaxAccessLevelCombined({
   ownerId,
 }: {
   directPermissions: (DB.Permission & {
-    userGroup?: (DB.UserGroup & { members: DB.User[] }) | null
+    userGroup?:
+      | (DB.UserGroup & { members: DB.User[]; admins: DB.User[] })
+      | null
   })[]
   objectDeleted: boolean
   ownerId?: string | null
@@ -2275,8 +2341,12 @@ function getMaxAccessLevelCombined({
           }
         }
       } else if (directPermission.userGroup) {
-        // iterate over the members and add / update the corresponding permissions for each user
-        directPermission.userGroup.members.forEach((user) => {
+        // iterate over the members and admins and add / update the corresponding permissions for each user
+        const groupMembers = [
+          ...directPermission.userGroup.members,
+          ...directPermission.userGroup.admins,
+        ]
+        groupMembers.forEach((user) => {
           if (
             typeof acc[user.id] !== 'undefined' &&
             permissionLevelMap[directPermission.permissionLevel] >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that user group admins are now correctly included in permission checks and recomputation, granting them the same access as group members.
	- Fixed permission inheritance and revocation logic when users are added to or removed from groups.

- **Tests**
	- Expanded test coverage for user group management, including group membership changes, role updates, group deletion, renaming, ownership transfer, and permission inheritance.
	- Improved validation of permission changes and error handling across various user group scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->