### PR TITLE
enhance(apps/frontend-manage): add separate confirmation step for permission revocation including hint to derived permissions

### DIFF
--- a/apps/frontend-manage/src/components/sharing/ExistingPermissionEntries.tsx
+++ b/apps/frontend-manage/src/components/sharing/ExistingPermissionEntries.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import usePermissionLevelSelection from '../../lib/hooks/usePermissionLevelSelection'
 import ModifyOwnPermissionsModal from './ModifyOwnPermissionsModal'
+import PermissionRevocationModal from './PermissionRevocationModal'
 
 function ExistingPermissionEntries({
   type,
@@ -43,6 +44,16 @@ function ExistingPermissionEntries({
     action: 'change',
   })
 
+  // state for managing the permission revocation modal
+  const [revocationModal, setRevocationModal] = useState<{
+    open: boolean
+    permissionId?: number
+    username?: string
+    userGroup?: string
+  }>({
+    open: false,
+  })
+
   // handle access level change with confirmation for own permissions
   const handlePermissionLevelChange = async (
     permissionId: number,
@@ -67,7 +78,9 @@ function ExistingPermissionEntries({
   // handle permission removal with confirmation for own permissions
   const handleRemovePermission = async (
     permissionId: number,
-    isOwn: boolean
+    isOwn: boolean,
+    username?: string,
+    userGroup?: string
   ) => {
     if (isOwn) {
       setModifyOwnPermissionsModal({
@@ -76,7 +89,12 @@ function ExistingPermissionEntries({
         action: 'remove',
       })
     } else {
-      await onPermissionRemoval(permissionId)
+      setRevocationModal({
+        open: true,
+        permissionId,
+        username,
+        userGroup,
+      })
     }
   }
 
@@ -91,6 +109,11 @@ function ExistingPermissionEntries({
       await onPermissionRemoval(modifyOwnPermissionsModal.permissionId!)
     }
     setModifyOwnPermissionsModal({ ...modifyOwnPermissionsModal, open: false })
+  }
+
+  // confirm permission revocation
+  const confirmRevocation = async () => {
+    await onPermissionRemoval(revocationModal.permissionId!)
   }
 
   return (
@@ -152,7 +175,9 @@ function ExistingPermissionEntries({
                 onClick={async () => {
                   await handleRemovePermission(
                     permission.permissionId,
-                    permission.isOwn ?? false
+                    permission.isOwn ?? false,
+                    permission.username ?? undefined,
+                    permission.userGroupName ?? undefined
                   )
                 }}
                 data={{
@@ -178,6 +203,13 @@ function ExistingPermissionEntries({
         onConfirm={confirmModifyOwnPermissions}
         action={modifyOwnPermissionsModal.action}
         newPermissionLevel={modifyOwnPermissionsModal.newPermissionLevel}
+      />
+      <PermissionRevocationModal
+        open={revocationModal.open}
+        onClose={() => setRevocationModal({ ...revocationModal, open: false })}
+        onRevocation={confirmRevocation}
+        username={revocationModal.username}
+        userGroup={revocationModal.userGroup}
       />
     </>
   )

--- a/apps/frontend-manage/src/components/sharing/PermissionRevocationModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/PermissionRevocationModal.tsx
@@ -1,0 +1,80 @@
+import { Button, Modal } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+
+interface PermissionRevocationModalProps {
+  open: boolean
+  onClose: () => void
+  onRevocation: () => Promise<void>
+  username?: string
+  userGroup?: string
+}
+
+function PermissionRevocationModal({
+  open,
+  onClose,
+  onRevocation,
+  username,
+  userGroup,
+}: PermissionRevocationModalProps) {
+  const t = useTranslations()
+  const [isRevoking, setIsRevoking] = useState(false)
+
+  const handleRevocation = async () => {
+    setIsRevoking(true)
+    try {
+      await onRevocation()
+    } finally {
+      setIsRevoking(false)
+      onClose()
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={t('manage.sharing.revokeDirectPermission')}
+      className={{ content: 'max-w-lg' }}
+      dataCloseButton={{ cy: 'close-permission-revocation-modal' }}
+      hideCloseButton
+    >
+      <div className="mb-6">
+        <p className="mb-2 text-base">
+          {username
+            ? t.rich('manage.sharing.revokeUserPermission', {
+                username,
+                b: (text) => <b>{text}</b>,
+              })
+            : t.rich('manage.sharing.revokeGroupPermission', {
+                groupName: userGroup,
+                b: (text) => <b>{text}</b>,
+              })}
+        </p>
+        <p className="text-sm text-gray-600">
+          {t('manage.sharing.derivedPermissionWarning')}
+        </p>
+      </div>
+
+      <div className="flex flex-row justify-between gap-2">
+        <Button
+          onClick={onClose}
+          disabled={isRevoking}
+          data={{ cy: 'cancel-revocation' }}
+        >
+          <Button.Label>{t('shared.generic.cancel')}</Button.Label>
+        </Button>
+        <Button
+          destructive
+          onClick={handleRevocation}
+          loading={isRevoking}
+          data={{ cy: 'confirm-revocation' }}
+        >
+          <Button.Label>{t('shared.generic.confirm')}</Button.Label>
+        </Button>
+      </div>
+    </Modal>
+  )
+}
+
+export default PermissionRevocationModal

--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1126,6 +1126,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(
       `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).click()
+    cy.get('[data-cy="confirm-revocation"]').click()
     cy.get(
       `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('not.exist')

--- a/cypress/cypress/e2e/T-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/T-resources-workflow.cy.ts
@@ -602,6 +602,11 @@ describe('Create, edit and share answer collections', function () {
     cy.get(
       `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).click()
+    cy.get('[data-cy="cancel-revocation"]').click()
+    cy.get(
+      `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+    ).click()
+    cy.get('[data-cy="confirm-revocation"]').click()
     cy.get(
       `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('not.exist')
@@ -2335,6 +2340,7 @@ describe('Create, edit and share answer collections', function () {
     cy.get(
       `[data-cy="revoke-permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
     ).click()
+    cy.get('[data-cy="confirm-revocation"]').click()
     cy.get(
       `[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
     ).should('not.exist')
@@ -2352,6 +2358,7 @@ describe('Create, edit and share answer collections', function () {
     cy.get(
       `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
     ).click()
+    cy.get('[data-cy="confirm-revocation"]').click()
     cy.get(
       `[data-cy="revoke-permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('not.be.disabled')

--- a/packages/graphql/src/services/resources.ts
+++ b/packages/graphql/src/services/resources.ts
@@ -208,7 +208,7 @@ export async function getSingleAnswerCollection(
       },
       permissions: { where: { userId: ctx.user.sub } },
       owner: { select: { shortname: true } },
-      _count: { select: { directPermissions: true } },
+      _count: { select: { permissions: true } },
     },
   })
 
@@ -232,9 +232,7 @@ export async function getSingleAnswerCollection(
       ...entry,
       numSolutionUsages: entry._count.itemUsages + entry._count.templateUsages,
     })),
-    numSharedUsers: isManager
-      ? collection._count?.directPermissions
-      : undefined,
+    numSharedUsers: isManager ? collection._count.permissions - 1 : undefined,
     permissionLevel: permissionLevel ?? DB.PermissionLevel.READ,
     ownerShortname: collection.owner?.shortname,
     isOwner,
@@ -311,7 +309,7 @@ export async function getAnswerCollectionsInfo(ctx: ContextWithUser) {
     return {
       ...collection,
       numOfEntries: collection._count.entries,
-      numSharedUsers: collection._count.permissions,
+      numSharedUsers: collection._count.permissions - 1,
       permissionLevel: object.permissionLevel,
       ownerShortname: collection.owner?.shortname,
       isOwner: object.permissionLevel === DB.PermissionLevel.OWNER,

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2700,9 +2700,9 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Beim Entfernen des Objekts ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support.',
       revokeDirectPermission: 'Direkten Zugriff entziehen',
       revokeUserPermission:
-        'Bitte bestätigen Sie, dass Sie den direkten Zugriff auf diese Ressource Nutzer <b>{username}</b> entziehen möchten.',
+        'Bitte bestätigen Sie, dass Sie Nutzer <b>{username}</b> den direkten Zugriff auf dieses Objekt entziehen möchten.',
       revokeGroupPermission:
-        'Bitte bestätigen Sie, dass Sie den direkten Zugriff auf diese Ressource der Nutzergruppe <b>{groupName}</b> entziehen möchten.',
+        'Bitte bestätigen Sie, dass Sie der Nutzergruppe <b>{groupName}</b> den direkten Zugriff auf dieses Objekt entziehen möchten.',
       derivedPermissionWarning:
         'Achtung: Das Entziehen der direkten Zugriffsrechte auf ein Objekt entfernt möglicherweise nicht den Zugriff des Nutzers darauf. Wenn ein Nutzer Zugriff auf andere Objekte hat, die von diesem Objekt abhängen, erhält er eine abgeleitete Berechtigung, die im unteren Bereich des Freigabedialogs eingesehen werden kann.',
     },

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2698,6 +2698,13 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Das Objekt wurde erfolgreich aus Ihrem Konto entfernt.',
       removalFailed:
         'Beim Entfernen des Objekts ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support.',
+      revokeDirectPermission: 'Direkten Zugriff entziehen',
+      revokeUserPermission:
+        'Bitte bestätigen Sie, dass Sie den direkten Zugriff auf diese Ressource Nutzer <b>{username}</b> entziehen möchten.',
+      revokeGroupPermission:
+        'Bitte bestätigen Sie, dass Sie den direkten Zugriff auf diese Ressource der Nutzergruppe <b>{groupName}</b> entziehen möchten.',
+      derivedPermissionWarning:
+        'Achtung: Das Entziehen der direkten Zugriffsrechte auf ein Objekt entfernt möglicherweise nicht den Zugriff des Nutzers darauf. Wenn ein Nutzer Zugriff auf andere Objekte hat, die von diesem Objekt abhängen, erhält er eine abgeleitete Berechtigung, die im unteren Bereich des Freigabedialogs eingesehen werden kann.',
     },
     groupActivity: {
       activityMissingOrNotCompleted:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2672,6 +2672,13 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         'The object has been removed successfully from your account.',
       removalFailed:
         'An error occurred while removing the object. Please try again or contact the support.',
+      revokeDirectPermission: 'Revoke Direct Access',
+      revokeUserPermission:
+        'Please confirm that you want to remove the direct access to this resource for user <b>{username}</b>.',
+      revokeGroupPermission:
+        'Please confirm that you want to remove the direct access to this resource for the user group <b>{groupName}</b>.',
+      derivedPermissionWarning:
+        "Caution: Removing the direct access rights to an object might not completely remove a user's access to it. In case a user has access to other objects that depend on this one, they will be granted a derived permission, which can be inspected at the bottom of the sharing dialog.",
     },
     groupActivity: {
       activityMissingOrNotCompleted:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation dialog when revoking permissions from other users or groups, improving clarity and control in the sharing interface.
  - Introduced warnings to inform users when revoking direct access may not fully remove permissions due to derived access.

- **Bug Fixes**
  - Standardized the calculation of shared user counts to exclude the owner, ensuring more accurate sharing information.

- **Tests**
  - Updated end-to-end tests to cover the new confirmation step in the permission revocation workflow.

- **Documentation**
  - Enhanced English and German localization with new messages related to permission revocation and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->