### PR TITLE
chore(packages/graphql): add unit testing to all existing sharing functionalities related to user groups

### DIFF
--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -3435,9 +3435,16 @@ export async function shareObject(
       isOwn: false,
     }
   } else if (typeof userGroupId !== 'undefined' && userGroupId !== null) {
-    // check if the user group exists and if the triggering member is a member, admin or owner of it
+    // check if the user group exists and if the triggering user is a member, admin or owner of it
     const userGroup = await ctx.prisma.userGroup.findUnique({
-      where: { id: userGroupId },
+      where: {
+        id: userGroupId,
+        OR: [
+          { ownerId: ctx.user.sub },
+          { admins: { some: { id: ctx.user.sub } } },
+          { members: { some: { id: ctx.user.sub } } },
+        ],
+      },
       select: { id: true, name: true },
     })
 

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -2137,12 +2137,13 @@ export async function changeObjectPermissionLevel(
   }
 
   // fetch the user group of the updated permission
-  const userGroup = previousPermission.userGroupId
-    ? await ctx.prisma.userGroup.findUnique({
-        where: { id: previousPermission.userGroupId },
-        include: { members: true, admins: true },
-      })
-    : null
+  const userGroup =
+    previousPermission.userGroupId !== null
+      ? await ctx.prisma.userGroup.findUnique({
+          where: { id: previousPermission.userGroupId },
+          include: { members: true, admins: true },
+        })
+      : null
 
   // execute the update and recomputation in a single transaction
   const permission = await ctx.prisma.$transaction(async (prisma) => {
@@ -2404,12 +2405,14 @@ export async function revokeObjectAccess(
     },
   })
 
-  const userGroup = permission?.userGroupId
-    ? await ctx.prisma.userGroup.findUnique({
-        where: { id: permission.userGroupId },
-        include: { members: true, admins: true },
-      })
-    : null
+  const userGroup =
+    typeof permission?.userGroupId !== 'undefined' &&
+    permission?.userGroupId !== null
+      ? await ctx.prisma.userGroup.findUnique({
+          where: { id: permission.userGroupId },
+          include: { members: true, admins: true },
+        })
+      : null
 
   if (!permission || permission.id !== permissionId) {
     return null

--- a/packages/graphql/test/catalogSharing.test.ts
+++ b/packages/graphql/test/catalogSharing.test.ts
@@ -1307,12 +1307,17 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(catalogObjects.length).toBe(3)
 
     const catalogObject1 = catalogObjects.find(
-      (object) => object.id === AC1!.id
+      (object) =>
+        object.id === AC1!.id &&
+        object.objectType === SharingObjectType.ANSWER_COLLECTION
     )
     const catalogObject2 = catalogObjects.find(
       (object) => object.uuid === activityId1
     )
-    const catalogObject3 = catalogObjects.find((object) => object.id === SC.id)
+    const catalogObject3 = catalogObjects.find(
+      (object) =>
+        object.id === SC.id && object.objectType === SharingObjectType.ELEMENT
+    )
     expect(catalogObject1).toBeDefined()
     expect(catalogObject2).toBeDefined()
     expect(catalogObject3).toBeDefined()
@@ -1320,11 +1325,13 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(catalogObject1!.id).toBe(AC1!.id)
     expect(catalogObject1!.objectType).toBe(SharingObjectType.ANSWER_COLLECTION)
     expect(catalogObject1!.assignmentId).toBe(assignment1.id)
+
     expect(catalogObject2!.uuid).toBe(activityId1)
     expect(catalogObject2!.objectType).toBe(
       SharingObjectType.LIVE_QUIZ_TEMPLATE
     )
     expect(catalogObject2!.assignmentId).toBe(assignment2.id)
+
     expect(catalogObject3!.id).toBe(SC.id)
     expect(catalogObject3!.objectType).toBe(SharingObjectType.ELEMENT)
     expect(catalogObject3!.assignmentId).toBe(assignment3.id)
@@ -1338,12 +1345,17 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(catalogObjects2.length).toBe(3)
 
     const catalogObject4 = catalogObjects2.find(
-      (object) => object.id === AC2!.id
+      (object) =>
+        object.id === AC2!.id &&
+        object.objectType === SharingObjectType.ANSWER_COLLECTION
     )
     const catalogObject5 = catalogObjects2.find(
       (object) => object.uuid === activityId2
     )
-    const catalogObject6 = catalogObjects2.find((object) => object.id === MC.id)
+    const catalogObject6 = catalogObjects2.find(
+      (object) =>
+        object.id === MC.id && object.objectType === SharingObjectType.ELEMENT
+    )
     expect(catalogObject4).toBeDefined()
     expect(catalogObject5).toBeDefined()
     expect(catalogObject6).toBeDefined()
@@ -1665,9 +1677,8 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     )
   })
 
