### PR TITLE
chore(cypress): extend e2e testing to include direct user group sharing functionalities

### DIFF
--- a/apps/frontend-manage/src/components/sharing/DirectSharingForm.tsx
+++ b/apps/frontend-manage/src/components/sharing/DirectSharingForm.tsx
@@ -168,6 +168,7 @@ function DirectSharingForm({
                             <span className="mr-5 text-gray-600">{`(${group.numOfMembers} ${t('manage.userGroups.members')})`}</span>
                           </div>
                         ),
+                        data: { cy: `user-group-${group.name}` },
                       })),
                       prop('labelString')
                     )

--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1686,5 +1686,258 @@ describe('Create different types of elements (with and without sample solution) 
       'not.exist'
     )
   })
-  // #region
+
+  it.only('Create user groups with all users and prepare a new selection question (incl. answer collection) for user group sharing', function () {
+    // create catalog collection with restricted access
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get('[data-cy="answer-collection-list"]').should('exist')
+    cy.createAnswerCollection({
+      name: this.data.collection.name,
+      description: this.data.collection.description,
+      entries: this.data.collection.options,
+      userId: Cypress.env('LECTURER_ID'),
+    })
+
+    cy.get('[data-cy="library"]').click()
+    cy.createQuestionSE({
+      name: this.data.SEML2.title,
+      content: this.data.SEML2.content,
+      numberOfInputs: this.data.SEML2.inputs,
+      collectionName: this.data.collection.name,
+      correctAnswers: this.data.collection.options.filter((_, i) =>
+        this.data.SEML2.solutions.includes(i)
+      ),
+      userId: Cypress.env('LECTURER_ID'),
+    })
+
+    // create user group with users 1 (OWNER) and pro1 (MEMBER)
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group1)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_IND_SHORTNAME')) // pro1 is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group1}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="view-edit-group-${this.data.group1}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-member-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+
+    // create user group with users 1 (OWNER) and pro2 (ADMIN)
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group2)
+    cy.get('[data-cy="cancel-create-user-group"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group2)
+
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_INST_EMAIL')) // pro2 is added as admin
+    cy.get('[data-cy="member-admin-0"]').realClick()
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group2}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="view-edit-group-${this.data.group2}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+    cy.logoutLecturer()
+
+    // create user group with users 1 (MEMBER) and pro3 (OWNER)
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group3)
+    cy.get('[data-cy="cancel-create-user-group"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group3)
+
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_SHORTNAME')) // lecturer is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group3}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group3}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group3}"]`).should('exist')
+
+    cy.get(`[data-cy="view-edit-group-${this.data.group3}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-member-${Cypress.env('LECTURER_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+    cy.logoutLecturer()
+  })
+
+  it.only('Grant direct READ, WRITE and ADMIN permissions to the element for the user groups', function () {
+    cy.loginLecturer()
+    cy.get(`[data-cy="actions-element-${this.data.SEML2.title}"]`).click()
+    cy.get(`[data-cy="share-element-${this.data.SEML2.title}"]`).click()
+    cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group1)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-READ"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsREAD
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+
+    // grant direct WRITE permissions to group 2
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group2)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-WRITE"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsWRITE
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+
+    // grant direct ADMIN permissions to group 3
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group3)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+  })
+
+  it.only('Verify that the users in group 1 have been granted READ permissions on the element and contained answer collection', function () {
+    cy.loginIndividualCatalyst()
+
+    // check that the shared element is available with the correct permissions
+    cy.get(`[data-cy="element-item-${this.data.SEML2.title}"]`).should('exist')
+    cy.get(`[data-cy="duplicate-element-${this.data.SEML2.title}"]`).should(
+      'exist'
+    )
+
+    // check that the contained answer collection is available with READ permissions
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(`[data-cy="answer-collection-${this.data.collection.name}"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.collection.name}"]`
+    ).click()
+    cy.get('[data-cy="view-answer-collection"]').click()
+    cy.get('[data-cy="open-collection-options"]').click()
+    cy.wrap(this.data.collection.options).each((value: string) => {
+      cy.findByText(value).should('exist')
+    })
+  })
+
+  it.only('Verify that the users in group 2 have been granted WRITE permissions on the element and contained answer collection', function () {
+    cy.loginInstitutionalCatalyst()
+
+    // check that the shared element is available with the correct permissions
+    cy.get(`[data-cy="element-item-${this.data.SEML2.title}"]`).should('exist')
+    cy.get(`[data-cy="duplicate-element-${this.data.SEML2.title}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="edit-element-${this.data.SEML2.title}"]`).should('exist')
+
+    // check that the contained answer collection is available with READ permissions
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(`[data-cy="answer-collection-${this.data.collection.name}"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.collection.name}"]`
+    ).click()
+    cy.get('[data-cy="view-answer-collection"]').click()
+    cy.get('[data-cy="open-collection-options"]').click()
+    cy.wrap(this.data.collection.options).each((value: string) => {
+      cy.findByText(value).should('exist')
+    })
+  })
+
+  it.only('Verify that the users in group 3 have been granted ADMIN permissions on the element and contained answer collection', function () {
+    cy.loginInstitutionalCatalyst2()
+
+    // check that the shared element is available with the correct permissions
+    cy.get(`[data-cy="element-item-${this.data.SEML2.title}"]`).should('exist')
+    cy.get(`[data-cy="duplicate-element-${this.data.SEML2.title}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="edit-element-${this.data.SEML2.title}"]`).should('exist')
+    cy.get(`[data-cy="actions-element-${this.data.SEML2.title}"]`).should(
+      'exist'
+    )
+
+    // check that the contained answer collection is available with READ permissions
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(`[data-cy="answer-collection-${this.data.collection.name}"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.collection.name}"]`
+    ).click()
+    cy.get('[data-cy="view-answer-collection"]').click()
+    cy.get('[data-cy="open-collection-options"]').click()
+    cy.wrap(this.data.collection.options).each((value: string) => {
+      cy.findByText(value).should('exist')
+    })
+  })
+  // #endregion
 })

