### PR TITLE
chore(cypress): extend e2e cypress test suite with coverage of element sharing

### DIFF
--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1,3 +1,4 @@
+import { SharingObjectType } from '@klicker-uzh/types'
 import messages from '../../../packages/i18n/messages/en'
 
 // global variable for ensured consistency with current dates
@@ -5,8 +6,11 @@ const currentYear = new Date().getFullYear()
 
 describe('Create different types of elements (with and without sample solution) and edit them', function () {
   beforeEach('Load data fixture', function () {
-    cy.fixture('D-questions.json').then((data) => {
-      this.data = data
+    cy.fixture('questions.json').then((sharedData) => {
+      this.data = sharedData
+    })
+    cy.fixture('D-questions.json').then((questionsData) => {
+      this.data = { ...this.data, ...questionsData }
     })
   })
 
@@ -358,6 +362,7 @@ describe('Create different types of elements (with and without sample solution) 
   // #endregion
 
   // ! Part 3: Element instance updates
+  // #region
   // helper function to publish / start one instance of each activity type with the defined name
   function publishSetOfActivities({
     course,
@@ -909,6 +914,687 @@ describe('Create different types of elements (with and without sample solution) 
       cy.get(`[data-cy="groupActivity-actions-${ga}"]`).should('not.exist')
     })
   })
+  // #endregion
+
+  // ! Part 4: Sharing functionalities for elements (restricted catalog collection)
+  // #region
+  it('Create a selection question', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get('[data-cy="answer-collection-list"]').should('exist')
+    cy.createAnswerCollection({
+      name: this.data.collection.name,
+      description: this.data.collection.description,
+      entries: this.data.collection.options,
+      userId: Cypress.env('LECTURER_ID'),
+    })
+
+    cy.get('[data-cy="library"]').click()
+    cy.createQuestionSE({
+      name: this.data.SEML.title,
+      content: this.data.SEML.content,
+      numberOfInputs: this.data.SEML.inputs,
+      collectionName: this.data.collection.name,
+      correctAnswers: this.data.collection.options.filter((_, i) =>
+        this.data.SEML.solutions.includes(i)
+      ),
+      userId: Cypress.env('LECTURER_ID'),
+    })
+  })
+
+  it('Add the question as a restricted collection to the catalog', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    // add question to catalog as restricted object
+    cy.addObjectToCatalog({
+      objectName: this.data.SEML.title,
+      objectType: SharingObjectType.ELEMENT,
+      permissionLevel: 'restricted',
+    })
+
+    // check that import and request functionalities are not available for owner (but deletion is)
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="remove-object-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it('Test filters and search on the catalog page', function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    // test search
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get('[data-cy="search-catalog-collection"]')
+      .click()
+      .type('SOME NON-EXISTING TITLE')
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get('[data-cy="search-catalog-collection"]')
+      .clear()
+      .type(this.data.SEML.title)
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+
+    // test access type filters
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get('[data-cy="catalog-access-type-filter"]').contains(
+      messages.manage.catalog.all
+    )
+    cy.get('[data-cy="catalog-access-type-filter"]').click()
+    cy.get('[data-cy="catalog-access-public"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get('[data-cy="catalog-access-type-filter"]').click()
+    cy.get('[data-cy="catalog-access-restricted"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get('[data-cy="catalog-access-type-filter"]').click()
+    cy.get('[data-cy="catalog-access-all"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it('Request access to restricted question (for user pro1)', function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="cancel-request-access"]').click()
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-request-access"]').click()
+
+    // check that access request is pending
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).contains(
+      messages.manage.catalog.accessRequested
+    )
+  })
+
+  it('Request access to restricted question (for user pro2)', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-request-access"]').click()
+
+    // check that access request is pending
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).contains(
+      messages.manage.catalog.accessRequested
+    )
+  })
+
+  it('Verify that access requests are correctly shown to collection owner', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro1"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('exist')
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro2"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('exist')
+  })
+
+  it('Temporarily award ADMIN permissions to user pro3 and verify that the access requests are visible as well', function () {
+    // grant ADMIN permissions to user pro3 through direct sharing
+    cy.loginLecturer()
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_INST2_SHORTNAME')
+    )
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
+    cy.logoutLecturer()
+
+    // verify that access requests are visible to user pro3
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro1"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('exist')
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro2"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('exist')
+    cy.logoutLecturer()
+
+    // revoke direct ADMIN permissions again
+    cy.loginLecturer()
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SEML.title}"]`).click()
+    cy.get(
+      `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).click()
+    cy.get(
+      `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).should('not.exist')
+    cy.logoutLecturer()
+
+    // verify that the access requests are not visible anymore to user pro3
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro1"]`).should(
+      'not.exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('not.exist')
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro2"]`).should(
+      'not.exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('not.exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('not.exist')
+  })
+
+  it('Cancel the request through user pro1 and request the element again', function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    // check that access request is pending
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).contains(
+      messages.manage.catalog.accessRequested
+    )
+
+    // cancel the request
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="cancel-request-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-request-cancellation"]').click()
+
+    // request the question again (should be possible)
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-request-access"]').click()
+
+    // check that access request is pending again
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).contains(
+      messages.manage.catalog.accessRequested
+    )
+  })
+
+  it('Grant access to restricted question (for user pro1)', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).click()
+
+    // approval modal
+    cy.get('[data-cy="permission-level-select"]').contains(
+      messages.manage.sharing.permissionsREAD
+    )
+    cy.get('[data-cy="permission-level-select"]').click()
+    cy.get('[data-cy="permission-level-READ"]').click()
+    cy.get('[data-cy="confirm-approval"]').click()
+  })
+
+  it('Decline access request to restricted question (for user pro2)', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).click()
+  })
+
+  it("Verify that the active permission for user 'pro1' is shown correctly", function () {
+    cy.loginLecturer()
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsREAD)
+  })
+
+  it('Verify that restricted question is visible for user pro1', function () {
+    cy.loginIndividualCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it('Verify that restricted question is not visible for user pro2', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+  })
+
+  it('Change the access level of the question in the catalog to public', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    cy.get(`[data-cy="${this.data.SEML.title}-object-access"]`).contains(
+      messages.manage.catalog.accessRESTRICTED
+    )
+    cy.get(`[data-cy="${this.data.SEML.title}-object-access"]`).realClick()
+    cy.get('[data-cy="object-access-restricted"]').should('exist')
+    cy.get('[data-cy="object-access-public"]').realClick()
+    cy.get('[data-cy="confirm-access-change"]').click()
+    cy.get(`[data-cy="${this.data.SEML.title}-object-access"]`).contains(
+      messages.manage.catalog.accessPUBLIC
+    )
+  })
+
+  it('Verify that question can now be imported or requested', function () {
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).should('exist')
+
+    // no owner / admin actions are available
+    cy.get(`[data-cy="remove-object-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="${this.data.SEML.title}-object-access"]`).should(
+      'not.exist'
+    )
+  })
+
+  it('Remove the question from the catalog (by owner)', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="remove-object-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-removal"]').click()
+  })
+
+  it('Verify that the question is no longer visible in the catalog', function () {
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+  })
+
+  it('Re-add the question with restricted access to the restricted catalog collection', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.addObjectToCatalog({
+      objectName: this.data.SEML.title,
+      objectType: SharingObjectType.ELEMENT,
+      permissionLevel: 'restricted',
+    })
+  })
+
+  it("Grant admin access to user 'pro2' for the restricted question", function () {
+    cy.loginLecturer()
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_INST_EMAIL')
+    )
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-username-or-email"]').clear()
+    cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_INST_EMAIL')
+    )
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
+  })
+
+  it('Verify that user pro2 should now be able to add this question to the catalog', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-0"]'
+    ).should('exist')
+  })
+
+  it('Cleanup: Delete all created objects and validate deletion', function () {
+    cy.loginLecturer()
+    cy.deleteElement({ elementName: this.data.SEML.title })
+
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.deleteAnswerCollection({ collectionName: this.data.collection.name })
+
+    // verify that all created data has been removed again
+    cy.task('verifyDeletionAnswerCollections').then((result) => {
+      if (result === null || result === false) {
+        throw new Error(
+          'The database contains answer collections beyond the seeded ones.'
+        )
+      }
+
+      // dummy action
+      cy.visit(Cypress.env('URL_MANAGE'))
+    })
+  })
+  // #endregion
+
+  // ! Part 5: Sharing functionalities for elements (public catalog collection)
+  // #region
+  it('Create a selection question', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get('[data-cy="answer-collection-list"]').should('exist')
+    cy.createAnswerCollection({
+      name: this.data.collection.name,
+      description: this.data.collection.description,
+      entries: this.data.collection.options,
+      userId: Cypress.env('LECTURER_ID'),
+    })
+
+    cy.get('[data-cy="library"]').click()
+    cy.createQuestionSE({
+      name: this.data.SEML.title,
+      content: this.data.SEML.content,
+      numberOfInputs: this.data.SEML.inputs,
+      collectionName: this.data.collection.name,
+      correctAnswers: this.data.collection.options.filter((_, i) =>
+        this.data.SEML.solutions.includes(i)
+      ),
+      userId: Cypress.env('LECTURER_ID'),
+    })
+  })
+
+  it('Add the question with public access to the catalog and verify visibility', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    cy.addObjectToCatalog({
+      objectName: this.data.SEML.title,
+      objectType: SharingObjectType.ELEMENT,
+      permissionLevel: 'public',
+    })
+
+    // question should be visible to owner, but cannot be requested / imported
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="remove-object-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it("Request access to the public question (for user 'pro1')", function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).click()
+    cy.findByText(messages.manage.catalog.requestPublicResource)
+    cy.get('[data-cy="confirm-request-access"]').click()
+
+    // check that access request is pending
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).contains(
+      messages.manage.catalog.accessRequested
+    )
+  })
+
+  it("Request access to the public question (for user 'pro2')", function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="request-access-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-request-access"]').click()
+
+    // check that access request is pending
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).contains(
+      messages.manage.catalog.accessRequested
+    )
+  })
+
+  it('Verify that access requests are correctly shown to question owner', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro1"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).should('exist')
+    cy.get(`[data-cy="sharing-request-${this.data.SEML.title}-pro2"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('exist')
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).should('exist')
+  })
+
+  it('Grant access to public question (for user pro1)', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="approve-sharing-request-${this.data.SEML.title}-pro1"]`
+    ).click()
+
+    // approval modal
+    cy.get('[data-cy="permission-level-select"]').contains(
+      messages.manage.sharing.permissionsREAD
+    )
+    cy.get('[data-cy="permission-level-select"]').click()
+    cy.get('[data-cy="permission-level-READ"]').click()
+    cy.get('[data-cy="confirm-approval"]').click()
+  })
+
+  it('Decline access request to public question (for user pro2)', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
+    ).click()
+  })
+
+  it("Verify that the active permission for user 'pro1' is shown correctly", function () {
+    cy.loginLecturer()
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsREAD)
+  })
+
+  it("Verify that the public question is visible for user 'pro1'", function () {
+    cy.loginIndividualCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it("Verify that the public question is not visible for user 'pro2'", function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should(
+      'not.exist'
+    )
+  })
+
+  it('Import (and copy) the public question (for user pro2)', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="close-object-import-modal"]').click()
+
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="cancel-object-import"]').click()
+    cy.get(`[data-cy="actions-dropdown-${this.data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${this.data.SEML.title}"]`).click()
+    cy.get('[data-cy="confirm-object-import"]').click()
+
+    // check that the collection is visible in resources
+    cy.get('[data-cy="library"]').click()
+    cy.reload() // make sure data is refetched (works without - this is to avoid race conditions in testing)
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it('Verify that imported question is visible to user pro2 (copied and with edit permissions)', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="edit-element-${this.data.SEML.title}"]`).click()
+  })
+
+  // TODO: re-introduce this test, once the removal functionality for elements is available
+  // it('Remove the public question from user pro1', function () {
+  //   cy.loginIndividualCatalyst()
+  //   cy.get('[data-cy="analytics"]').should('exist')
+  //   cy.get('[data-cy="resources"]').click()
+  //   cy.get('[data-cy="answer-collections"]').click()
+  //   cy.get(`[data-cy="answer-collection-${this.data.SEML.title}"]`).should(
+  //     'exist'
+  //   )
+  //   removeAnswerCollection({ name: this.data.SEML.title })
+  //   cy.get(`[data-cy="answer-collection-${this.data.SEML.title}"]`).should(
+  //     'not.exist'
+  //   )
+  // })
+
+  it('Delete the original public question', function () {
+    cy.loginLecturer()
+    cy.deleteElement({ elementName: this.data.SEML.title })
+  })
+
+  it('Verify that imported question is still visible to user pro2 (due to derived permission)', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
+  })
+
+  it('Remove the imported question from user pro2', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.deleteElement({ elementName: this.data.SEML.title })
+  })
+
+  it('Cleanup: Delete all created objects and validate deletion', function () {
+    cy.loginLecturer()
+
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.deleteAnswerCollection({ collectionName: this.data.collection.name })
+
+    // verify that all created data has been removed again
+    cy.task('verifyDeletionAnswerCollections').then((result) => {
+      if (result === null || result === false) {
+        throw new Error(
+          'The database contains answer collections beyond the seeded ones.'
+        )
+      }
+
+      // dummy action
+      cy.visit(Cypress.env('URL_MANAGE'))
+    })
+  })
+  // #endregion
 
   // ! Verification
   // #region

--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1708,18 +1708,6 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
       'not.exist'
     )
-
-    cy.loginInstitutionalCatalyst()
-    cy.reload()
-    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
-      'not.exist'
-    )
-
-    cy.loginInstitutionalCatalyst2()
-    cy.reload()
-    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
-      'not.exist'
-    )
   })
   // #region
 

--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1541,8 +1541,13 @@ describe('Create different types of elements (with and without sample solution) 
   it('Verify that imported question is visible to user pro2 (copied and with edit permissions)', function () {
     cy.loginInstitutionalCatalyst()
     cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
-    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).click()
-    cy.get(`[data-cy="edit-element-${this.data.SEML.title}"]`).click()
+    cy.get(`[data-cy="edit-element-${this.data.SEML.title}"]`).should('exist')
+    cy.get(`[data-cy="duplicate-element-${this.data.SEML.title}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="actions-element-${this.data.SEML.title}"]`).should(
+      'exist'
+    )
   })
 
   // TODO: re-introduce this test, once the removal functionality for elements is available