-  it('Verify that catalog collections can be directly shared with other users and user groups', async () => {
-    const { publicCatalog, restrictedCatalog } =
-      await seedCatalogCollections(userOneCtx)
+  it('Verify that catalog collections can be directly shared with individual users', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
 
     // verify that the function fails, if the provided user does not exist
     const failure1 = await shareObject(
@@ -1814,8 +1825,152 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(auditLogEntry3!.message).toBe(
       `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} to user ${userFour.id}.`
     )
+  })
 
-    // TODO: as soon as user groups are available, extend the corresponding coverage of this unit test
+  it('Verify that catalog collections can be shared with user groups', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+
+    // create a user group with users 1 (ADMIN), 2, and 3 and grant WRITE permissions to them
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userOne.id,
+        members: {
+          connect: [{ id: userTwo.id }, { id: userThree.id }],
+        },
+      },
+    })
+    const groupPermission = await shareObject(
+      {
+        catalogCollectionId: publicCatalog.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+      userOneCtx
+    )
+    expect(groupPermission).toBeTruthy()
+    expect(groupPermission!.userGroupId).toBe(group.id)
+    expect(groupPermission!.userGroupName).toBe(group.name)
+
+    // create a user group with users 1, 3 (ADMIN), and 4 and grant ADMIN permissions to them
+    const group2 = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group 2',
+        ownerId: userThree.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userFour.id }],
+        },
+      },
+    })
+    const groupPermission2 = await shareObject(
+      {
+        catalogCollectionId: publicCatalog.id,
+        userGroupId: group2.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+      userOneCtx
+    )
+    expect(groupPermission2).toBeTruthy()
+    expect(groupPermission2!.userGroupId).toBe(group2.id)
+    expect(groupPermission2!.userGroupName).toBe(group2.name)
+
+    // verify that the correct direct permissions have been created in the database
+    const dbPermission1 = await prisma.permission.findUnique({
+      where: {
+        catalogCollectionId_userGroupId: {
+          catalogCollectionId: publicCatalog.id,
+          userGroupId: group.id,
+        },
+      },
+    })
+    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const dbPermission2 = await prisma.permission.findUnique({
+      where: {
+        catalogCollectionId_userGroupId: {
+          catalogCollectionId: publicCatalog.id,
+          userGroupId: group2.id,
+        },
+      },
+    })
+    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct derived permissions have been created in the database
+    // OWNER for user 1, WRITE for user 2, ADMIN for users 3 and 4
+    const derivedPermission1 = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
+
+    const derivedPermission2 = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const derivedPermission3 = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    const derivedPermission4 = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(derivedPermission4).toBeDefined()
+    expect(derivedPermission4?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct audit log entries have been created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} to user group ${group.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group2.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} to user group ${group2.id}.`
+    )
   })
 
   it('Verify that access requests to catalog collections are shown correctly to owners and admins', async () => {

--- a/packages/graphql/test/catalogSharing.test.ts
+++ b/packages/graphql/test/catalogSharing.test.ts
@@ -1539,7 +1539,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     )
   })
 
-  it('Verify that direct permissions on the catalog collection can be revoked without conditions', async () => {
+  it('Verify that direct individual permissions on the catalog collection can be revoked without conditions', async () => {
     const { publicCatalog, restrictedCatalog } =
       await seedCatalogCollections(userOneCtx)
 
@@ -1605,6 +1605,167 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(audigLogEntry).toBeTruthy()
     expect(audigLogEntry!.message).toBe(
       `Permission revoked for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
+  })
+
+  it('Verify that direct group permissions on the catalog collection can be revoked without conditions', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+
+    // create a user group with users 1, 2, 3, and 4 (OWNER)
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userFour.id,
+        members: {
+          connect: [
+            { id: userOne.id },
+            { id: userTwo.id },
+            { id: userThree.id },
+          ],
+        },
+      },
+    })
+
+    // grant WRITE permissions to the user group
+    const groupPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.WRITE,
+        userGroupId: group.id,
+        catalogCollectionId: publicCatalog.id,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+
+    // verify that all users have derived permissions for the catalog collection
+    const permissionUserOne = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(permissionUserOne).toBeDefined()
+    expect(permissionUserOne?.permissionLevel).toBe(PermissionLevel.OWNER)
+    expect(permissionUserOne?.directPermissionId).toBeNull()
+
+    const permissionUserTwo = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(permissionUserTwo).toBeDefined()
+    expect(permissionUserTwo?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserTwo?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserThree = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(permissionUserThree).toBeDefined()
+    expect(permissionUserThree?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserThree?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserFour = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(permissionUserFour).toBeDefined()
+    expect(permissionUserFour?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserFour?.directPermissionId).toBe(groupPermission.id)
+
+    // revoke the permission
+    const deletedPermissionId = await revokeObjectAccess(
+      {
+        catalogCollectionId: publicCatalog.id,
+        permissionId: groupPermission.id,
+      },
+      userOneCtx
+    )
+    expect(deletedPermissionId).toBe(groupPermission.id)
+
+    // verify that both the acutal permission and the derived ones have been deleted
+    const deletedPermission = await prisma.permission.findUnique({
+      where: {
+        id: groupPermission.id,
+      },
+    })
+    expect(deletedPermission).toBeNull()
+
+    const persistentPermissionUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          catalogCollectionId_userId: {
+            catalogCollectionId: publicCatalog.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(persistentPermissionUserOne).toBeDefined()
+    expect(persistentPermissionUserOne?.permissionLevel).toBe(
+      PermissionLevel.OWNER
+    )
+
+    const deletedPermissionUserTwo = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(deletedPermissionUserTwo).toBeNull()
+
+    const deletedPermissionUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          catalogCollectionId_userId: {
+            catalogCollectionId: publicCatalog.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(deletedPermissionUserThree).toBeNull()
+
+    const deletedPermissionUserFour = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          catalogCollectionId_userId: {
+            catalogCollectionId: publicCatalog.id,
+            userId: userFour.id,
+          },
+        },
+      }
+    )
+    expect(deletedPermissionUserFour).toBeNull()
+
+    // verify that an audit log entry has been created for this permission revocation
+    const audigLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_REVOKED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(audigLogEntry).toBeTruthy()
+    expect(audigLogEntry!.message).toBe(
+      `Permission revoked for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) by owner / admin ${userOne.id} for user group ${group.id}.`
     )
   })
 