--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1089,7 +1089,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`)
       .should('exist')
       .contains(messages.manage.sharing.permissionsADMIN)
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that access requests are visible to user pro3
     cy.loginInstitutionalCatalyst2()
@@ -1114,7 +1114,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(
       `[data-cy="deny-sharing-request-${this.data.SEML.title}-pro2"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // revoke direct ADMIN permissions again
     cy.loginLecturer()
@@ -1130,7 +1130,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(
       `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('not.exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that the access requests are not visible anymore to user pro3
     cy.loginInstitutionalCatalyst2()
@@ -1647,7 +1647,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(`[data-cy="actions-element-${this.data.SCML.title}"]`).should(
       'not.exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // WRITE permissions should enable a user to duplicate or edit the element (no re-use, no deletion / sharing)
     cy.loginInstitutionalCatalyst()
@@ -1659,7 +1659,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get(`[data-cy="actions-element-${this.data.SCML.title}"]`).should(
       'not.exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // ADMIN permissions should enable a user to duplicate, edit, delete or share the element
     cy.loginInstitutionalCatalyst2()
@@ -1772,7 +1772,7 @@ describe('Create different types of elements (with and without sample solution) 
       `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
     ).should('exist')
     cy.get('[data-cy="close-user-group-edit-modal"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // create user group with users 1 (MEMBER) and pro3 (OWNER)
     cy.loginInstitutionalCatalyst2()
@@ -1807,13 +1807,15 @@ describe('Create different types of elements (with and without sample solution) 
       `[data-cy="group-member-${Cypress.env('LECTURER_SHORTNAME')}"]`
     ).should('exist')
     cy.get('[data-cy="close-user-group-edit-modal"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Grant direct READ, WRITE and ADMIN permissions to the element for the user groups', function () {
     cy.loginLecturer()
     cy.get(`[data-cy="actions-element-${this.data.SEML2.title}"]`).click()
     cy.get(`[data-cy="share-element-${this.data.SEML2.title}"]`).click()
+
+    // grant direct READ permissions to group 1
     cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
     cy.get('[data-cy="new-permission-user-group"]').realClick()
     cy.get(`[data-cy="user-group-${this.data.group1}"]`).click()
@@ -1825,6 +1827,9 @@ describe('Create different types of elements (with and without sample solution) 
       messages.manage.sharing.permissionsREAD
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group1}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsREAD)
 
     // grant direct WRITE permissions to group 2
     cy.get('[data-cy="new-permission-user-group"]').contains(
@@ -1840,6 +1845,9 @@ describe('Create different types of elements (with and without sample solution) 
       messages.manage.sharing.permissionsWRITE
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group2}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsWRITE)
 
     // grant direct ADMIN permissions to group 3
     cy.get('[data-cy="new-permission-user-group"]').contains(
@@ -1855,6 +1863,9 @@ describe('Create different types of elements (with and without sample solution) 
       messages.manage.sharing.permissionsADMIN
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group3}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
   })
 
   it('Verify that the users in group 1 have been granted READ permissions on the element and contained answer collection', function () {

--- a/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
+++ b/cypress/cypress/e2e/M-elements-operations-workflow.cy.ts
@@ -1687,7 +1687,7 @@ describe('Create different types of elements (with and without sample solution) 
     )
   })
 
-  it.only('Create user groups with all users and prepare a new selection question (incl. answer collection) for user group sharing', function () {
+  it('Create user groups with all users and prepare a new selection question (incl. answer collection) for user group sharing', function () {
     // create catalog collection with restricted access
     cy.loginLecturer()
     cy.get('[data-cy="analytics"]').should('exist')
@@ -1810,7 +1810,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.logoutLecturer()
   })
 
-  it.only('Grant direct READ, WRITE and ADMIN permissions to the element for the user groups', function () {
+  it('Grant direct READ, WRITE and ADMIN permissions to the element for the user groups', function () {
     cy.loginLecturer()
     cy.get(`[data-cy="actions-element-${this.data.SEML2.title}"]`).click()
     cy.get(`[data-cy="share-element-${this.data.SEML2.title}"]`).click()
@@ -1857,7 +1857,7 @@ describe('Create different types of elements (with and without sample solution) 
     cy.get('[data-cy="new-permission-submit"]').click()
   })
 
-  it.only('Verify that the users in group 1 have been granted READ permissions on the element and contained answer collection', function () {
+  it('Verify that the users in group 1 have been granted READ permissions on the element and contained answer collection', function () {
     cy.loginIndividualCatalyst()
 
     // check that the shared element is available with the correct permissions
@@ -1883,7 +1883,7 @@ describe('Create different types of elements (with and without sample solution) 
     })
   })
 
-  it.only('Verify that the users in group 2 have been granted WRITE permissions on the element and contained answer collection', function () {
+  it('Verify that the users in group 2 have been granted WRITE permissions on the element and contained answer collection', function () {
     cy.loginInstitutionalCatalyst()
 
     // check that the shared element is available with the correct permissions
@@ -1910,7 +1910,7 @@ describe('Create different types of elements (with and without sample solution) 
     })
   })
 
-  it.only('Verify that the users in group 3 have been granted ADMIN permissions on the element and contained answer collection', function () {
+  it('Verify that the users in group 3 have been granted ADMIN permissions on the element and contained answer collection', function () {
     cy.loginInstitutionalCatalyst2()
 
     // check that the shared element is available with the correct permissions

--- a/cypress/cypress/e2e/T-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/T-resources-workflow.cy.ts
@@ -1428,6 +1428,221 @@ describe('Create, edit and share answer collections', function () {
   })
   // #endregion
 
+  // ! 5. Sharing functionalities (user groups)
+  // #region
+  it('Create user groups with all users and prepare a new answer collection for user group sharing', function () {
+    // create answer collection with restricted access
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get('[data-cy="answer-collection-list"]').should('exist')
+    cy.createAnswerCollection({
+      name: this.data.shared.name,
+      description: this.data.shared.description,
+      entries: this.data.shared.items,
+      userId: Cypress.env('LECTURER_ID'),
+    })
+
+    // create user group with users 1 (OWNER) and pro1 (MEMBER)
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group1)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_IND_SHORTNAME')) // pro1 is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group1}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="view-edit-group-${this.data.group1}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-member-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+
+    // create user group with users 1 (OWNER) and pro2 (ADMIN)
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group2)
+    cy.get('[data-cy="cancel-create-user-group"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group2)
+
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_INST_EMAIL')) // pro2 is added as admin
+    cy.get('[data-cy="member-admin-0"]').realClick()
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group2}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="view-edit-group-${this.data.group2}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+    cy.logoutLecturer()
+
+    // create user group with users 1 (MEMBER) and pro3 (OWNER)
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group3)
+    cy.get('[data-cy="cancel-create-user-group"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group3)
+
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_SHORTNAME')) // lecturer is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group3}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group3}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group3}"]`).should('exist')
+
+    cy.get(`[data-cy="view-edit-group-${this.data.group3}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-member-${Cypress.env('LECTURER_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+    cy.logoutLecturer()
+  })
+
+  it('Grant direct READ, WRITE and ADMIN permissions to the answer collection for the user groups', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.shared.name}"]`
+    ).click()
+    cy.get('[data-cy="share-answer-collection"]').click()
+
+    // grant direct READ permissions to group 1
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group1)
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-READ"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsREAD
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+
+    // grant direct WRITE permissions to group 2
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group2)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-WRITE"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsWRITE
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+
+    // grant direct ADMIN permissions to group 3
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group3)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+  })
+
+  it('Verify that the users in group 1 have been granted READ permissions on the answer collection', function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(`[data-cy="answer-collection-${this.data.shared.name}"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.shared.name}"]`
+    ).click()
+    cy.get('[data-cy="view-answer-collection"]').click()
+    cy.get('[data-cy="open-collection-options"]').click()
+    cy.wrap(this.data.shared.items).each((value: string) => {
+      cy.findByText(value).should('exist')
+    })
+  })
+
+  it('Verify that the users in group 2 have been granted WRITE permissions on the answer collection', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(`[data-cy="answer-collection-${this.data.shared.name}"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.shared.name}"]`
+    ).click()
+    cy.get('[data-cy="edit-answer-collection"]').click()
+  })
+
+  it('Verify that the users in group 3 have been granted ADMIN permissions on the answer collection', function () {
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    cy.get(`[data-cy="answer-collection-${this.data.shared.name}"]`).should(
+      'exist'
+    )
+    cy.get(
+      `[data-cy="answer-collection-actions-${this.data.shared.name}"]`
+    ).click()
+    cy.get('[data-cy="edit-answer-collection"]').click()
+  })
+  // #endregion
+
   // ! 5. Modification of availability in catalog (automatic declining of requests / persistence of access / ...)
   // #region
   it('Create a private answer collection', function () {

--- a/cypress/cypress/e2e/T-resources-workflow.cy.ts
+++ b/cypress/cypress/e2e/T-resources-workflow.cy.ts
@@ -560,7 +560,7 @@ describe('Create, edit and share answer collections', function () {
     cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`)
       .should('exist')
       .contains(messages.manage.sharing.permissionsADMIN)
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that access requests are visible to user pro3
     cy.loginInstitutionalCatalyst2()
@@ -585,7 +585,7 @@ describe('Create, edit and share answer collections', function () {
     cy.get(
       `[data-cy="deny-sharing-request-${this.data.restricted.name}-pro2"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // revoke direct ADMIN permissions again
     cy.loginLecturer()
@@ -610,7 +610,7 @@ describe('Create, edit and share answer collections', function () {
     cy.get(
       `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('not.exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that the access requests are not visible anymore to user pro3
     cy.loginInstitutionalCatalyst2()
@@ -1503,7 +1503,7 @@ describe('Create, edit and share answer collections', function () {
       `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
     ).should('exist')
     cy.get('[data-cy="close-user-group-edit-modal"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // create user group with users 1 (MEMBER) and pro3 (OWNER)
     cy.loginInstitutionalCatalyst2()
@@ -1538,7 +1538,7 @@ describe('Create, edit and share answer collections', function () {
       `[data-cy="group-member-${Cypress.env('LECTURER_SHORTNAME')}"]`
     ).should('exist')
     cy.get('[data-cy="close-user-group-edit-modal"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Grant direct READ, WRITE and ADMIN permissions to the answer collection for the user groups', function () {
@@ -1564,6 +1564,9 @@ describe('Create, edit and share answer collections', function () {
       messages.manage.sharing.permissionsREAD
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group1}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsREAD)
 
     // grant direct WRITE permissions to group 2
     cy.get('[data-cy="new-permission-user-group"]').contains(
@@ -1579,6 +1582,9 @@ describe('Create, edit and share answer collections', function () {
       messages.manage.sharing.permissionsWRITE
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group2}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsWRITE)
 
     // grant direct ADMIN permissions to group 3
     cy.get('[data-cy="new-permission-user-group"]').contains(
@@ -1594,6 +1600,9 @@ describe('Create, edit and share answer collections', function () {
       messages.manage.sharing.permissionsADMIN
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group3}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
   })
 
   it('Verify that the users in group 1 have been granted READ permissions on the answer collection', function () {

--- a/cypress/cypress/e2e/U-catalog-workflow.cy.ts
+++ b/cypress/cypress/e2e/U-catalog-workflow.cy.ts
@@ -920,6 +920,249 @@ describe('Test all functionalities of catalog collections and objects contained 
     ).click()
     cy.get('[data-cy="cancel-removal"]').click()
   })
+
+  it('Create user groups with all users and prepare a new catalog collection for user group sharing', function () {
+    // create catalog collection with restricted access
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get('[data-cy="create-catalog-collection-button"]').click()
+    cy.get('[data-cy="catalog-collection-name-input"]')
+      .click()
+      .type(this.data.CCRestricted2)
+    cy.get('[data-cy="modal-object-access"]').click()
+    cy.get('[data-cy="object-access-restricted"]').click()
+    cy.get('[data-cy="modal-object-access"]').contains(
+      messages.manage.catalog.accessRESTRICTED
+    )
+    cy.get('[data-cy="create-catalog-collection-submit"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.CCRestricted2}"]`)
+      .should('exist')
+      .contains(messages.manage.catalog.accessRESTRICTED)
+
+    // create user group with users 1 (OWNER) and pro1 (MEMBER)
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group1)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_IND_SHORTNAME')) // pro1 is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group1}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group1}"]`).should('exist')
+    cy.get(`[data-cy="view-edit-group-${this.data.group1}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-member-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+
+    // create user group with users 1 (OWNER) and pro2 (ADMIN)
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group2)
+    cy.get('[data-cy="cancel-create-user-group"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group2)
+
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_INST_EMAIL')) // pro2 is added as admin
+    cy.get('[data-cy="member-admin-0"]').realClick()
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group2}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group2}"]`).should('exist')
+    cy.get(`[data-cy="view-edit-group-${this.data.group2}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+    cy.logoutLecturer()
+
+    // create user group with users 1 (MEMBER) and pro3 (OWNER)
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group3)
+    cy.get('[data-cy="cancel-create-user-group"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.group3)
+
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_SHORTNAME')) // lecturer is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+
+    // check that the user group has been created correctly
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).should('exist')
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).contains(
+      messages.shared.generic.owner
+    )
+    cy.get(`[data-cy="user-group-actions-${this.data.group3}"]`).click()
+    cy.get(`[data-cy="view-edit-group-${this.data.group3}"]`).should('exist')
+    cy.get(`[data-cy="delete-group-${this.data.group3}"]`).should('exist')
+
+    cy.get(`[data-cy="view-edit-group-${this.data.group3}"]`).click()
+    cy.get(`[data-cy="edit-group-name"]`).should('exist')
+    cy.get(
+      `[data-cy="group-member-${Cypress.env('LECTURER_SHORTNAME')}"]`
+    ).should('exist')
+    cy.get('[data-cy="close-user-group-edit-modal"]').click()
+    cy.logoutLecturer()
+  })
+
+  it('Grant direct READ, WRITE and ADMIN permissions to the catalog collection for the user groups', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(
+      `[data-cy="catalog-collection-${this.data.CCRestricted2}-actions"]`
+    ).realClick()
+    cy.get('[data-cy="share-catalog-collection"]').click()
+    cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
+
+    // enter a username
+    cy.get('[data-cy="new-permission-username-or-email"]')
+      .click()
+      .type(Cypress.env('LECTURER_IND_SHORTNAME'))
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-username-or-email"]').should(
+      'have.value',
+      Cypress.env('LECTURER_IND_SHORTNAME')
+    )
+
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group1)
+    cy.get('[data-cy="new-permission-username-or-email"]').should(
+      'have.value',
+      ''
+    ) // username field should have been cleared automatically
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+
+    // entering a username again, should reset the user group field
+    cy.get('[data-cy="new-permission-username-or-email"]')
+      .click()
+      .type(Cypress.env('LECTURER_INST2_SHORTNAME'))
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-username-or-email"]').should(
+      'have.value',
+      Cypress.env('LECTURER_INST2_SHORTNAME')
+    )
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+
+    // select the user group again
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group1}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group1)
+
+    // choose permission level for group 1 and grant direct group permission
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-READ"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsREAD
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+
+    // grant direct WRITE permissions to group 2
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group2}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group2)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-WRITE"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsWRITE
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+
+    // grant direct ADMIN permissions to group 3
+    cy.get('[data-cy="new-permission-user-group"]').contains(
+      messages.manage.sharing.noUserGroupSelected
+    )
+    cy.get('[data-cy="new-permission-user-group"]').realClick()
+    cy.get(`[data-cy="user-group-${this.data.group3}"]`).click()
+    cy.get('[data-cy="new-permission-user-group"]').contains(this.data.group3)
+    cy.get('[data-cy="new-permission-submit"]').should('not.be.disabled')
+    cy.get('[data-cy="new-permission-access-level"]').click()
+    cy.get('[data-cy="permission-level-ADMIN"]').click()
+    cy.get('[data-cy="new-permission-access-level"]').contains(
+      messages.manage.sharing.permissionsADMIN
+    )
+    cy.get('[data-cy="new-permission-submit"]').click()
+  })
+
+  it('Verify that the users in group 1 have been granted READ permissions on the catalog collection', function () {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.CCRestricted2}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(
+      this.data.CCRestricted2
+    )
+    cy.get('[data-cy="add-object-to-catalog-button"]').should('not.exist')
+  })
+
+  it('Verify that the users in group 2 have been granted WRITE permissions on the catalog collection', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.CCRestricted2}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(
+      this.data.CCRestricted2
+    )
+    cy.get('[data-cy="add-object-to-catalog-button"]').should('exist')
+  })
+
+  it('Verify that the users in group 3 have been granted ADMIN permissions on the catalog collection', function () {
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+    cy.get(`[data-cy="catalog-object-${this.data.CCRestricted2}"]`).click()
+    cy.get('[data-cy="catalog-browser-title"]').contains(
+      this.data.CCRestricted2
+    )
+    cy.get('[data-cy="add-object-to-catalog-button"]').should('exist')
+  })
   // #endregion
 
   // ! Part 3: Object Sharing

--- a/cypress/cypress/e2e/U-catalog-workflow.cy.ts
+++ b/cypress/cypress/e2e/U-catalog-workflow.cy.ts
@@ -385,7 +385,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="catalog-object-${this.data.CCRestricted}"]`).should(
       'exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // other users should not see empty public collection (restricted for access requests)
     cy.loginIndividualCatalyst()
@@ -470,7 +470,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="catalog-object-${this.data.CCRestricted}"]`).should(
       'exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // other users should also see both catalog collections and content of public one
     cy.loginIndividualCatalyst()
@@ -1000,7 +1000,7 @@ describe('Test all functionalities of catalog collections and objects contained 
       `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
     ).should('exist')
     cy.get('[data-cy="close-user-group-edit-modal"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // create user group with users 1 (MEMBER) and pro3 (OWNER)
     cy.loginInstitutionalCatalyst2()
@@ -1035,7 +1035,7 @@ describe('Test all functionalities of catalog collections and objects contained 
       `[data-cy="group-member-${Cypress.env('LECTURER_SHORTNAME')}"]`
     ).should('exist')
     cy.get('[data-cy="close-user-group-edit-modal"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Grant direct READ, WRITE and ADMIN permissions to the catalog collection for the user groups', function () {
@@ -1047,9 +1047,9 @@ describe('Test all functionalities of catalog collections and objects contained 
       `[data-cy="catalog-collection-${this.data.CCRestricted2}-actions"]`
     ).realClick()
     cy.get('[data-cy="share-catalog-collection"]').click()
-    cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
 
-    // enter a username
+    // grant direct READ permissions to group 1
+    cy.get('[data-cy="new-permission-submit"]').should('be.disabled')
     cy.get('[data-cy="new-permission-username-or-email"]')
       .click()
       .type(Cypress.env('LECTURER_IND_SHORTNAME'))
@@ -1096,6 +1096,9 @@ describe('Test all functionalities of catalog collections and objects contained 
       messages.manage.sharing.permissionsREAD
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group1}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsREAD)
 
     // grant direct WRITE permissions to group 2
     cy.get('[data-cy="new-permission-user-group"]').contains(
@@ -1111,6 +1114,9 @@ describe('Test all functionalities of catalog collections and objects contained 
       messages.manage.sharing.permissionsWRITE
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group2}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsWRITE)
 
     // grant direct ADMIN permissions to group 3
     cy.get('[data-cy="new-permission-user-group"]').contains(
@@ -1126,6 +1132,9 @@ describe('Test all functionalities of catalog collections and objects contained 
       messages.manage.sharing.permissionsADMIN
     )
     cy.get('[data-cy="new-permission-submit"]').click()
+    cy.get(`[data-cy="permission-${this.data.group3}"]`)
+      .should('exist')
+      .contains(messages.manage.sharing.permissionsADMIN)
   })
 
   it('Verify that the users in group 1 have been granted READ permissions on the catalog collection', function () {
@@ -1202,7 +1211,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get('[data-cy="resources"]').click()
     cy.get('[data-cy="catalog"]').click()
     cy.get(`[data-cy="catalog-object-${this.data.CCPublic}"]`).click() // navigate back to catalog collection
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Verify that user pro3 can see and request access to objects in restricted answer collection with READ permissions', function () {
@@ -1255,7 +1264,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="share-object-${this.data.AC2.name}"]`).should('not.exist')
     cy.get(`[data-cy="request-access-${this.data.AC2.name}"]`).click()
     cy.get(`[data-cy="cancel-request-access"]`).click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // pro1 - ADMIN of AC1 and OWNER of AC2 with corresponding sharing permissions
     cy.loginIndividualCatalyst()
@@ -1282,7 +1291,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="share-object-${this.data.AC2.name}"]`).click()
     cy.get('[data-cy="transfer-ownership"]').should('exist')
     cy.get('[data-cy="close-share-object"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // pro2 - ADMIN of catalog collection CC2 but without permissions on answer collections should not be able to access sharing dialogs
     cy.loginInstitutionalCatalyst()
@@ -1434,7 +1443,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="remove-group-member-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // log in as an admin user, verify that all functionalities except from ownership transfer are available
     cy.loginIndividualCatalyst()
@@ -1497,7 +1506,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="remove-group-member-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // log in as a member user, verify that no modification actions are available and that the user emails are not shown
     cy.loginInstitutionalCatalyst2()
@@ -1561,7 +1570,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="remove-group-member-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
     ).should('not.exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Verify that creating another group with the same name fails', function () {
@@ -1680,7 +1689,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="group-member-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that the changes went into effect for the corresponding users
     cy.loginIndividualCatalyst()
@@ -1691,7 +1700,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="user-group-${this.data.userGroup.name}"]`).contains(
       messages.manage.userGroups.member
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     cy.loginInstitutionalCatalyst2()
     cy.get('[data-cy="analytics"]').should('exist')
@@ -1701,7 +1710,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="user-group-${this.data.userGroup.name}"]`).contains(
       messages.manage.userGroups.admin
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Remove a member and an admin from the group and verify that the corresponding users lost access', function () {
@@ -1727,7 +1736,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="group-member-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
     ).should('not.exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that the changes went into effect for the corresponding users
     cy.loginIndividualCatalyst()
@@ -1737,7 +1746,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="user-group-${this.data.userGroup.name}"]`).should(
       'not.exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     cy.loginInstitutionalCatalyst2()
     cy.get('[data-cy="analytics"]').should('exist')
@@ -1746,7 +1755,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="user-group-${this.data.userGroup.name}"]`).should(
       'not.exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Transfer the ownership to one of the group admins, verify the change and transfer the ownership back', function () {
@@ -1774,7 +1783,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="group-admin-${Cypress.env('LECTURER_SHORTNAME')}"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // verify that the changes went into effect for the corresponding users and transfer the ownership back
     cy.loginInstitutionalCatalyst()
@@ -1801,7 +1810,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(
       `[data-cy="group-admin-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`
     ).should('exist')
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
 
   it('Change the name of the user group and verify its persistence', function () {
@@ -1855,7 +1864,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="user-group-${this.data.userGroup.nameNew}"]`).should(
       'not.exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     cy.loginInstitutionalCatalyst()
     cy.get('[data-cy="analytics"]').should('exist')
@@ -1864,7 +1873,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get(`[data-cy="user-group-${this.data.userGroup.nameNew}"]`).should(
       'not.exist'
     )
-    cy.logoutLecturer()
+    cy.logoutUser()
   })
   // #endregion
 
@@ -1885,7 +1894,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     ).click()
     cy.get('[data-cy="remove-answer-collection"]').click()
     cy.get('[data-cy="confirm-remove-object"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // remove the shared answer collections from pro2
     cy.loginInstitutionalCatalyst()
@@ -1897,7 +1906,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     ).click()
     cy.get('[data-cy="remove-answer-collection"]').click()
     cy.get('[data-cy="confirm-remove-object"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // remove the shared answer collections from pro3
     cy.loginInstitutionalCatalyst2()
@@ -1909,7 +1918,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     ).click()
     cy.get('[data-cy="remove-answer-collection"]').click()
     cy.get('[data-cy="confirm-remove-object"]').click()
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // delete answer collection AC1
     cy.loginLecturer()
@@ -1917,7 +1926,7 @@ describe('Test all functionalities of catalog collections and objects contained 
     cy.get('[data-cy="resources"]').click()
     cy.get('[data-cy="answer-collections"]').click()
     cy.deleteAnswerCollection({ collectionName: this.data.AC1.name })
-    cy.logoutLecturer()
+    cy.logoutUser()
 
     // delete answer collection AC2
     cy.loginIndividualCatalyst()

--- a/cypress/cypress/fixtures/DM-questions.json
+++ b/cypress/cypress/fixtures/DM-questions.json
@@ -504,5 +504,8 @@
     "groupActivity1": "Group Activity 1",
     "groupActivity2": "Group Activity 2",
     "groupActivity3": "Group Activity 3"
-  }
+  },
+  "group1": "Group 1",
+  "group2": "Group 2",
+  "group3": "Group 3"
 }

--- a/cypress/cypress/fixtures/T-resources.json
+++ b/cypress/cypress/fixtures/T-resources.json
@@ -106,5 +106,24 @@
       "Nine",
       "Ten"
     ]
-  }
+  },
+  "shared": {
+    "name": "Shared Answer Collection",
+    "description": "This is a shared answer collection",
+    "items": [
+      "Eleven",
+      "Twelve",
+      "Thirteen",
+      "Fourteen",
+      "Fifteen",
+      "Sixteen",
+      "Seventeen",
+      "Eighteen",
+      "Nineteen",
+      "Twenty"
+    ]
+  },
+  "group1": "Group 1",
+  "group2": "Group 2",
+  "group3": "Group 3"
 }

--- a/cypress/cypress/fixtures/U-catalog.json
+++ b/cypress/cypress/fixtures/U-catalog.json
@@ -43,8 +43,12 @@
   },
   "CCPublic": "Public Catalog Collection",
   "CCRestricted": "Restricted Catalog Collection",
+  "CCRestricted2": "Second Catalog Collection",
   "userGroup": {
     "name": "User Group TEST",
     "nameNew": "User Group NEW"
-  }
+  },
+  "group1": "Group 1",
+  "group2": "Group 2",
+  "group3": "Group 3"
 }

--- a/cypress/cypress/support/commands.ts
+++ b/cypress/cypress/support/commands.ts
@@ -123,7 +123,7 @@ Cypress.Commands.add(
   })
 )
 
-Cypress.Commands.add('logoutLecturer', () => {
+Cypress.Commands.add('logoutUser', () => {
   cy.clearCookie('next-auth.session-token')
 })
 
@@ -1153,7 +1153,7 @@ declare global {
       loginIndividualCatalyst(): Chainable<void>
       loginInstitutionalCatalyst(): Chainable<void>
       loginInstitutionalCatalyst2(): Chainable<void>
-      logoutLecturer(): Chainable<void>
+      logoutUser(): Chainable<void>
       loginStudent(): Chainable<void>
       loginStudentPassword({ username }: { username: string }): Chainable<void>
       createAnswerCollection({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced sharing options by supporting direct permission assignment (READ, WRITE, ADMIN) to user groups for elements, answer collections, and catalog collections.
  - Improved UI testability by adding unique data attributes to user group options in sharing forms.

- **Tests**
  - Added comprehensive end-to-end tests covering user group creation, permission assignment, and access verification across elements, answer collections, and catalog collections.
  - Extended test data fixtures to include new user groups and shared collections for improved test coverage.
  - Standardized logout commands in tests for consistent user session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->