@@ -1595,6 +1600,128 @@ describe('Create different types of elements (with and without sample solution) 
     })
   })
   // #endregion
+
+  // ! Part 6: Direct sharing / enabled functionalities
+  // #region
+  it('Create a single choice question and share it with different permission levels', function () {
+    // create SC question
+    cy.loginLecturer()
+    cy.createQuestionSC({
+      name: this.data.SCML.title,
+      content: this.data.SCML.content,
+      choices: this.data.SCML.choices,
+      userId: Cypress.env('LECTURER_ID'),
+    })
+
+    // share it directly with READ, WRITE and ADMIN permissions with the users pro1, pro2 and pro3, respectively
+    cy.get(`[data-cy="actions-element-${this.data.SCML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SCML.title}"]`).click()
+
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_IND_SHORTNAME')
+    )
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-READ"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsREAD
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsREAD)
+
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_INST_SHORTNAME')
+    )
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-WRITE"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsWRITE
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsWRITE)
+
+    cy.get('[data-cy="new-permission-username-or-email"]').type(
+      Cypress.env('LECTURER_INST2_SHORTNAME')
+    )
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
+  })
+
+  it('Verify that the user with granted access are able to access the correct element manipulation functionalities', function () {
+    // READ permissions should enable a user to duplicate the element (no editing, no re-use, no deletion / sharing)
+    cy.loginIndividualCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should('exist')
+    cy.get(`[data-cy="edit-element-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="duplicate-element-${this.data.SCML.title}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="actions-element-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+    cy.logoutLecturer()
+
+    // WRITE permissions should enable a user to duplicate or edit the element (no re-use, no deletion / sharing)
+    cy.loginInstitutionalCatalyst()
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should('exist')
+    cy.get(`[data-cy="edit-element-${this.data.SCML.title}"]`).should('exist')
+    cy.get(`[data-cy="duplicate-element-${this.data.SCML.title}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="actions-element-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+    cy.logoutLecturer()
+
+    // ADMIN permissions should enable a user to duplicate, edit, delete or share the element
+    cy.loginInstitutionalCatalyst2()
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should('exist')
+    cy.get(`[data-cy="edit-element-${this.data.SCML.title}"]`).should('exist')
+    cy.get(`[data-cy="duplicate-element-${this.data.SCML.title}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="actions-element-${this.data.SCML.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SCML.title}"]`).should('exist')
+    cy.get(`[data-cy="delete-element-${this.data.SCML.title}"]`).should('exist')
+  })
+
+  it('Cleanup: Delete the created question again and verify deletion', function () {
+    cy.loginLecturer()
+    cy.deleteElement({ elementName: this.data.SCML.title })
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+
+    cy.loginIndividualCatalyst()
+    cy.reload()
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+
+    cy.loginInstitutionalCatalyst()
+    cy.reload()
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+
+    cy.loginInstitutionalCatalyst2()
+    cy.reload()
+    cy.get(`[data-cy="element-item-${this.data.SCML.title}"]`).should(
+      'not.exist'
+    )
+  })
+  // #region
 
   // ! Verification
   // #region

--- a/cypress/cypress/e2e/T-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/T-resources-workflow.cy.ts
@@ -388,7 +388,6 @@ describe('Create, edit and share answer collections', function () {
   it('Cleanup: Verify that all answer collections have been deleted properly', function () {
     validateDatabaseContent()
   })
-
   // #endregion
 
   // ! 3. Sharing functionalities (restricted collection)

--- a/cypress/cypress/e2e/U-catalog-workflow.cy.ts
+++ b/cypress/cypress/e2e/U-catalog-workflow.cy.ts
@@ -22,9 +22,11 @@ describe('Test all functionalities of catalog collections and objects contained 
   function verifyAdminOwnerPermissionsCCPublic({
     data,
     ownership,
+    elementOwnership,
   }: {
     data: any
     ownership: boolean
+    elementOwnership: boolean
   }) {
     cy.get(
       `[data-cy="catalog-collection-${data.CCPublic}-actions"]`
@@ -89,11 +91,102 @@ describe('Test all functionalities of catalog collections and objects contained 
     )
     cy.get(`[data-cy="remove-object-${data.liveQuiz.template.name}"]`).click()
     cy.get('[data-cy="cancel-removal"]').click()
+    cy.get('[data-cy="leave-catalog-collection"]').click()
+
+    // verify that the selection questions can be imported or requested from the catalog collection
+    cy.get(`[data-cy="catalog-object-${data.SEML.title}"]`)
+      .should('exist')
+      .should(
+        elementOwnership ? 'contain' : 'not.contain',
+        messages.manage.catalog.accessRESTRICTED
+      ) // user not admin on object -> object permissions relevant in top-level catalog collection
+    cy.get(`[data-cy="actions-dropdown-${data.SEML.title}"]`).realClick()
+    cy.get(`[data-cy="import-object-${data.SEML.title}"]`).should('not.exist') // restricted objects cannot be imported
+    if (elementOwnership) {
+      cy.get(`[data-cy="share-object-${data.SEML.title}"]`).click()
+      cy.get('[data-cy="close-share-object"]').click()
+    } else {
+      cy.get(`[data-cy="request-access-${data.SEML.title}"]`).click()
+      cy.get('[data-cy="cancel-request-access"]').click()
+    }
+
+    cy.get(`[data-cy="catalog-object-${data.SEML2.title}"]`)
+      .should('exist')
+      .should(
+        elementOwnership ? 'contain' : 'not.contain',
+        messages.manage.catalog.accessPUBLIC
+      ) // user not admin on object -> object permissions relevant in top-level catalog collection
+    cy.get(`[data-cy="actions-dropdown-${data.SEML2.title}"]`).realClick()
+    if (elementOwnership) {
+      cy.get(`[data-cy="share-object-${data.SEML2.title}"]`).click()
+      cy.get('[data-cy="close-share-object"]').click()
+    } else {
+      cy.get(`[data-cy="import-object-${data.SEML2.title}"]`).should('exist')
+      cy.get(`[data-cy="request-access-${data.SEML2.title}"]`).click()
+      cy.get('[data-cy="cancel-request-access"]').click()
+    }
+
+    // move into catalog collection (public)
+    cy.get(`[data-cy="catalog-object-${data.CCPublic}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(data.CCPublic)
+    cy.get(`[data-cy="catalog-object-${data.SEML.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessRESTRICTED)
+    cy.get(`[data-cy="actions-dropdown-${data.SEML.title}"]`).realClick()
+    if (elementOwnership) {
+      cy.get(`[data-cy="share-object-${data.SEML.title}"]`).click()
+      cy.get('[data-cy="close-share-object"]').click()
+    } else {
+      cy.get(`[data-cy="import-object-${data.SEML.title}"]`).should('not.exist') // restricted objects cannot be imported
+      cy.get(`[data-cy="request-access-${data.SEML.title}"]`).click()
+      cy.get('[data-cy="cancel-request-access"]').click()
+    }
+
+    cy.get(`[data-cy="catalog-object-${data.SEML2.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessPUBLIC)
+    cy.get(`[data-cy="actions-dropdown-${data.SEML2.title}"]`).realClick()
+    if (elementOwnership) {
+      cy.get(`[data-cy="share-object-${data.SEML2.title}"]`).click()
+      cy.get('[data-cy="close-share-object"]').click()
+    } else {
+      cy.get(`[data-cy="import-object-${data.SEML2.title}"]`).should('exist')
+      cy.get(`[data-cy="request-access-${data.SEML2.title}"]`).click()
+      cy.get('[data-cy="cancel-request-access"]').click()
+    }
+    cy.get('[data-cy="leave-catalog-collection"]').click()
+    cy.get(`[data-cy="catalog-object-${data.CCRestricted}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(data.CCRestricted)
+    cy.get(`[data-cy="catalog-object-${data.SEML.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessRESTRICTED)
+    cy.get(`[data-cy="actions-dropdown-${data.SEML.title}"]`).realClick()
+    if (elementOwnership) {
+      cy.get(`[data-cy="share-object-${data.SEML.title}"]`).click()
+      cy.get('[data-cy="close-share-object"]').click()
+    } else {
+      cy.get(`[data-cy="import-object-${data.SEML.title}"]`).should('not.exist') // restricted objects cannot be imported
+      cy.get(`[data-cy="request-access-${data.SEML.title}"]`).click()
+      cy.get('[data-cy="cancel-request-access"]').click()
+    }
+
+    cy.get(`[data-cy="catalog-object-${data.SEML2.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessPUBLIC)
+    cy.get(`[data-cy="actions-dropdown-${data.SEML2.title}"]`).realClick()
+    if (elementOwnership) {
+      cy.get(`[data-cy="share-object-${data.SEML2.title}"]`).click()
+      cy.get('[data-cy="close-share-object"]').click()
+    } else {
+      cy.get(`[data-cy="import-object-${data.SEML2.title}"]`).should('exist')
+      cy.get(`[data-cy="request-access-${data.SEML2.title}"]`).click()
+      cy.get('[data-cy="cancel-request-access"]').click()
+    }
   }
 
   // ! Part 1: Creation of Catalog Collections and Content
   // #region
-  it('Create a new answer collection AC1 in lecturer account', function () {
+  it('Create a new answer collection AC1 in the lecturer account', function () {
     cy.loginLecturer()
     cy.get('[data-cy="analytics"]').should('exist')
     cy.get('[data-cy="resources"]').click()
@@ -110,7 +203,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     )
   })
 
-  it('Create a new answer collection AC2 in pro1 account', function () {
+  it('Create a new answer collection AC2 in the pro1 account', function () {
     cy.loginIndividualCatalyst()
     cy.get('[data-cy="analytics"]').should('exist')
     cy.get('[data-cy="resources"]').click()
@@ -125,6 +218,26 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="answer-collection-${this.data.AC2.name}"]`).should(
       'exist'
     )
+  })
+
+  it('Create two new selection questions in the pro1 account', function () {
+    cy.loginIndividualCatalyst()
+    cy.createQuestionSE({
+      name: this.data.SEML.title,
+      content: this.data.SEML.content,
+      numberOfInputs: this.data.SEML.inputs,
+      collectionName: this.data.AC2.name,
+      userId: Cypress.env('LECTURER_IND_ID'),
+    })
+    cy.get(`[data-cy="element-item-${this.data.SEML.title}"]`).should('exist')
+    cy.createQuestionSE({
+      name: this.data.SEML2.title,
+      content: this.data.SEML2.content,
+      numberOfInputs: this.data.SEML2.inputs,
+      collectionName: this.data.AC2.name,
+      userId: Cypress.env('LECTURER_IND_ID'),
+    })
+    cy.get(`[data-cy="element-item-${this.data.SEML2.title}"]`).should('exist')
   })
 
   it('Create the questions that will be required for this test workflow', function () {
@@ -469,7 +582,7 @@ describe('Test all functionalities of catalog collections and objects contained 
       .contains(messages.manage.sharing.permissionsADMIN)
   })
 
-  it('Add AC2 to both catalog collections with restricted visibility using WRITE / ADMIN permissions respectively', function () {
+  it('Add the second answer collection to both catalog collections with restricted visibility using WRITE / ADMIN permissions respectively', function () {
     cy.loginIndividualCatalyst()
     cy.get('[data-cy="analytics"]').should('exist')
     cy.get('[data-cy="resources"]').click()
@@ -586,13 +699,152 @@ describe('Test all functionalities of catalog collections and objects contained 
     ).contains(messages.manage.catalog.accessPUBLIC)
   })
 
+  it('Add the selection questions to the catalog collections and the top-level catalg collection', function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    // add the two selection questions to the top level of the catalog collection
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-restricted"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessRESTRICTED
+    )
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-0"]'
+    ).click()
+    cy.get('[id="object-selection-catalog-addition"]').contains(
+      this.data.SEML.title
+    )
+    cy.get('[data-cy="submit-add-object-button"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessRESTRICTED)
+
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-public"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessPUBLIC
+    )
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-1"]'
+    ).click()
+    cy.get('[id="object-selection-catalog-addition"]').contains(
+      this.data.SEML2.title
+    )
+    cy.get('[data-cy="submit-add-object-button"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML2.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessPUBLIC)
+
+    // add the selection queestions as public and restricted objects to the public catalog collection
+    cy.get(`[data-cy="catalog-object-${this.data.CCPublic}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(this.data.CCPublic)
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-restricted"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessRESTRICTED
+    )
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-0"]'
+    ).click()
+    cy.get('[id="object-selection-catalog-addition"]').contains(
+      this.data.SEML.title
+    )
+    cy.get('[data-cy="submit-add-object-button"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessRESTRICTED)
+
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-public"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessPUBLIC
+    )
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-1"]'
+    ).click()
+    cy.get('[id="object-selection-catalog-addition"]').contains(
+      this.data.SEML2.title
+    )
+    cy.get('[data-cy="submit-add-object-button"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML2.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessPUBLIC)
+
+    // add the selection questions as public and restricted objects to the restricted catalog collection
+    cy.get('[data-cy="leave-catalog-collection"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.CCRestricted}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(this.data.CCRestricted)
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-restricted"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessRESTRICTED
+    )
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-0"]'
+    ).click()
+    cy.get('[id="object-selection-catalog-addition"]').contains(
+      this.data.SEML.title
+    )
+    cy.get('[data-cy="submit-add-object-button"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessRESTRICTED)
+
+    cy.get('[data-cy="add-object-to-catalog-button"]').click()
+    cy.get('[data-cy="object-type-selection"]').click()
+    cy.get(`[data-cy="object-type-${SharingObjectType.ELEMENT}"]`).click()
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-public"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessPUBLIC
+    )
+    cy.get('[id="object-selection-catalog-addition"]').click()
+    cy.get(
+      '[id="react-select-object-selection-catalog-addition-option-1"]'
+    ).click()
+    cy.get('[id="object-selection-catalog-addition"]').contains(
+      this.data.SEML2.title
+    )
+    cy.get('[data-cy="submit-add-object-button"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.SEML2.title}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessPUBLIC)
+  })
+
   it('Verify that the permissions on the catalog collections are correctly set for lecturer', function () {
     // test owner privileges on public catalog collection (share, transfer ownership, delete, edit)
     cy.loginLecturer()
     cy.get('[data-cy="analytics"]').should('exist')
     cy.get('[data-cy="resources"]').click()
     cy.get('[data-cy="catalog"]').click()
-    verifyAdminOwnerPermissionsCCPublic({ data: this.data, ownership: true })
+    verifyAdminOwnerPermissionsCCPublic({
+      data: this.data,
+      ownership: true,
+      elementOwnership: false,
+    })
 
     // minimal testing of owner privileges on restricted catalog collection
     cy.get('[data-cy="leave-catalog-collection"]').click()
@@ -618,7 +870,11 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get('[data-cy="catalog"]').click()
 
     // test availability of ADMIN permissions for user pro1 on public catalog collection
-    verifyAdminOwnerPermissionsCCPublic({ data: this.data, ownership: false })
+    verifyAdminOwnerPermissionsCCPublic({
+      data: this.data,
+      ownership: false,
+      elementOwnership: true,
+    })
 
     // test availability of WRITE permissions for user pro1 on restricted catalog collection (can modify object assignments)
     cy.get('[data-cy="leave-catalog-collection"]').click()
@@ -656,7 +912,10 @@ describe('Test all functionalities of catalog collections and objects contained 
     ).click()
     cy.get('[data-cy="cancel-removal"]').click()
   })
+  // #endregion
 
+  // ! Part 3: Object Sharing
+  // #region
   it('Verify that user pro2 without permissions on the public catalog collection can see and request / import content', function () {
     cy.loginInstitutionalCatalyst()
     cy.get('[data-cy="analytics"]').should('exist')
@@ -692,6 +951,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get('[data-cy="resources"]').click()
     cy.get('[data-cy="catalog"]').click()
     cy.get(`[data-cy="catalog-object-${this.data.CCPublic}"]`).click() // navigate back to catalog collection
+    cy.logoutLecturer()
   })
 
   it('Verify that user pro3 can see and request access to objects in restricted answer collection with READ permissions', function () {
@@ -717,10 +977,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="request-access-${this.data.AC2.name}"]`).click()
     cy.get(`[data-cy="cancel-request-access"]`).click()
   })
-  // #endregion
 
-  // ! Part 3: Object Sharing
-  // #region
   it('Verify that the permissions on the objects themselves (sharing, etc.) are determined by object access', function () {
     // main lecturer - OWNER of AC1 and no access to AC2 with corresponding sharing permissions
     cy.loginLecturer()
@@ -1362,6 +1619,17 @@ describe('Test all functionalities of catalog collections and objects contained 
 
   // ! Cleanup
   // #region
+  it('Cleanup: Delete all questions that have been created', function () {
+    cy.loginLecturer()
+    cy.deleteElement({ elementName: this.data.SC.title })
+    cy.deleteElement({ elementName: this.data.SCML.title })
+    cy.logoutLecturer()
+
+    cy.loginIndividualCatalyst()
+    cy.deleteElement({ elementName: this.data.SEML.title })
+    cy.deleteElement({ elementName: this.data.SEML2.title })
+  })
+
   it('Cleanup: Remove the shared answer collection from all accounts and delete it', function () {
     // remove the shared answer collections from pro1
     cy.loginIndividualCatalyst()
@@ -1426,12 +1694,6 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="live-quiz-${this.data.liveQuiz.template.name}"]`).should(
       'not.exist'
     )
-  })
-
-  it('Cleanup: Delete all questions that have been created', function () {
-    cy.loginLecturer()
-    cy.deleteElement({ elementName: this.data.SC.title })
-    cy.deleteElement({ elementName: this.data.SCML.title })
   })
 
   it('Cleanup: Remove the two catalog collections through the lecturer account (owner)', function () {

--- a/cypress/cypress/support/commands.ts
+++ b/cypress/cypress/support/commands.ts
@@ -590,7 +590,7 @@ interface DeleteElementArgs {
 }
 
 Cypress.Commands.add('deleteElement', ({ elementName }: DeleteElementArgs) => {
-  cy.get(`[data-cy="actions-element-${elementName}"]`).click()
+  cy.get(`[data-cy="actions-element-${elementName}"]`).first().realClick()
   cy.get(`[data-cy="delete-element-${elementName}"]`).first().click()
   cy.get('[data-cy="confirm-question-deletion"]').click()
 })

--- a/packages/graphql/src/services/questions.ts
+++ b/packages/graphql/src/services/questions.ts
@@ -488,6 +488,7 @@ export async function deleteQuestion(
           isDeleted: true,
           answerCollection: { disconnect: true },
           answerCollectionItems: { set: [] },
+          directPermissions: { deleteMany: {} }, // delete all direct permissions on the element
         },
       })
 

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -260,7 +260,7 @@ export async function seedElements(
       name: 'SC Element',
       content: 'SC Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 
@@ -270,7 +270,7 @@ export async function seedElements(
       name: 'MC Element',
       content: 'MC Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 
@@ -280,7 +280,7 @@ export async function seedElements(
       name: 'KP Element',
       content: 'KP Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 
@@ -290,7 +290,7 @@ export async function seedElements(
       name: 'NR Element',
       content: 'NR Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 
@@ -300,7 +300,7 @@ export async function seedElements(
       name: 'FT Element',
       content: 'FT Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 
@@ -310,7 +310,7 @@ export async function seedElements(
       name: 'SE Element',
       content: 'SE Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
       answerCollectionId: AC.id,
     },
   })
@@ -321,7 +321,7 @@ export async function seedElements(
       name: 'CS Element',
       content: 'CS Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
       answerCollectionId: AC.id,
       answerCollectionItems: {
         connect: [{ id: AC.entries[1]!.id }, { id: AC.entries[2]!.id }],
@@ -335,7 +335,7 @@ export async function seedElements(
       name: 'FC Element',
       content: 'FC Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 
@@ -345,7 +345,7 @@ export async function seedElements(
       name: 'CT Element',
       content: 'CT Content',
       options: {},
-      ownerId: userContext.user.id,
+      ownerId: userContext.user.sub,
     },
   })
 

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -226,7 +226,13 @@ export async function seedAnswerCollections(
   return collections as AnswerCollection[]
 }
 
-// TODO: docstring
+/**
+ * Seeds the database with different types of elements for testing
+ *
+ * @param userContext - The user context containing the Prisma client and user information
+ * @param answerCollectionId - The ID of the answer collection to associate with certain elements
+ * @returns An object containing all created elements (SC, MC, KP, NR, FT, SE, CS, FC, CT)
+ */
 export async function seedElements(
   userContext,
   answerCollectionId: number
@@ -432,7 +438,16 @@ export async function seedAnswerCollectionPermissions(
   await recomputeDerivedPermissions({ answerCollectionId: AC2Id }, prisma)
 }
 
-// TODO: docstring
+/**
+ * Seeds catalog collection permissions for testing
+ *
+ * Creates user permissions (READ, WRITE, ADMIN) for users 2, 3, and 4 on specified
+ * public and restricted catalog collections.
+ *
+ * @param prisma - Prisma client instance
+ * @param publicId - ID of the public catalog collection
+ * @param restrictedId - ID of the restricted catalog collection
+ */
 export async function seedCatalogCollectionPermissions(
   prisma: PrismaClient,
   publicId: string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded catalog workflow tests to cover creation and management of selection questions with various access levels.
  - Added comprehensive sharing and access request workflows for elements in restricted and public catalog collections.
  - Improved permission verification and test cleanup for catalog collections and contained objects.
  - Enhanced test clarity with refined case titles and additional user session handling.
  - Merged test data fixtures for streamlined element operations testing.
  - Updated element deletion command for improved interaction reliability.
  - Added cleanup steps to ensure proper deletion of created elements and answer collections.

- **Documentation**
  - Added detailed documentation to helper functions used for test data seeding and permission setup.

- **Bug Fixes**
  - Ensured deletion of direct permissions when soft deleting questions to maintain data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->