--- a/packages/graphql/test/catalogSharing.test.ts
+++ b/packages/graphql/test/catalogSharing.test.ts
@@ -1376,7 +1376,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
 
   // ! Catalog Collection Sharing
   // #region
-  it('Change the permission level of direct permissions on a catalog collection', async () => {
+  it('Change the permission level of a direct individual permission on a catalog collection', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
 
     // grant READ permissions to user 2
@@ -1427,6 +1427,115 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(auditLogEntry).toBeTruthy()
     expect(auditLogEntry!.message).toBe(
       `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) through owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
+  })
+
+  it('Change the permission level of a direct user group permission on a catalog collection', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+
+    // create a user group with users 1, 2, and 3 (ADMIN)
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userThree.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userTwo.id }],
+        },
+      },
+    })
+
+    // grant READ permissions to the user group
+    const readPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.READ,
+        userGroupId: group.id,
+        catalogCollectionId: publicCatalog.id,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+
+    // change the permission level to WRITE
+    const success = await changeObjectPermissionLevel(
+      {
+        catalogCollectionId: publicCatalog.id,
+        permissionId: readPermission.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+      userOneCtx
+    )
+    expect(success).toBe(true)
+
+    // verify that the permission level has been updated in the database
+    const updatedPermission = await prisma.permission.findUnique({
+      where: {
+        id: readPermission.id,
+      },
+    })
+    expect(updatedPermission).toBeDefined()
+    expect(updatedPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(updatedPermission?.catalogCollectionId).toBe(publicCatalog.id)
+    expect(updatedPermission?.userGroupId).toBe(group.id)
+
+    // verify that the individual permissions of the user group members have been updated
+    const ownerPerimission = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(ownerPerimission).toBeDefined()
+    expect(ownerPerimission?.permissionLevel).toBe(PermissionLevel.OWNER)
+
+    const userTwoPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(userTwoPermission).toBeDefined()
+    expect(userTwoPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const userThreePermission = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(userThreePermission).toBeDefined()
+    expect(userThreePermission?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const userFourPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        catalogCollectionId_userId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(userFourPermission).toBeNull()
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_MODIFIED,
+        objectId: publicCatalog.id,
+        objectType: ObjectType.CATALOG_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.CATALOG_COLLECTION} (ID ${publicCatalog.id}) through owner / admin ${userOne.id} for user group ${group.id}.`
     )
   })
 

--- a/packages/graphql/test/elementSharing.test.ts
+++ b/packages/graphql/test/elementSharing.test.ts
@@ -563,6 +563,385 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     expect(derivedPermission6!.derived).toBe(true)
   })
 
+  it('Verify that direct group permissions on the element can be revoked without conditions and derived permissions are revoked as well', async () => {
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SE } = await seedElements(userOneCtx, AC!.id)
+
+    // create a user group with users 1, 2, 3, 4, and 5 (OWNER)
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userFive.id,
+        members: {
+          connect: [
+            { id: userOne.id },
+            { id: userTwo.id },
+            { id: userThree.id },
+            { id: userFour.id },
+          ],
+        },
+      },
+    })
+
+    // grant WRITE permissions to the user group
+    const groupPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.WRITE,
+        userGroupId: group.id,
+        elementId: SE.id,
+      },
+    })
+    await recomputeDerivedPermissions({ elementId: SE.id }, prisma)
+
+    // grant direct individual READ permissions to user 2 and 3 on the answer collection and element respectively
+    const elementReadPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.READ,
+        userId: userTwo.id,
+        elementId: SE.id,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { elementId: SE.id, userId: userTwo.id },
+      prisma
+    )
+    const answerCollectionReadPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.READ,
+        userId: userThree.id,
+        answerCollectionId: AC!.id,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { answerCollectionId: AC!.id, userId: userThree.id },
+      prisma
+    )
+
+    // verify that all users have derived permissions on the element
+    const permissionUserOne = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(permissionUserOne).toBeDefined()
+    expect(permissionUserOne?.permissionLevel).toBe(PermissionLevel.OWNER)
+    expect(permissionUserOne?.directPermissionId).toBeNull()
+
+    const permissionUserTwo = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(permissionUserTwo).toBeDefined()
+    expect(permissionUserTwo?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserTwo?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserThree = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(permissionUserThree).toBeDefined()
+    expect(permissionUserThree?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserThree?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserFour = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(permissionUserFour).toBeDefined()
+    expect(permissionUserFour?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserFour?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserFive = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userFive.id,
+        },
+      },
+    })
+    expect(permissionUserFive).toBeDefined()
+    expect(permissionUserFive?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserFive?.directPermissionId).toBe(groupPermission.id)
+
+    // verify that derived permissions on the contained answer collection exist
+    const ACDerivedPermissionUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(ACDerivedPermissionUserOne).toBeDefined()
+    expect(ACDerivedPermissionUserOne?.permissionLevel).toBe(
+      PermissionLevel.OWNER
+    )
+    expect(ACDerivedPermissionUserOne?.directPermissionId).toBeNull()
+    expect(ACDerivedPermissionUserOne?.derived).toBe(false)
+
+    const ACDerivedPermissionUserTwo =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(ACDerivedPermissionUserTwo).toBeDefined()
+    expect(ACDerivedPermissionUserTwo?.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(ACDerivedPermissionUserTwo?.directPermissionId).toBe(
+      groupPermission.id
+    )
+    expect(ACDerivedPermissionUserTwo?.derived).toBe(true)
+
+    const ACDerivedPermissionUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(ACDerivedPermissionUserThree).toBeDefined()
+    expect(ACDerivedPermissionUserThree?.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(ACDerivedPermissionUserThree?.directPermissionId).toBe(
+      answerCollectionReadPermission.id
+    )
+    expect(ACDerivedPermissionUserThree?.derived).toBe(false)
+
+    const ACDerivedPermissionUserFour =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userFour.id,
+          },
+        },
+      })
+    expect(ACDerivedPermissionUserFour).toBeDefined()
+    expect(ACDerivedPermissionUserFour?.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(ACDerivedPermissionUserFour?.directPermissionId).toBe(
+      groupPermission.id
+    )
+    expect(ACDerivedPermissionUserFour?.derived).toBe(true)
+
+    const ACDerivedPermissionUserFive =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userFive.id,
+          },
+        },
+      })
+    expect(ACDerivedPermissionUserFive).toBeDefined()
+    expect(ACDerivedPermissionUserFive?.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(ACDerivedPermissionUserFive?.directPermissionId).toBe(
+      groupPermission.id
+    )
+    expect(ACDerivedPermissionUserFive?.derived).toBe(true)
+
+    // revoke the permission
+    const deletedPermissionId = await revokeObjectAccess(
+      {
+        elementId: SE.id,
+        permissionId: groupPermission.id,
+      },
+      userOneCtx
+    )
+    expect(deletedPermissionId).toBe(groupPermission.id)
+
+    // verify that both the acutal permission and the derived ones have been deleted
+    const deletedPermission = await prisma.permission.findUnique({
+      where: {
+        id: groupPermission.id,
+      },
+    })
+    expect(deletedPermission).toBeNull()
+
+    const persistentPermissionUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(persistentPermissionUserOne).toBeDefined()
+    expect(persistentPermissionUserOne?.permissionLevel).toBe(
+      PermissionLevel.OWNER
+    )
+    expect(persistentPermissionUserOne?.directPermissionId).toBeNull()
+    expect(persistentPermissionUserOne?.derived).toBe(false)
+
+    const deletedPermissionUserTwo = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(deletedPermissionUserTwo).toBeDefined()
+    expect(deletedPermissionUserTwo?.permissionLevel).toBe(PermissionLevel.READ)
+    expect(deletedPermissionUserTwo?.directPermissionId).toBe(
+      elementReadPermission.id
+    )
+    expect(deletedPermissionUserTwo?.derived).toBe(false)
+
+    const deletedPermissionUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(deletedPermissionUserThree).toBeNull()
+
+    const deletedPermissionUserFour = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userFour.id,
+          },
+        },
+      }
+    )
+    expect(deletedPermissionUserFour).toBeNull()
+
+    const deletedPermissionUserFive = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userFive.id,
+          },
+        },
+      }
+    )
+    expect(deletedPermissionUserFive).toBeNull()
+
+    // verify that the derived perissions on the answer collection only persist for user 1, 2 (derived) and 3 (direct)
+    const persistentACPermissionUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(persistentACPermissionUserOne).toBeDefined()
+    expect(persistentACPermissionUserOne?.permissionLevel).toBe(
+      PermissionLevel.OWNER
+    )
+    expect(persistentACPermissionUserOne?.directPermissionId).toBeNull()
+    expect(persistentACPermissionUserOne?.derived).toBe(false)
+
+    const persistentACPermissionUserTwo =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(persistentACPermissionUserTwo).toBeDefined()
+    expect(persistentACPermissionUserTwo?.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(persistentACPermissionUserTwo?.directPermissionId).toBe(
+      elementReadPermission.id
+    )
+    expect(persistentACPermissionUserTwo?.derived).toBe(true)
+
+    const persistentACPermissionUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(persistentACPermissionUserThree).toBeDefined()
+    expect(persistentACPermissionUserThree?.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(persistentACPermissionUserThree?.directPermissionId).toBe(
+      answerCollectionReadPermission.id
+    )
+    expect(persistentACPermissionUserThree?.derived).toBe(false)
+
+    const deletedACPermissionUserFour =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userFour.id,
+          },
+        },
+      })
+    expect(deletedACPermissionUserFour).toBeNull()
+
+    const deletedACPermissionUserFive =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userFive.id,
+          },
+        },
+      })
+    expect(deletedACPermissionUserFive).toBeNull()
+
+    // verify that an audit log entry has been created for this permission revocation
+    const audigLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_REVOKED,
+        objectId: String(SE.id),
+        objectType: ObjectType.ELEMENT,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(audigLogEntry).toBeTruthy()
+    expect(audigLogEntry!.message).toBe(
+      `Permission revoked for ${ObjectType.ELEMENT} (ID ${SE.id}) by owner / admin ${userOne.id} for user group ${group.id}.`
+    )
+  })
+
   it('Test the direct sharing functionality for elements with different permission levels for user groups', async () => {
     const [AC1] = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)

--- a/packages/graphql/test/elementSharing.test.ts
+++ b/packages/graphql/test/elementSharing.test.ts
@@ -86,7 +86,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
   // ! Sharing functionalities for elements
   // #region
-  it('Verify that the level of granted direct permissions can be modified', async () => {
+  it('Verify that the level of granted direct individual permissions can be modified', async () => {
     const [AC1] = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC1!.id)
 
@@ -170,6 +170,167 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     expect(auditLogEntry).toBeTruthy()
     expect(auditLogEntry!.message).toBe(
       `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.ELEMENT} (ID ${SC!.id}) through owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
+  })
+
+  it('Verify that the level of granted direct group permissions can be modified', async () => {
+    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { SE } = await seedElements(userOneCtx, AC1!.id)
+
+    // create a user group with users 1, 2, and 3 (ADMIN)
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userThree.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userTwo.id }],
+        },
+      },
+    })
+
+    // grant individual WRITE permissions to user 2
+    const directPermission = await prisma.permission.create({
+      data: {
+        userId: userTwo.id,
+        elementId: SE.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { elementId: SE.id, userId: userTwo.id },
+      prisma
+    )
+
+    // grant READ permissions to the group
+    const groupPermission = await prisma.permission.create({
+      data: {
+        userGroupId: group.id,
+        elementId: SE.id,
+        permissionLevel: PermissionLevel.READ,
+      },
+    })
+    await recomputeDerivedPermissions({ elementId: SE.id }, prisma)
+
+    // verify that the correct derived permissions have been created in the database
+    // OWNER for user 1, WRITE for user 2, READ for user 3
+    const derivedPermission1 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
+    expect(derivedPermission1?.directPermissionId).toBeNull()
+
+    const derivedPermission2 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(derivedPermission2?.directPermissionId).toBe(directPermission.id)
+
+    const derivedPermission3 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.READ)
+    expect(derivedPermission3?.directPermissionId).toBe(groupPermission.id)
+
+    // change the group permission level to change to ADMIN, overriding individual permissions
+    const success = await changeObjectPermissionLevel(
+      {
+        permissionId: groupPermission!.id,
+        permissionLevel: PermissionLevel.ADMIN,
+        elementId: SE.id,
+      },
+      userOneCtx
+    )
+    expect(success).toBe(true)
+
+    // verify that the direct and derived permissions have been updated correctly
+    const updatedDirectPermission = await prisma.permission.findUnique({
+      where: {
+        elementId_userGroupId: {
+          elementId: SE.id,
+          userGroupId: group.id,
+        },
+      },
+    })
+    expect(updatedDirectPermission).toBeDefined()
+    expect(updatedDirectPermission!.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // OWNER for user 1, ADMIN for user 2, ADMIN for user 3
+    const updatedDerivedPermission1 = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userOne.id,
+          },
+        },
+      }
+    )
+    expect(updatedDerivedPermission1).toBeDefined()
+    expect(updatedDerivedPermission1?.permissionLevel).toBe(
+      PermissionLevel.OWNER
+    )
+
+    const updatedDerivedPermission2 = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userTwo.id,
+          },
+        },
+      }
+    )
+    expect(updatedDerivedPermission2).toBeDefined()
+    expect(updatedDerivedPermission2?.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+
+    const updatedDerivedPermission3 = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          elementId_userId: {
+            elementId: SE.id,
+            userId: userThree.id,
+          },
+        },
+      }
+    )
+    expect(updatedDerivedPermission3).toBeDefined()
+    expect(updatedDerivedPermission3?.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_MODIFIED,
+        objectType: ObjectType.ELEMENT,
+        objectId: String(SE!.id),
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.ADMIN} for ${ObjectType.ELEMENT} (ID ${SE.id}) through owner / admin ${userOne.id} for user group ${group.id}.`
     )
   })
 
@@ -581,13 +742,13 @@ describe('Unit tests for sharing functionalities of elements (questions, content
       where: {
         answerCollectionId_userId: {
           answerCollectionId: AC1!.id,
-          userId: userTwo.id,
+          userId: userOne.id,
         },
       },
     })
     expect(derivedPermission5).toBeTruthy()
-    expect(derivedPermission5!.permissionLevel).toBe(PermissionLevel.ADMIN)
-    expect(derivedPermission5!.directPermissionId).toBe(ACPermission1.id)
+    expect(derivedPermission5!.permissionLevel).toBe(PermissionLevel.OWNER)
+    expect(derivedPermission5!.directPermissionId).toBeNull()
     expect(derivedPermission5!.derived).toBe(false)
 
     const derivedPermission6 = await prisma.derivedPermission.findUnique({

--- a/packages/graphql/test/elementSharing.test.ts
+++ b/packages/graphql/test/elementSharing.test.ts
@@ -173,7 +173,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     )
   })
 
-  it('Test the sharing functionality for elements with different permission levels', async () => {
+  it('Test the direct sharing functionality for elements with different permission levels for individual users', async () => {
     const [AC1] = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
@@ -400,6 +400,234 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     expect(derivedPermission6!.permissionLevel).toBe(PermissionLevel.READ)
     expect(derivedPermission6!.directPermissionId).toBe(dbPermission3!.id)
     expect(derivedPermission6!.derived).toBe(true)
+  })
+
+  it('Test the direct sharing functionality for elements with different permission levels for user groups', async () => {
+    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { SE } = await seedElements(userOneCtx, AC1!.id)
+
+    // create a user group with users 1 (ADMIN), 2, and 3 and grant WRITE permissions on the element to them
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userOne.id,
+        members: {
+          connect: [{ id: userTwo.id }, { id: userThree.id }],
+        },
+      },
+    })
+    const groupPermission = await shareObject(
+      {
+        elementId: SE.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+      userOneCtx
+    )
+    expect(groupPermission).toBeTruthy()
+    expect(groupPermission!.userGroupId).toBe(group.id)
+    expect(groupPermission!.userGroupName).toBe(group.name)
+
+    // create a user group with users 1, 3 (ADMIN), and 4 and grant ADMIN permissions on the element to them
+    const group2 = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group 2',
+        ownerId: userThree.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userFour.id }],
+        },
+      },
+    })
+    const groupPermission2 = await shareObject(
+      {
+        elementId: SE.id,
+        userGroupId: group2.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+      userOneCtx
+    )
+    expect(groupPermission2).toBeTruthy()
+    expect(groupPermission2!.userGroupId).toBe(group2.id)
+    expect(groupPermission2!.userGroupName).toBe(group2.name)
+
+    // seed ADMIN and READ permissions on the answer collection for users 2 and 3
+    const ACPermission1 = await prisma.permission.create({
+      data: {
+        userId: userTwo.id,
+        answerCollectionId: AC1!.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    const ACPermission2 = await prisma.permission.create({
+      data: {
+        userId: userThree.id,
+        answerCollectionId: AC1!.id,
+        permissionLevel: PermissionLevel.READ,
+      },
+    })
+    await recomputeDerivedPermissions({ answerCollectionId: AC1!.id }, prisma)
+
+    // try sharing the object with a user group that does not exist
+    const res1 = await shareObject(
+      {
+        elementId: SE.id,
+        userGroupId: 123456789,
+        permissionLevel: PermissionLevel.READ,
+      },
+      userOneCtx
+    )
+    expect(res1).toBeNull()
+
+    // verify that the correct direct permissions have been created in the database
+    const dbPermission1 = await prisma.permission.findUnique({
+      where: {
+        elementId_userGroupId: {
+          elementId: SE.id,
+          userGroupId: group.id,
+        },
+      },
+    })
+    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const dbPermission2 = await prisma.permission.findUnique({
+      where: {
+        elementId_userGroupId: {
+          elementId: SE.id,
+          userGroupId: group2.id,
+        },
+      },
+    })
+    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct derived permissions have been created in the database
+    // OWNER for user 1, WRITE for user 2, ADMIN for users 3 and 4
+    const derivedPermission1 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
+
+    const derivedPermission2 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const derivedPermission3 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    const derivedPermission4 = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(derivedPermission4).toBeDefined()
+    expect(derivedPermission4?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct audit log entries have been created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(SE.id),
+        objectType: ObjectType.ELEMENT,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.ELEMENT} (ID ${SE.id}) by owner / admin ${userOne.id} to user group ${group.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(SE.id),
+        objectType: ObjectType.ELEMENT,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group2.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.ELEMENT} (ID ${SE.id}) by owner / admin ${userOne.id} to user group ${group2.id}.`
+    )
+
+    // verify that derived permissions on the dependent answer collection have been created for all users (READ if no higher direct permission)
+    const derivedPermission5 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedPermission5).toBeTruthy()
+    expect(derivedPermission5!.permissionLevel).toBe(PermissionLevel.ADMIN)
+    expect(derivedPermission5!.directPermissionId).toBe(ACPermission1.id)
+    expect(derivedPermission5!.derived).toBe(false)
+
+    const derivedPermission6 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedPermission6).toBeTruthy()
+    expect(derivedPermission6!.permissionLevel).toBe(PermissionLevel.ADMIN)
+    expect(derivedPermission6!.directPermissionId).toBe(ACPermission1.id)
+    expect(derivedPermission6!.derived).toBe(false)
+
+    const derivedPermission7 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedPermission7).toBeTruthy()
+    expect(derivedPermission7!.permissionLevel).toBe(PermissionLevel.READ)
+    expect(derivedPermission7!.directPermissionId).toBe(ACPermission2.id)
+    expect(derivedPermission7!.derived).toBe(false)
+
+    const derivedPermission8 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(derivedPermission8).toBeTruthy()
+    expect(derivedPermission8!.permissionLevel).toBe(PermissionLevel.READ)
+    expect(derivedPermission8!.directPermissionId).toBe(dbPermission2!.id)
+    expect(derivedPermission8!.derived).toBe(true)
   })
 
   it('Verify that direct permissions on the elements are loaded correctly', async () => {

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -149,8 +149,11 @@ export async function testCleanup(prisma: PrismaClient) {
     )
   }
 
-  // delete all users that have been added for the test run
+  // delete all users, participants and user groups / participant groups that have been added for the test run
   await prisma.user.deleteMany()
+  await prisma.participant.deleteMany()
+  await prisma.userGroup.deleteMany()
+  await prisma.participantGroup.deleteMany()
 }
 
 // setup test database configuration

--- a/packages/graphql/test/resourceSharing.test.ts
+++ b/packages/graphql/test/resourceSharing.test.ts
@@ -1487,7 +1487,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     )
   })
 
-  it('Test the sharing functionality for answer collections with different permission levels', async () => {
+  it('Test the direct sharing functionality for answer collections with different permission levels and individual users', async () => {
     const [AC1] = await seedAnswerCollections(userOneCtx)
 
     // try sharing the object with a user that does not exist
@@ -1655,6 +1655,152 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     expect(auditLogEntry3).toBeTruthy()
     expect(auditLogEntry3!.message).toBe(
       `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} to user ${userFour.id}.`
+    )
+  })
+
+  it('Test the direct sharing functionality for answer collections with different permission levels and user groups', async () => {
+    const [AC1] = await seedAnswerCollections(userOneCtx)
+
+    // create a user group with users 1 (ADMIN), 2, and 3 and grant WRITE permissions to them
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userOne.id,
+        members: {
+          connect: [{ id: userTwo.id }, { id: userThree.id }],
+        },
+      },
+    })
+    const groupPermission = await shareObject(
+      {
+        answerCollectionId: AC1!.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+      userOneCtx
+    )
+    expect(groupPermission).toBeTruthy()
+    expect(groupPermission!.userGroupId).toBe(group.id)
+    expect(groupPermission!.userGroupName).toBe(group.name)
+
+    // create a user group with users 1, 3 (ADMIN), and 4 and grant ADMIN permissions to them
+    const group2 = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group 2',
+        ownerId: userThree.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userFour.id }],
+        },
+      },
+    })
+    const groupPermission2 = await shareObject(
+      {
+        answerCollectionId: AC1!.id,
+        userGroupId: group2.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+      userOneCtx
+    )
+    expect(groupPermission2).toBeTruthy()
+    expect(groupPermission2!.userGroupId).toBe(group2.id)
+    expect(groupPermission2!.userGroupName).toBe(group2.name)
+
+    // verify that the correct direct permissions have been created in the database
+    const dbPermission1 = await prisma.permission.findUnique({
+      where: {
+        answerCollectionId_userGroupId: {
+          answerCollectionId: AC1!.id,
+          userGroupId: group.id,
+        },
+      },
+    })
+    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const dbPermission2 = await prisma.permission.findUnique({
+      where: {
+        answerCollectionId_userGroupId: {
+          answerCollectionId: AC1!.id,
+          userGroupId: group2.id,
+        },
+      },
+    })
+    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct derived permissions have been created in the database
+    // OWNER for user 1, WRITE for user 2, ADMIN for users 3 and 4
+    const derivedPermission1 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
+
+    const derivedPermission2 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const derivedPermission3 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    const derivedPermission4 = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(derivedPermission4).toBeDefined()
+    expect(derivedPermission4?.permissionLevel).toBe(PermissionLevel.ADMIN)
+
+    // verify that the correct audit log entries have been created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} to user group ${group.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group2.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) by owner / admin ${userOne.id} to user group ${group2.id}.`
     )
   })
   // #endregion

--- a/packages/graphql/test/resourceSharing.test.ts
+++ b/packages/graphql/test/resourceSharing.test.ts
@@ -856,7 +856,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
   // ! Sharing Operations for Answer Collections
   // #region
-  it('Verify that the level of granted direct permissions can be modified', async () => {
+  it('Verify that the level of granted direct individual permissions can be modified', async () => {
     const [AC1] = await seedAnswerCollections(userOneCtx)
 
     // grant READ permissions to user 2
@@ -939,6 +939,112 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     expect(auditLogEntry).toBeTruthy()
     expect(auditLogEntry!.message).toBe(
       `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) through owner / admin ${userOne.id} for user ${userTwo.id}.`
+    )
+  })
+
+  it('Verify that the level of granted direct group permissions can be modified', async () => {
+    const [AC1] = await seedAnswerCollections(userOneCtx)
+
+    // create a user group with users 1, 2, and 3 (ADMIN)
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userThree.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userTwo.id }],
+        },
+      },
+    })
+
+    // grant READ permissions to the user group
+    const readPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.READ,
+        userGroupId: group.id,
+        answerCollectionId: AC1!.id,
+      },
+    })
+    await recomputeDerivedPermissions({ answerCollectionId: AC1!.id }, prisma)
+
+    // change the permission level to WRITE
+    const success = await changeObjectPermissionLevel(
+      {
+        answerCollectionId: AC1!.id,
+        permissionId: readPermission.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+      userOneCtx
+    )
+    expect(success).toBe(true)
+
+    // verify that the permission level has been updated in the database
+    const updatedPermission = await prisma.permission.findUnique({
+      where: {
+        id: readPermission.id,
+      },
+    })
+    expect(updatedPermission).toBeDefined()
+    expect(updatedPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(updatedPermission?.answerCollectionId).toBe(AC1!.id)
+    expect(updatedPermission?.userGroupId).toBe(group.id)
+
+    // verify that the individual permissions of the user group members have been updated
+    const ownerPerimission = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(ownerPerimission).toBeDefined()
+    expect(ownerPerimission?.permissionLevel).toBe(PermissionLevel.OWNER)
+
+    const userTwoPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(userTwoPermission).toBeDefined()
+    expect(userTwoPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const userThreePermission = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(userThreePermission).toBeDefined()
+    expect(userThreePermission?.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const userFourPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC1!.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(userFourPermission).toBeNull()
+
+    // verify that the audit log entry has been created correctly
+    const auditLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_MODIFIED,
+        objectId: String(AC1!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(auditLogEntry).toBeTruthy()
+    expect(auditLogEntry!.message).toBe(
+      `Permission level changed from ${PermissionLevel.READ} to ${PermissionLevel.WRITE} for ${ObjectType.ANSWER_COLLECTION} (ID ${AC1!.id}) through owner / admin ${userOne.id} for user group ${group.id}.`
     )
   })
 

--- a/packages/graphql/test/resourceSharing.test.ts
+++ b/packages/graphql/test/resourceSharing.test.ts
@@ -1048,7 +1048,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     )
   })
 
-  it('Verify that direct permissions to an answer collection can be revoked, but might be replaced with derived permissions', async () => {
+  it('Verify that direct individual permissions to an answer collection can be revoked, but might be replaced with derived permissions', async () => {
     // create answer collections for testing
     const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
     await seedAnswerCollectionPermissions(prisma, AC1!.id, AC2!.id)
@@ -1348,6 +1348,164 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       },
     })
     expect(derivedPermission4).toBeNull()
+  })
+
+  it('Verify that direct group permissions on an answer collection can be revoked without conditions', async () => {
+    const [AC] = await seedAnswerCollections(userOneCtx)
+
+    // create a user group with users 1, 2, 3, and 4 (OWNER)
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userFour.id,
+        members: {
+          connect: [
+            { id: userOne.id },
+            { id: userTwo.id },
+            { id: userThree.id },
+          ],
+        },
+      },
+    })
+
+    // grant WRITE permissions to the user group
+    const groupPermission = await prisma.permission.create({
+      data: {
+        permissionLevel: PermissionLevel.WRITE,
+        userGroupId: group.id,
+        answerCollectionId: AC!.id,
+      },
+    })
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+
+    // verify that all users have derived permissions for the answer collection
+    const permissionUserOne = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC!.id,
+          userId: userOne.id,
+        },
+      },
+    })
+    expect(permissionUserOne).toBeDefined()
+    expect(permissionUserOne?.permissionLevel).toBe(PermissionLevel.OWNER)
+    expect(permissionUserOne?.directPermissionId).toBeNull()
+
+    const permissionUserTwo = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(permissionUserTwo).toBeDefined()
+    expect(permissionUserTwo?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserTwo?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserThree = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC!.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(permissionUserThree).toBeDefined()
+    expect(permissionUserThree?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserThree?.directPermissionId).toBe(groupPermission.id)
+
+    const permissionUserFour = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC!.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(permissionUserFour).toBeDefined()
+    expect(permissionUserFour?.permissionLevel).toBe(PermissionLevel.WRITE)
+    expect(permissionUserFour?.directPermissionId).toBe(groupPermission.id)
+
+    // revoke the permission
+    const deletedPermissionId = await revokeObjectAccess(
+      {
+        answerCollectionId: AC!.id,
+        permissionId: groupPermission.id,
+      },
+      userOneCtx
+    )
+    expect(deletedPermissionId).toBe(groupPermission.id)
+
+    // verify that both the acutal permission and the derived ones have been deleted
+    const deletedPermission = await prisma.permission.findUnique({
+      where: {
+        id: groupPermission.id,
+      },
+    })
+    expect(deletedPermission).toBeNull()
+
+    const persistentPermissionUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(persistentPermissionUserOne).toBeDefined()
+    expect(persistentPermissionUserOne?.permissionLevel).toBe(
+      PermissionLevel.OWNER
+    )
+
+    const deletedPermissionUserTwo = await prisma.derivedPermission.findUnique({
+      where: {
+        answerCollectionId_userId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(deletedPermissionUserTwo).toBeNull()
+
+    const deletedPermissionUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(deletedPermissionUserThree).toBeNull()
+
+    const deletedPermissionUserFour = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userFour.id,
+          },
+        },
+      }
+    )
+    expect(deletedPermissionUserFour).toBeNull()
+
+    // verify that an audit log entry has been created for this permission revocation
+    const audigLogEntry = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_REVOKED,
+        objectId: String(AC!.id),
+        objectType: ObjectType.ANSWER_COLLECTION,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group.id,
+      },
+    })
+    expect(audigLogEntry).toBeTruthy()
+    expect(audigLogEntry!.message).toBe(
+      `Permission revoked for ${ObjectType.ANSWER_COLLECTION} (ID ${AC!.id}) by owner / admin ${userOne.id} for user group ${group.id}.`
+    )
   })
 
   it('Verify that direct permissions on the answer collection are loaded correctly', async () => {

--- a/packages/util/src/permissions.ts
+++ b/packages/util/src/permissions.ts
@@ -176,13 +176,7 @@ export async function recomputeDerivedPermissions(
  * @returns Promise that resolves when the permission recomputation completes
  */
 async function recomputeCatalogCollectionPermissions(
-  {
-    id,
-    userId,
-  }: {
-    id: string
-    userId?: string
-  },
+  { id, userId }: { id: string; userId?: string },
   prisma: PrismaTransactionClient
 ) {
   // for the top-level default catalog collection, no permissions are awarded
@@ -255,6 +249,7 @@ async function recomputeCatalogCollectionPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -463,6 +458,7 @@ async function recomputeAnswerCollectionPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -868,6 +864,7 @@ async function recomputeElementPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -1401,6 +1398,7 @@ async function recomputeLiveQuizPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -1684,6 +1682,7 @@ async function recomputePracticeQuizPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -1969,6 +1968,7 @@ async function recomputeMicroLearningPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -2254,6 +2254,7 @@ async function recomputeGroupActivityPermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -2537,6 +2538,7 @@ async function recomputeCoursePermissionsUser(
             {
               userGroup: {
                 OR: [
+                  { ownerId: userId },
                   { members: { some: { id: userId } } },
                   { admins: { some: { id: userId } } },
                 ],
@@ -2813,12 +2815,13 @@ function getMaxAccessLevelCombined({
           }
         }
       } else if (directPermission.userGroup) {
-        // iterate over the members and admins and add / update the corresponding permissions for each user
+        // iterate over all users in the group and add / update the corresponding permissions for each user
         const groupMembers = [
           { id: directPermission.userGroup.ownerId },
           ...directPermission.userGroup.members,
           ...directPermission.userGroup.admins,
         ]
+
         groupMembers.forEach((user) => {
           if (
             typeof acc[user.id] !== 'undefined' &&
@@ -2838,9 +2841,7 @@ function getMaxAccessLevelCombined({
           }
         })
       } else {
-        throw new Error(
-          `Direct permission without user or user group found for catalog collection.`
-        )
+        throw new Error(`Direct permission without user or user group found.`)
       }
 
       return acc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sharing elements, catalog collections, and answer collections directly with user groups, including correct permission propagation and audit logging.

- **Bug Fixes**
  - Improved validation to ensure users can only share objects with groups they belong to as owner, admin, or member.

- **Tests**
  - Expanded test coverage for sharing with user groups, including comprehensive checks for permissions and audit logs.
  - Enhanced test cleanup to remove related entities and prevent leftover test data.

- **Documentation**
  - Updated test descriptions for clarity around individual user and user group sharing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->