### PR TITLE
fix: handle edge cases during access request updates correctly and extend unit testing for access request update coverage

### DIFF
--- a/packages/graphql/test/access.test.ts
+++ b/packages/graphql/test/access.test.ts
@@ -1,5 +1,6 @@
 import {
   AuditLogType,
+  ElementInstanceType,
   ElementType,
   ObjectAccess,
   ObjectType,
@@ -8,8 +9,13 @@ import {
   PublicationStatus,
 } from '@klicker-uzh/prisma'
 import {
+  ElementInstanceResults,
+  SelectionElementData,
+} from '@klicker-uzh/types'
+import {
   MISSING_CATALOG_COLLECTION_ID,
   recomputeDerivedPermissions,
+  updateAccessRequestInstances,
 } from '@klicker-uzh/util'
 import { EventEmitter } from 'events'
 import type { ContextWithUser } from '../src/lib/context.js'
@@ -27,6 +33,7 @@ import {
   initializePrisma,
   seedAnswerCollections,
   seedCatalogCollections,
+  seedElements,
   testCleanup,
   testInitialization,
 } from './helpers.js'
@@ -1469,6 +1476,1389 @@ describe('Unit tests for object access validation', () => {
 
   // ! Duplication of Pending Access Requests
   // #region
+  it('Verify that new access request instances are created for new object admins (with userId argument)', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SC } = await seedElements(userOneCtx, AC!.id)
+
+    // create an access request for user 2 on all objects
+    const catalogRequest = await prisma.accessRequest.create({
+      data: {
+        catalogCollectionId: publicCatalog.id,
+        userId: userTwo.id,
+        objectAdminOrOwnerId: userOne.id,
+        permissionLevel: PermissionLevel.READ,
+      },
+    })
+    const answerCollectionRequest = await prisma.accessRequest.create({
+      data: {
+        answerCollectionId: AC!.id,
+        userId: userTwo.id,
+        objectAdminOrOwnerId: userOne.id,
+        permissionLevel: PermissionLevel.WRITE,
+      },
+    })
+    const elementRequest = await prisma.accessRequest.create({
+      data: {
+        elementId: SC.id,
+        userId: userTwo.id,
+        objectAdminOrOwnerId: userOne.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // add ADMIN permissions for user 3 on all objects
+    await prisma.permission.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          elementId: SC.id,
+          userId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+
+    // create a user group with users 4 and 5 and grant ADMIN permissions to the group on all objects
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userOne.id,
+        admins: { connect: { id: userFive.id } },
+        members: { connect: { id: userFour.id } },
+      },
+    })
+    await prisma.permission.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userGroupId: group.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userGroupId: group.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          elementId: SC.id,
+          userGroupId: group.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+
+    // recompute the derived permissions on all objects without updating the access requests
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+    await recomputeDerivedPermissions({ elementId: SC.id }, prisma)
+
+    // verify that still only three access requests are pending
+    const pendingRequestsCount = await prisma.accessRequest.count()
+    expect(pendingRequestsCount).toBe(3)
+
+    // update the access request instances for user 3 on one object after the other and verify the results
+    await updateAccessRequestInstances(
+      { catalogCollectionId: publicCatalog.id, userId: userThree.id },
+      prisma
+    )
+    const pendingRequestsCount2 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount2).toBe(4)
+    const newRequest1 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newRequest1).toBeTruthy()
+    expect(newRequest1!.permissionLevel).toBe(catalogRequest.permissionLevel)
+
+    await updateAccessRequestInstances(
+      { answerCollectionId: AC!.id, userId: userThree.id },
+      prisma
+    )
+    const pendingRequestsCount3 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount3).toBe(5)
+    const newRequest2 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newRequest2).toBeTruthy()
+    expect(newRequest2!.permissionLevel).toBe(
+      answerCollectionRequest.permissionLevel
+    )
+
+    await updateAccessRequestInstances(
+      { elementId: SC.id, userId: userThree.id },
+      prisma
+    )
+    const pendingRequestsCount4 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount4).toBe(6)
+    const newRequest3 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newRequest3).toBeTruthy()
+    expect(newRequest3!.permissionLevel).toBe(elementRequest.permissionLevel)
+
+    // update the access request instances for user 4 on all objects in the same way
+    await updateAccessRequestInstances(
+      { catalogCollectionId: publicCatalog.id, userId: userFour.id },
+      prisma
+    )
+    const pendingRequestsCount5 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount5).toBe(7)
+    const newRequest4 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(newRequest4).toBeTruthy()
+    expect(newRequest4!.permissionLevel).toBe(catalogRequest.permissionLevel)
+
+    await updateAccessRequestInstances(
+      { answerCollectionId: AC!.id, userId: userFour.id },
+      prisma
+    )
+    const pendingRequestsCount6 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount6).toBe(8)
+    const newRequest5 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(newRequest5).toBeTruthy()
+    expect(newRequest5!.permissionLevel).toBe(
+      answerCollectionRequest.permissionLevel
+    )
+
+    await updateAccessRequestInstances(
+      { elementId: SC.id, userId: userFour.id },
+      prisma
+    )
+    const pendingRequestsCount7 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount7).toBe(9)
+    const newRequest6 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(newRequest6).toBeTruthy()
+    expect(newRequest6!.permissionLevel).toBe(elementRequest.permissionLevel)
+
+    // trigger access request recomputation through derived permissions update for user 5 on all objects
+    await recomputeDerivedPermissions(
+      {
+        catalogCollectionId: publicCatalog.id,
+        userId: userFive.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions(
+      {
+        answerCollectionId: AC!.id,
+        userId: userFive.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions(
+      { elementId: SC.id, userId: userFive.id, updateAccessRequests: true },
+      prisma
+    )
+
+    // verify that the access requests for user 5 have been created
+    const pendingRequestsCount8 = await prisma.accessRequest.count()
+    expect(pendingRequestsCount8).toBe(12)
+
+    const newRequest7 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(newRequest7).toBeTruthy()
+    expect(newRequest7!.permissionLevel).toBe(catalogRequest.permissionLevel)
+
+    const newRequest8 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(newRequest8).toBeTruthy()
+    expect(newRequest8!.permissionLevel).toBe(
+      answerCollectionRequest.permissionLevel
+    )
+
+    const newRequest9 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(newRequest9).toBeTruthy()
+    expect(newRequest9!.permissionLevel).toBe(elementRequest.permissionLevel)
+  })
+
+  it('Verify that access request instances are removed alongisde derived permissions when user looses admin or owner access', async () => {
+    const { publicCatalog } = await seedCatalogCollections(userOneCtx)
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SC } = await seedElements(userOneCtx, AC!.id)
+
+    // add ADMIN permissions for user 3 on all objects
+    await prisma.permission.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          elementId: SC.id,
+          userId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+
+    // create a user group with users 4 and 5 and grant ADMIN permissions to the group on all objects
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userOne.id,
+        admins: { connect: { id: userFive.id } },
+        members: { connect: { id: userFour.id } },
+      },
+    })
+    await prisma.permission.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userGroupId: group.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userGroupId: group.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          elementId: SC.id,
+          userGroupId: group.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+
+    // recompute the derived permissions on all objects without updating the access requests
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+    await recomputeDerivedPermissions({ elementId: SC.id }, prisma)
+
+    // create access requests for user 2 on all objects and linked to all admins
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+    const accessRequestsCount = await prisma.accessRequest.count()
+    expect(accessRequestsCount).toBe(12)
+
+    // remove the admin permissions for user 3 and the group
+    await prisma.permission.deleteMany({
+      where: {
+        OR: [
+          {
+            catalogCollectionId: publicCatalog.id,
+            userId: userThree.id,
+          },
+          {
+            answerCollectionId: AC!.id,
+            userId: userThree.id,
+          },
+          {
+            elementId: SC.id,
+            userId: userThree.id,
+          },
+          {
+            catalogCollectionId: publicCatalog.id,
+            userGroupId: group.id,
+          },
+          {
+            answerCollectionId: AC!.id,
+            userGroupId: group.id,
+          },
+          {
+            elementId: SC.id,
+            userGroupId: group.id,
+          },
+        ],
+      },
+    })
+
+    // recompute derived permissions without triggering an access request update
+    await recomputeDerivedPermissions(
+      { catalogCollectionId: publicCatalog.id },
+      prisma
+    )
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+    await recomputeDerivedPermissions({ elementId: SC.id }, prisma)
+    const accessRequestsCount2 = await prisma.accessRequest.count()
+    expect(accessRequestsCount2).toBe(12)
+
+    // update the access request instances for user 3 and verify that they are removed correctly
+    await updateAccessRequestInstances(
+      { catalogCollectionId: publicCatalog.id, userId: userThree.id },
+      prisma
+    )
+    await updateAccessRequestInstances(
+      { answerCollectionId: AC!.id, userId: userThree.id },
+      prisma
+    )
+    await updateAccessRequestInstances(
+      { elementId: SC.id, userId: userThree.id },
+      prisma
+    )
+    const accessRequestsCount3 = await prisma.accessRequest.count()
+    expect(accessRequestsCount3).toBe(9)
+
+    const accessRequest1 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(accessRequest1).toBeNull()
+    const accessRequest2 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(accessRequest2).toBeNull()
+    const accessRequest3 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(accessRequest3).toBeNull()
+
+    // update the access request instances for user 4 and verify that they are removed correctly
+    await updateAccessRequestInstances(
+      { catalogCollectionId: publicCatalog.id, userId: userFour.id },
+      prisma
+    )
+    await updateAccessRequestInstances(
+      { answerCollectionId: AC!.id, userId: userFour.id },
+      prisma
+    )
+    await updateAccessRequestInstances(
+      { elementId: SC.id, userId: userFour.id },
+      prisma
+    )
+    const accessRequestsCount4 = await prisma.accessRequest.count()
+    expect(accessRequestsCount4).toBe(6)
+
+    const accessRequest4 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(accessRequest4).toBeNull()
+    const accessRequest5 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(accessRequest5).toBeNull()
+    const accessRequest6 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(accessRequest6).toBeNull()
+
+    // update the access request instances for user 5 through the derived permissions recomputation function and verify that they are removed correctly
+    await recomputeDerivedPermissions(
+      {
+        catalogCollectionId: publicCatalog.id,
+        userId: userFive.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions(
+      {
+        answerCollectionId: AC!.id,
+        userId: userFive.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions(
+      { elementId: SC.id, userId: userFive.id, updateAccessRequests: true },
+      prisma
+    )
+    const accessRequestsCount5 = await prisma.accessRequest.count()
+    expect(accessRequestsCount5).toBe(3)
+
+    const accessRequest7 = await prisma.accessRequest.findUnique({
+      where: {
+        catalogCollectionId_userId_objectAdminOrOwnerId: {
+          catalogCollectionId: publicCatalog.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(accessRequest7).toBeNull()
+    const accessRequest8 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(accessRequest8).toBeNull()
+    const accessRequest9 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(accessRequest9).toBeNull()
+
+    // verify that on object deletion, the access requests are removed through cascading delete
+    await prisma.catalogCollection.delete({
+      where: { id: publicCatalog.id },
+    })
+    await prisma.answerCollection.delete({
+      where: { id: AC!.id },
+    })
+    await prisma.element.delete({
+      where: { id: SC.id },
+    })
+    const accessRequestsCount6 = await prisma.accessRequest.count()
+    expect(accessRequestsCount6).toBe(0)
+  })
+
+  it('Verify that access requests for soft-deleted objects are automatically removed for all users', async () => {
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SC } = await seedElements(userOneCtx, AC!.id)
+    const liveQuiz = await prisma.liveQuiz.create({
+      data: {
+        name: 'Live Quiz Test',
+        displayName: 'Live Quiz Test',
+        description: 'Test Description',
+        ownerId: userOne.id,
+      },
+    })
+    const course = await prisma.course.create({
+      data: {
+        name: 'Course Test',
+        displayName: 'Course Test',
+        description: 'Test Description',
+        pinCode: 8888,
+        startDate: new Date(),
+        endDate: new Date(),
+        groupDeadlineDate: new Date(),
+        ownerId: userOne.id,
+      },
+    })
+    const practiceQuiz = await prisma.practiceQuiz.create({
+      data: {
+        name: 'Practice Quiz Test',
+        displayName: 'Practice Quiz Test',
+        description: 'Test Description',
+        ownerId: userOne.id,
+        courseId: course.id,
+      },
+    })
+    const microlearning = await prisma.microLearning.create({
+      data: {
+        name: 'Microlearning Test',
+        displayName: 'Microlearning Test',
+        description: 'Test Description',
+        scheduledStartAt: new Date(),
+        scheduledEndAt: new Date(),
+        ownerId: userOne.id,
+        courseId: course.id,
+      },
+    })
+    const groupActivity = await prisma.groupActivity.create({
+      data: {
+        name: 'Group Activity Test',
+        displayName: 'Group Activity Test',
+        description: 'Test Description',
+        scheduledStartAt: new Date(),
+        scheduledEndAt: new Date(),
+        ownerId: userOne.id,
+        courseId: course.id,
+      },
+    })
+
+    // create access requests for user 2 on all objects
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          liveQuizId: liveQuiz.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          courseId: course.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          practiceQuizId: practiceQuiz.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          microLearningId: microlearning.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          groupActivityId: groupActivity.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+      ],
+    })
+    const accessRequestsCount = await prisma.accessRequest.count()
+    expect(accessRequestsCount).toBe(7)
+
+    // soft delete the objects one after the other and verify that the corresponding access requests are removed
+    // to update access requests use a combination of the update access requests functions (with and without userId) and the derived permission recomputation
+    await prisma.answerCollection.update({
+      where: { id: AC!.id },
+      data: { isDeleted: true },
+    })
+    await updateAccessRequestInstances(
+      {
+        answerCollectionId: AC!.id,
+        userId: userOne.id,
+        objectSoftDeleted: true,
+      },
+      prisma
+    )
+    const accessRequestsCount2 = await prisma.accessRequest.count()
+    expect(accessRequestsCount2).toBe(6)
+
+    await prisma.element.update({
+      where: { id: SC.id },
+      data: { isDeleted: true },
+    })
+    await updateAccessRequestInstances(
+      { elementId: SC.id, userId: userOne.id, objectSoftDeleted: true },
+      prisma
+    )
+    const accessRequestsCount3 = await prisma.accessRequest.count()
+    expect(accessRequestsCount3).toBe(5)
+
+    await prisma.liveQuiz.update({
+      where: { id: liveQuiz.id },
+      data: { isDeleted: true },
+    })
+    await updateAccessRequestInstances(
+      { liveQuizId: liveQuiz.id, objectSoftDeleted: true },
+      prisma
+    )
+    const accessRequestsCount4 = await prisma.accessRequest.count()
+    expect(accessRequestsCount4).toBe(4)
+
+    await prisma.practiceQuiz.update({
+      where: { id: practiceQuiz.id },
+      data: { isDeleted: true },
+    })
+    await updateAccessRequestInstances(
+      { practiceQuizId: practiceQuiz.id, objectSoftDeleted: true },
+      prisma
+    )
+    const accessRequestsCount5 = await prisma.accessRequest.count()
+    expect(accessRequestsCount5).toBe(3)
+
+    await prisma.microLearning.update({
+      where: { id: microlearning.id },
+      data: { isDeleted: true },
+    })
+    await recomputeDerivedPermissions(
+      {
+        microLearningId: microlearning.id,
+        userId: userOne.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    const accessRequestsCount6 = await prisma.accessRequest.count()
+    expect(accessRequestsCount6).toBe(2)
+
+    await prisma.groupActivity.update({
+      where: { id: groupActivity.id },
+      data: { isDeleted: true },
+    })
+    await recomputeDerivedPermissions(
+      { groupActivityId: groupActivity.id, updateAccessRequests: true },
+      prisma
+    )
+    const accessRequestsCount7 = await prisma.accessRequest.count()
+    expect(accessRequestsCount7).toBe(1)
+  })
+
+  it('Test the combination of permission propagation and access request instance updates', async () => {
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SE } = await seedElements(userOneCtx, AC!.id)
+    const liveQuiz = await prisma.liveQuiz.create({
+      data: {
+        name: 'Live Quiz Test',
+        displayName: 'Live Quiz Test',
+        description: 'Test Description',
+        ownerId: userOne.id,
+        blocks: {
+          create: [
+            {
+              order: 0,
+              elements: {
+                create: [
+                  {
+                    order: 0,
+                    elementId: SE.id,
+                    migrationId: '',
+                    type: ElementInstanceType.LIVE_QUIZ,
+                    elementType: ElementType.SC,
+                    options: {},
+                    elementData: {} as SelectionElementData,
+                    results: {} as ElementInstanceResults,
+                    anonymousResults: {} as ElementInstanceResults,
+                    ownerId: userOne.id,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    // create access requests for user 2 on all objects
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SE.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          liveQuizId: liveQuiz.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+    const accessRequestsCount = await prisma.accessRequest.count()
+    expect(accessRequestsCount).toBe(3)
+
+    // add ADMIN permissions for user 3 on the live quiz
+    await prisma.permission.create({
+      data: {
+        liveQuizId: liveQuiz.id,
+        userId: userThree.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // trigger a recomputation of the derived permissions and verify that derived
+    // permissions on all three objects were created with the correct permission levels
+    await recomputeDerivedPermissions(
+      {
+        liveQuizId: liveQuiz.id,
+        userId: userThree.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+
+    const derivedPermissionLiveQuiz = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userThree.id,
+          },
+        },
+      }
+    )
+    expect(derivedPermissionLiveQuiz).toBeTruthy()
+    expect(derivedPermissionLiveQuiz!.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+
+    const derivedPermissionElement = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SE.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedPermissionElement).toBeTruthy()
+    expect(derivedPermissionElement!.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+
+    const derivedPermissionAnswerCollection =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC!.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(derivedPermissionAnswerCollection).toBeTruthy()
+    expect(derivedPermissionAnswerCollection!.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+
+    // verify that new access request instances have been created for user 3 on the objects where they are admin
+    const accessRequestsCount2 = await prisma.accessRequest.count()
+    expect(accessRequestsCount2).toBe(5)
+
+    const newAccessRequestLiveQuiz = await prisma.accessRequest.findUnique({
+      where: {
+        liveQuizId_userId_objectAdminOrOwnerId: {
+          liveQuizId: liveQuiz.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newAccessRequestLiveQuiz).toBeTruthy()
+    expect(newAccessRequestLiveQuiz!.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+
+    const newAccessRequestElement = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SE.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newAccessRequestElement).toBeTruthy()
+    expect(newAccessRequestElement!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const newAccessRequestAnswerCollection =
+      await prisma.accessRequest.findUnique({
+        where: {
+          answerCollectionId_userId_objectAdminOrOwnerId: {
+            answerCollectionId: AC!.id,
+            userId: userTwo.id,
+            objectAdminOrOwnerId: userThree.id,
+          },
+        },
+      })
+    expect(newAccessRequestAnswerCollection).toBeNull()
+
+    // remove the direct ADMIN permission on the live quiz again
+    await prisma.permission.delete({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userThree.id,
+        },
+      },
+    })
+
+    // trigger a recomputation of the derived permissions and verify that the access request instances are removed
+    await recomputeDerivedPermissions(
+      {
+        liveQuizId: liveQuiz.id,
+        userId: userThree.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    const accessRequestsCount3 = await prisma.accessRequest.count()
+    expect(accessRequestsCount3).toBe(3)
+
+    const removedAccessRequestLiveQuiz = await prisma.accessRequest.findUnique({
+      where: {
+        liveQuizId_userId_objectAdminOrOwnerId: {
+          liveQuizId: liveQuiz.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(removedAccessRequestLiveQuiz).toBeNull()
+
+    const removedAccessRequestElement = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SE.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(removedAccessRequestElement).toBeNull()
+  })
+
+  it('Verify that triggering an access request instances update without userId does update the instances for all users', async () => {
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SC } = await seedElements(userOneCtx, AC!.id)
+
+    // create access requests for user 2 on all objects
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+      ],
+    })
+    const accessRequestsCount = await prisma.accessRequest.count()
+    expect(accessRequestsCount).toBe(2)
+
+    // grant ADMIN permissions to user 3 on both objects
+    await prisma.permission.create({
+      data: {
+        answerCollectionId: AC!.id,
+        userId: userThree.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    await prisma.permission.create({
+      data: {
+        elementId: SC.id,
+        userId: userThree.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // create a user gorup with users 4, 5, and 6 and grant ADMIN permissions to the group on both objects
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userSix.id,
+        admins: { connect: [{ id: userFive.id }, { id: userOne.id }] },
+        members: { connect: { id: userFour.id } },
+      },
+    })
+    await prisma.permission.create({
+      data: {
+        answerCollectionId: AC!.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    await prisma.permission.create({
+      data: {
+        elementId: SC.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // trigger a recomputation of the derived permissions without updating the access requests
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+    await updateAccessRequestInstances({ answerCollectionId: AC!.id }, prisma)
+    const accessRequestsCount2 = await prisma.accessRequest.count()
+    expect(accessRequestsCount2).toBe(6)
+
+    const newAccessRequest1 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newAccessRequest1).toBeTruthy()
+    expect(newAccessRequest1!.permissionLevel).toBe(PermissionLevel.READ)
+
+    const newAccessRequest2 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(newAccessRequest2).toBeTruthy()
+    expect(newAccessRequest2!.permissionLevel).toBe(PermissionLevel.READ)
+
+    const newAccessRequest3 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(newAccessRequest3).toBeTruthy()
+    expect(newAccessRequest3!.permissionLevel).toBe(PermissionLevel.READ)
+
+    const newAccessRequest4 = await prisma.accessRequest.findUnique({
+      where: {
+        answerCollectionId_userId_objectAdminOrOwnerId: {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userSix.id,
+        },
+      },
+    })
+    expect(newAccessRequest4).toBeTruthy()
+    expect(newAccessRequest4!.permissionLevel).toBe(PermissionLevel.READ)
+
+    // trigger a recomputation of the dervied permissions, including an update of the corresponding access request instances
+    await recomputeDerivedPermissions(
+      {
+        elementId: SC.id,
+        updateAccessRequests: true,
+      },
+      prisma
+    )
+    const accessRequestsCount3 = await prisma.accessRequest.count()
+    expect(accessRequestsCount3).toBe(10)
+
+    const newAccessRequest5 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+        },
+      },
+    })
+    expect(newAccessRequest5).toBeTruthy()
+    expect(newAccessRequest5!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const newAccessRequest6 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+        },
+      },
+    })
+    expect(newAccessRequest6).toBeTruthy()
+    expect(newAccessRequest6!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const newAccessRequest7 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+        },
+      },
+    })
+    expect(newAccessRequest7).toBeTruthy()
+    expect(newAccessRequest7!.permissionLevel).toBe(PermissionLevel.WRITE)
+
+    const newAccessRequest8 = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userSix.id,
+        },
+      },
+    })
+    expect(newAccessRequest8).toBeTruthy()
+    expect(newAccessRequest8!.permissionLevel).toBe(PermissionLevel.WRITE)
+  })
+
+  it('Verify that triggering an access request instances update without userId after permission revocation does update the instances for all users', async () => {
+    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { SC } = await seedElements(userOneCtx, AC!.id)
+
+    // grant ADMIN permissions to user 3 on both objects
+    await prisma.permission.create({
+      data: {
+        answerCollectionId: AC!.id,
+        userId: userThree.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    await prisma.permission.create({
+      data: {
+        elementId: SC.id,
+        userId: userThree.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // create a user gorup with users 4, 5, and 6 and grant ADMIN permissions to the group on both objects
+    const group = await prisma.userGroup.create({
+      data: {
+        name: 'Test Group',
+        ownerId: userSix.id,
+        admins: { connect: [{ id: userFive.id }, { id: userOne.id }] },
+        members: { connect: { id: userFour.id } },
+      },
+    })
+    await prisma.permission.create({
+      data: {
+        answerCollectionId: AC!.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+    await prisma.permission.create({
+      data: {
+        elementId: SC.id,
+        userGroupId: group.id,
+        permissionLevel: PermissionLevel.ADMIN,
+      },
+    })
+
+    // trigger a recomputation of the derived permissions for both objects
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+    await recomputeDerivedPermissions({ elementId: SC.id }, prisma)
+
+    // create access requests for user 2 on all objects for all admin users (1, 3, 4, 5, and 6)
+    await prisma.accessRequest.createMany({
+      data: [
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userThree.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFour.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userFive.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          answerCollectionId: AC!.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userSix.id,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userSix.id,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+      ],
+    })
+    const accessRequestsCount = await prisma.accessRequest.count()
+    expect(accessRequestsCount).toBe(10)
+
+    // revoke the admin permissions on the answer collection and recompute the access requests using the dedicated function
+    await prisma.permission.deleteMany({
+      where: {
+        OR: [
+          {
+            answerCollectionId: AC!.id,
+            userId: userThree.id,
+          },
+          {
+            answerCollectionId: AC!.id,
+            userGroupId: group.id,
+          },
+        ],
+      },
+    })
+    await recomputeDerivedPermissions({ answerCollectionId: AC!.id }, prisma)
+    await updateAccessRequestInstances({ answerCollectionId: AC!.id }, prisma)
+
+    // verify that the admin access request instances for the answer collection were removed
+    const accessRequestsCount2 = await prisma.accessRequest.count()
+    expect(accessRequestsCount2).toBe(6)
+
+    // revoke the admin permissions on the element and recompute the access requests inside the derived permissions function
+    await prisma.permission.deleteMany({
+      where: {
+        OR: [
+          {
+            elementId: SC.id,
+            userId: userThree.id,
+          },
+          {
+            elementId: SC.id,
+            userGroupId: group.id,
+          },
+        ],
+      },
+    })
+    await recomputeDerivedPermissions(
+      { elementId: SC.id, updateAccessRequests: true },
+      prisma
+    )
+
+    // verify that the admin access request instances for the element were removed
+    const accessRequestsCount3 = await prisma.accessRequest.count()
+    expect(accessRequestsCount3).toBe(2)
+
+    // verify that only the access request instances for the owner persist
+    const ownerAnswerCollectionAccessRequest =
+      await prisma.accessRequest.findUnique({
+        where: {
+          answerCollectionId_userId_objectAdminOrOwnerId: {
+            answerCollectionId: AC!.id,
+            userId: userTwo.id,
+            objectAdminOrOwnerId: userOne.id,
+          },
+        },
+      })
+    expect(ownerAnswerCollectionAccessRequest).toBeTruthy()
+    expect(ownerAnswerCollectionAccessRequest!.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+
+    const ownerElementAccessRequest = await prisma.accessRequest.findUnique({
+      where: {
+        elementId_userId_objectAdminOrOwnerId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+          objectAdminOrOwnerId: userOne.id,
+        },
+      },
+    })
+    expect(ownerElementAccessRequest).toBeTruthy()
+    expect(ownerElementAccessRequest!.permissionLevel).toBe(
+      PermissionLevel.WRITE
+    )
+  })
+
   it('Test that resolving an access request with ADMIN permissions triggers a duplication of pending access requests', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
     const [AC1] = await seedAnswerCollections(userOneCtx)

--- a/packages/graphql/test/access.test.ts
+++ b/packages/graphql/test/access.test.ts
@@ -1478,7 +1478,7 @@ describe('Unit tests for object access validation', () => {
   // #region
   it('Verify that new access request instances are created for new object admins (with userId argument)', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC!.id)
 
     // create an access request for user 2 on all objects
@@ -1750,7 +1750,7 @@ describe('Unit tests for object access validation', () => {
 
   it('Verify that access request instances are removed alongisde derived permissions when user looses admin or owner access', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC!.id)
 
     // add ADMIN permissions for user 3 on all objects
@@ -2097,7 +2097,7 @@ describe('Unit tests for object access validation', () => {
   })
 
   it('Verify that access requests for soft-deleted objects are automatically removed for all users', async () => {
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC!.id)
     const liveQuiz = await prisma.liveQuiz.create({
       data: {
@@ -2279,7 +2279,7 @@ describe('Unit tests for object access validation', () => {
   })
 
   it('Test the combination of permission propagation and access request instance updates', async () => {
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC!.id)
     const liveQuiz = await prisma.liveQuiz.create({
       data: {
@@ -2489,7 +2489,7 @@ describe('Unit tests for object access validation', () => {
   })
 
   it('Verify that triggering an access request instances update without userId does update the instances for all users', async () => {
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC!.id)
 
     // create access requests for user 2 on all objects
@@ -2667,7 +2667,7 @@ describe('Unit tests for object access validation', () => {
   })
 
   it('Verify that triggering an access request instances update without userId after permission revocation does update the instances for all users', async () => {
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC!.id)
 
     // grant ADMIN permissions to user 3 on both objects
@@ -2861,7 +2861,7 @@ describe('Unit tests for object access validation', () => {
 
   it('Test that resolving an access request with ADMIN permissions triggers a duplication of pending access requests', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // create two access requests for the public catalog collection (user 2 and 3)
     const catalogRequest2 = await prisma.accessRequest.create({
@@ -2983,7 +2983,7 @@ describe('Unit tests for object access validation', () => {
 
   it('Test that increasing the level of an existing individual permission to ADMIN level results in a duplication of all pending access requests', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // grant READ permissions to user 2 on the public catalog collection and the answer collection
     const catalogPermission = await prisma.permission.create({
@@ -3270,7 +3270,7 @@ describe('Unit tests for object access validation', () => {
 
   it('Test that reduction the level of an existing individual permission from ADMIN level results in a duplication of all pending access requests', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // grant ADMIN permissions to user 2 on the public catalog collection and the answer collection
     const catalogPermission = await prisma.permission.create({
@@ -3741,7 +3741,7 @@ describe('Unit tests for object access validation', () => {
 
   it('Verify that on revocation of individual ADMIN object permissions, access request instances are removed for the previous ADMIN', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // grant ADMIN permissions to user 2 on the public catalog collection and the answer collection
     const catalogPermission = await prisma.permission.create({
@@ -4372,7 +4372,7 @@ describe('Unit tests for object access validation', () => {
   })
 
   it('Verify that any pending access requests are also assigned to new owner on answer collection ownership transfer', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // create access requests for users 3 and 4
     await prisma.accessRequest.createMany({
@@ -4466,7 +4466,7 @@ describe('Unit tests for object access validation', () => {
 
   it('Verify that any pending access requests to an object are duplicated when granting ADMIN permissions to a new user', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // create access requests for users 3 and 4
     await prisma.accessRequest.createMany({

--- a/packages/graphql/test/access.test.ts
+++ b/packages/graphql/test/access.test.ts
@@ -1474,7 +1474,7 @@ describe('Unit tests for object access validation', () => {
   })
   // #endregion
 
-  // ! Duplication of Pending Access Requests
+  // ! Updates of Pending Access Requests
   // #region
   it('Verify that new access request instances are created for new object admins (with userId argument)', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)

--- a/packages/graphql/test/catalogSharing.test.ts
+++ b/packages/graphql/test/catalogSharing.test.ts
@@ -768,7 +768,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(restrictedCatalog3?.isShared).toBe(false)
 
     // add an object to the public catalog collection and verify that it is now shown to user 3
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     await prisma.catalogCollectionAssignment.create({
       data: {
         catalogCollectionId: publicCatalog.id,
@@ -1018,7 +1018,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       await seedCatalogCollections(userOneCtx)
 
     // create an answer collection and assign it to the restricted catalog collection
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     await prisma.catalogCollectionAssignment.create({
       data: {
         catalogCollectionId: restrictedCatalog.id,
@@ -1064,7 +1064,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
   // ! Catalog Object Sharing (general functions without explicit object dependence)
   // #region
   it('Verify that the correct number of access requests is shown to all users', async () => {
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
 
     // add three two access requests for user 1 and one for user 2
     await prisma.accessRequest.createMany({
@@ -1098,7 +1098,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
   })
 
   it('Verify that access requests are correctly removed and new permissions created when being resolved', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // add two access requests for users 2 and 3 on the answer collection
     const request1 = await prisma.accessRequest.create({
@@ -1253,7 +1253,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
   })
 
   it('Make sure that objects in the catalog are queried correctly', async () => {
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     const { SC, MC } = await seedElements(userOneCtx, AC1!.id)
     const { activityId1, activityId2 } = await seedLiveQuizTemplates(prisma)
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
@@ -2366,7 +2366,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
 
   it('Verify that the object access of an object included in the catalog can be modified (assuming sufficient permissions)', async () => {
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // assign the answer collection to the top-level and public catalog collections
     const assignment1 = await prisma.catalogCollectionAssignment.create({

--- a/packages/graphql/test/catalogSharing.test.ts
+++ b/packages/graphql/test/catalogSharing.test.ts
@@ -99,7 +99,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         userTwoCtx
       )
     expect(valid1).toBe(true)
-    expect(catalog1).toBeDefined()
+    expect(catalog1).not.toBeNull()
     expect(catalog1?.id).toBe(MISSING_CATALOG_COLLECTION_ID)
 
     // seed public and restricted catalog collections with user 1 as the owner
@@ -116,7 +116,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         userOneCtx
       )
     expect(valid2).toBe(true)
-    expect(catalog2).toBeDefined()
+    expect(catalog2).not.toBeNull()
     expect(catalog2?.id).toBe(publicCatalog.id)
 
     const { valid: valid3, catalogCollection: catalog3 } =
@@ -128,7 +128,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         userOneCtx
       )
     expect(valid3).toBe(true)
-    expect(catalog3).toBeDefined()
+    expect(catalog3).not.toBeNull()
     expect(catalog3?.id).toBe(restrictedCatalog.id)
 
     // verify that the validation fails for user 2 without access to neither catalog collection
@@ -186,7 +186,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         userThreeCtx
       )
     expect(valid6).toBe(true)
-    expect(catalog6).toBeDefined()
+    expect(catalog6).not.toBeNull()
     expect(catalog6?.id).toBe(publicCatalog.id)
 
     const { valid: valid7, catalogCollection: catalog7 } =
@@ -198,7 +198,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         userThreeCtx
       )
     expect(valid7).toBe(true)
-    expect(catalog7).toBeDefined()
+    expect(catalog7).not.toBeNull()
     expect(catalog7?.id).toBe(publicCatalog.id)
 
     const { valid: valid8, catalogCollection: catalog8 } =
@@ -210,7 +210,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         userFourCtx
       )
     expect(valid8).toBe(true)
-    expect(catalog8).toBeDefined()
+    expect(catalog8).not.toBeNull()
     expect(catalog8?.id).toBe(restrictedCatalog.id)
 
     const { valid: failed1, catalogCollection: failedCatalog1 } =
@@ -410,7 +410,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       },
       userOneCtx
     )
-    expect(publicCatalog).toBeDefined()
+    expect(publicCatalog).not.toBeNull()
     expect(publicCatalog.name).toBe(publicName)
     expect(publicCatalog.access).toBe(ObjectAccess.PUBLIC)
 
@@ -421,7 +421,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       },
       userOneCtx
     )
-    expect(restrictedCatalog).toBeDefined()
+    expect(restrictedCatalog).not.toBeNull()
     expect(restrictedCatalog.name).toBe(restrictedName)
     expect(restrictedCatalog.access).toBe(ObjectAccess.RESTRICTED)
 
@@ -429,14 +429,14 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const dbCatalog = await prisma.catalogCollection.findUnique({
       where: { id: publicCatalog.id },
     })
-    expect(dbCatalog).toBeDefined()
+    expect(dbCatalog).not.toBeNull()
     expect(dbCatalog?.name).toBe(publicName)
     expect(dbCatalog?.access).toBe(ObjectAccess.PUBLIC)
     expect(dbCatalog?.ownerId).toBe(userOne.id)
     const dbCatalog2 = await prisma.catalogCollection.findUnique({
       where: { id: restrictedCatalog.id },
     })
-    expect(dbCatalog2).toBeDefined()
+    expect(dbCatalog2).not.toBeNull()
     expect(dbCatalog2?.name).toBe(restrictedName)
     expect(dbCatalog2?.access).toBe(ObjectAccess.RESTRICTED)
     expect(dbCatalog2?.ownerId).toBe(userOne.id)
@@ -499,7 +499,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: publicCatalog.id },
       userOneCtx
     )
-    expect(info3).toBeDefined()
+    expect(info3).not.toBeNull()
     expect(info3!.id).toBe(publicCatalog.id)
     expect(info3!.name).toBe(publicCatalog.name)
     expect(info3!.access).toBe(ObjectAccess.PUBLIC)
@@ -515,7 +515,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: publicCatalog.id },
       userTwoCtx
     )
-    expect(info4).toBeDefined()
+    expect(info4).not.toBeNull()
     expect(info4!.id).toBe(publicCatalog.id)
     expect(info4!.name).toBe(publicCatalog.name)
     expect(info4!.access).toBe(ObjectAccess.PUBLIC)
@@ -532,7 +532,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: publicCatalog.id },
       userFiveCtx
     )
-    expect(info5).toBeDefined()
+    expect(info5).not.toBeNull()
     expect(info5!.id).toBe(publicCatalog.id)
     expect(info5!.name).toBe(publicCatalog.name)
     expect(info5!.access).toBe(ObjectAccess.PUBLIC)
@@ -549,7 +549,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: restrictedCatalog.id },
       userOneCtx
     )
-    expect(info6).toBeDefined()
+    expect(info6).not.toBeNull()
     expect(info6!.id).toBe(restrictedCatalog.id)
     expect(info6!.name).toBe(restrictedCatalog.name)
     expect(info6!.access).toBe(ObjectAccess.RESTRICTED)
@@ -565,7 +565,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: restrictedCatalog.id },
       userTwoCtx
     )
-    expect(info7).toBeDefined()
+    expect(info7).not.toBeNull()
     expect(info7!.id).toBe(restrictedCatalog.id)
     expect(info7!.name).toBe(restrictedCatalog.name)
     expect(info7!.access).toBe(ObjectAccess.RESTRICTED)
@@ -581,7 +581,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: restrictedCatalog.id },
       userThreeCtx
     )
-    expect(info8).toBeDefined()
+    expect(info8).not.toBeNull()
     expect(info8!.id).toBe(restrictedCatalog.id)
     expect(info8!.name).toBe(restrictedCatalog.name)
     expect(info8!.access).toBe(ObjectAccess.RESTRICTED)
@@ -597,7 +597,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: restrictedCatalog.id },
       userFourCtx
     )
-    expect(info9).toBeDefined()
+    expect(info9).not.toBeNull()
     expect(info9!.id).toBe(restrictedCatalog.id)
     expect(info9!.name).toBe(restrictedCatalog.name)
     expect(info9!.access).toBe(ObjectAccess.RESTRICTED)
@@ -627,7 +627,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const updatedCatalog = await prisma.catalogCollection.findUnique({
       where: { id: publicCatalog.id },
     })
-    expect(updatedCatalog).toBeDefined()
+    expect(updatedCatalog).not.toBeNull()
     expect(updatedCatalog?.access).toBe(ObjectAccess.RESTRICTED)
 
     // verify that an audit log entry has been created successfully
@@ -662,7 +662,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const updatedCatalog = await prisma.catalogCollection.findUnique({
       where: { id: publicCatalog.id },
     })
-    expect(updatedCatalog).toBeDefined()
+    expect(updatedCatalog).not.toBeNull()
     expect(updatedCatalog?.name).toBe(newName)
   })
 
@@ -685,7 +685,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
 
     // check that the created catalog collections are loaded correctly
     const catalogs1 = await getCatalogCollectionsList(userOneCtx)
-    expect(catalogs1).toBeDefined()
+    expect(catalogs1).not.toBeNull()
     expect(catalogs1.length).toBe(2)
 
     const publicCatalog1 = catalogs1.find(
@@ -694,8 +694,8 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const restrictedCatalog1 = catalogs1.find(
       (catalog) => catalog.id === restrictedCatalog.id
     )
-    expect(publicCatalog1).toBeDefined()
-    expect(restrictedCatalog1).toBeDefined()
+    expect(publicCatalog1).not.toBeNull()
+    expect(restrictedCatalog1).not.toBeNull()
     expect(publicCatalog1?.name).toBe(publicCatalog.name)
     expect(publicCatalog1?.access).toBe(ObjectAccess.PUBLIC)
     expect(publicCatalog1?.ownerId).toBe(userOne.id)
@@ -716,7 +716,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(restrictedCatalog1?.isShared).toBe(false)
 
     const catalogs2 = await getCatalogCollectionsList(userTwoCtx)
-    expect(catalogs2).toBeDefined()
+    expect(catalogs2).not.toBeNull()
     expect(catalogs2.length).toBe(2)
 
     const publicCatalog2 = catalogs2.find(
@@ -725,8 +725,8 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const restrictedCatalog2 = catalogs2.find(
       (catalog) => catalog.id === restrictedCatalog.id
     )
-    expect(publicCatalog2).toBeDefined()
-    expect(restrictedCatalog2).toBeDefined()
+    expect(publicCatalog2).not.toBeNull()
+    expect(restrictedCatalog2).not.toBeNull()
     expect(publicCatalog2?.name).toBe(publicCatalog.name)
     expect(publicCatalog2?.access).toBe(ObjectAccess.PUBLIC)
     expect(publicCatalog2?.ownerId).toBe(userOne.id)
@@ -747,7 +747,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     expect(restrictedCatalog2?.isShared).toBe(false)
 
     const catalogs3 = await getCatalogCollectionsList(userThreeCtx)
-    expect(catalogs3).toBeDefined()
+    expect(catalogs3).not.toBeNull()
     expect(catalogs3.length).toBe(1)
     const publicCatalog3 = catalogs3.find(
       (catalog) => catalog.id === publicCatalog.id
@@ -756,7 +756,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       (catalog) => catalog.id === restrictedCatalog.id
     )
     expect(publicCatalog3).toBeUndefined()
-    expect(restrictedCatalog3).toBeDefined()
+    expect(restrictedCatalog3).not.toBeNull()
     expect(restrictedCatalog3?.name).toBe(restrictedCatalog.name)
     expect(restrictedCatalog3?.access).toBe(ObjectAccess.RESTRICTED)
     expect(restrictedCatalog3?.ownerId).toBe(userOne.id)
@@ -777,7 +777,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     })
 
     const catalogs4 = await getCatalogCollectionsList(userThreeCtx)
-    expect(catalogs4).toBeDefined()
+    expect(catalogs4).not.toBeNull()
     expect(catalogs4.length).toBe(2)
     const publicCatalog4 = catalogs4.find(
       (catalog) => catalog.id === publicCatalog.id
@@ -785,8 +785,8 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const restrictedCatalog4 = catalogs4.find(
       (catalog) => catalog.id === restrictedCatalog.id
     )
-    expect(publicCatalog4).toBeDefined()
-    expect(restrictedCatalog4).toBeDefined()
+    expect(publicCatalog4).not.toBeNull()
+    expect(restrictedCatalog4).not.toBeNull()
     expect(publicCatalog4?.name).toBe(publicCatalog.name)
     expect(publicCatalog4?.access).toBe(ObjectAccess.PUBLIC)
     expect(publicCatalog4?.ownerId).toBe(userOne.id)
@@ -834,7 +834,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(ownerAccessRequest).toBeDefined()
+    expect(ownerAccessRequest).not.toBeNull()
     expect(ownerAccessRequest?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const adminAccessRequest = await prisma.accessRequest.findUnique({
@@ -846,7 +846,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(adminAccessRequest).toBeDefined()
+    expect(adminAccessRequest).not.toBeNull()
     expect(adminAccessRequest?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     // verify that the corresponding audit log entries have been created successfully
@@ -963,7 +963,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(ownerAccessRequest2).toBeDefined()
+    expect(ownerAccessRequest2).not.toBeNull()
     expect(ownerAccessRequest2?.permissionLevel).toBe(PermissionLevel.READ)
 
     const adminAccessRequest2 = await prisma.accessRequest.findUnique({
@@ -975,7 +975,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(adminAccessRequest2).toBeDefined()
+    expect(adminAccessRequest2).not.toBeNull()
     expect(adminAccessRequest2?.permissionLevel).toBe(PermissionLevel.READ)
 
     // request access again with WRITE permissions and verify that the permission level is updated accordingly
@@ -997,7 +997,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(ownerAccessRequest3).toBeDefined()
+    expect(ownerAccessRequest3).not.toBeNull()
     expect(ownerAccessRequest3?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const adminAccessRequest3 = await prisma.accessRequest.findUnique({
@@ -1009,7 +1009,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(adminAccessRequest3).toBeDefined()
+    expect(adminAccessRequest3).not.toBeNull()
     expect(adminAccessRequest3?.permissionLevel).toBe(PermissionLevel.WRITE)
   })
 
@@ -1144,7 +1144,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         id: request1.id,
       },
     })
-    expect(dbRequest1).toBeDefined()
+    expect(dbRequest1).not.toBeNull()
 
     // deny the access request and verify that it is removed from the database
     const success1 = await resolveObjectSharingRequest(
@@ -1218,7 +1218,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(directPermission).toBeDefined()
+    expect(directPermission).not.toBeNull()
     expect(directPermission?.permissionLevel).toBe(PermissionLevel.READ)
     expect(directPermission?.answerCollectionId).toBe(AC1!.id)
     expect(directPermission?.userId).toBe(userFour.id)
@@ -1231,7 +1231,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(derivedPermission).toBeDefined()
+    expect(derivedPermission).not.toBeNull()
     expect(derivedPermission?.permissionLevel).toBe(PermissionLevel.READ)
     expect(derivedPermission?.answerCollectionId).toBe(AC1!.id)
     expect(derivedPermission?.userId).toBe(userFour.id)
@@ -1303,7 +1303,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: MISSING_CATALOG_COLLECTION_ID },
       userOneCtx
     )
-    expect(catalogObjects).toBeDefined()
+    expect(catalogObjects).not.toBeNull()
     expect(catalogObjects.length).toBe(3)
 
     const catalogObject1 = catalogObjects.find(
@@ -1318,9 +1318,9 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       (object) =>
         object.id === SC.id && object.objectType === SharingObjectType.ELEMENT
     )
-    expect(catalogObject1).toBeDefined()
-    expect(catalogObject2).toBeDefined()
-    expect(catalogObject3).toBeDefined()
+    expect(catalogObject1).not.toBeNull()
+    expect(catalogObject2).not.toBeNull()
+    expect(catalogObject3).not.toBeNull()
 
     expect(catalogObject1!.id).toBe(AC1!.id)
     expect(catalogObject1!.objectType).toBe(SharingObjectType.ANSWER_COLLECTION)
@@ -1341,7 +1341,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { catalogCollectionId: publicCatalog.id },
       userOneCtx
     )
-    expect(catalogObjects2).toBeDefined()
+    expect(catalogObjects2).not.toBeNull()
     expect(catalogObjects2.length).toBe(3)
 
     const catalogObject4 = catalogObjects2.find(
@@ -1356,9 +1356,9 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       (object) =>
         object.id === MC.id && object.objectType === SharingObjectType.ELEMENT
     )
-    expect(catalogObject4).toBeDefined()
-    expect(catalogObject5).toBeDefined()
-    expect(catalogObject6).toBeDefined()
+    expect(catalogObject4).not.toBeNull()
+    expect(catalogObject5).not.toBeNull()
+    expect(catalogObject6).not.toBeNull()
 
     expect(catalogObject4!.id).toBe(AC2!.id)
     expect(catalogObject4!.objectType).toBe(SharingObjectType.ANSWER_COLLECTION)
@@ -1409,7 +1409,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         id: readPermission.id,
       },
     })
-    expect(updatedPermission).toBeDefined()
+    expect(updatedPermission).not.toBeNull()
     expect(updatedPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(updatedPermission?.catalogCollectionId).toBe(publicCatalog.id)
     expect(updatedPermission?.userId).toBe(userTwo.id)
@@ -1474,7 +1474,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         id: readPermission.id,
       },
     })
-    expect(updatedPermission).toBeDefined()
+    expect(updatedPermission).not.toBeNull()
     expect(updatedPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(updatedPermission?.catalogCollectionId).toBe(publicCatalog.id)
     expect(updatedPermission?.userGroupId).toBe(group.id)
@@ -1488,7 +1488,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(ownerPerimission).toBeDefined()
+    expect(ownerPerimission).not.toBeNull()
     expect(ownerPerimission?.permissionLevel).toBe(PermissionLevel.OWNER)
 
     const userTwoPermission = await prisma.derivedPermission.findUnique({
@@ -1499,7 +1499,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(userTwoPermission).toBeDefined()
+    expect(userTwoPermission).not.toBeNull()
     expect(userTwoPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const userThreePermission = await prisma.derivedPermission.findUnique({
@@ -1510,7 +1510,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(userThreePermission).toBeDefined()
+    expect(userThreePermission).not.toBeNull()
     expect(userThreePermission?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const userFourPermission = await prisma.derivedPermission.findUnique({
@@ -1648,7 +1648,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(permissionUserOne).toBeDefined()
+    expect(permissionUserOne).not.toBeNull()
     expect(permissionUserOne?.permissionLevel).toBe(PermissionLevel.OWNER)
     expect(permissionUserOne?.directPermissionId).toBeNull()
 
@@ -1660,7 +1660,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(permissionUserTwo).toBeDefined()
+    expect(permissionUserTwo).not.toBeNull()
     expect(permissionUserTwo?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserTwo?.directPermissionId).toBe(groupPermission.id)
 
@@ -1672,7 +1672,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(permissionUserThree).toBeDefined()
+    expect(permissionUserThree).not.toBeNull()
     expect(permissionUserThree?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserThree?.directPermissionId).toBe(groupPermission.id)
 
@@ -1684,7 +1684,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(permissionUserFour).toBeDefined()
+    expect(permissionUserFour).not.toBeNull()
     expect(permissionUserFour?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserFour?.directPermissionId).toBe(groupPermission.id)
 
@@ -1715,7 +1715,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
           },
         },
       })
-    expect(persistentPermissionUserOne).toBeDefined()
+    expect(persistentPermissionUserOne).not.toBeNull()
     expect(persistentPermissionUserOne?.permissionLevel).toBe(
       PermissionLevel.OWNER
     )
@@ -1808,7 +1808,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
       { id: publicCatalog.id },
       userOneCtx
     )
-    expect(directPermissions).toBeDefined()
+    expect(directPermissions).not.toBeNull()
     expect(directPermissions.length).toBe(2)
 
     const userPermission = directPermissions.find(
@@ -1817,8 +1817,8 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const groupPermission = directPermissions.find(
       (permission) => permission.userGroupId === group.id
     )
-    expect(userPermission).toBeDefined()
-    expect(groupPermission).toBeDefined()
+    expect(userPermission).not.toBeNull()
+    expect(groupPermission).not.toBeNull()
     expect(userPermission?.permissionLevel).toBe(PermissionLevel.READ)
     expect(userPermission?.userId).toBe(userTwo.id)
     expect(userPermission?.permissionId).toBe(dbUserPermission.id)
@@ -2016,7 +2016,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1).not.toBeNull()
     expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.READ)
 
     const dbPermission2 = await prisma.permission.findUnique({
@@ -2027,7 +2027,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2).not.toBeNull()
     expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const dbPermission3 = await prisma.permission.findUnique({
@@ -2038,7 +2038,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(dbPermission3).toBeDefined()
+    expect(dbPermission3).not.toBeNull()
     expect(dbPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the recomputation of derived permissions was triggered correctly
@@ -2050,7 +2050,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.READ)
 
     // verify that the correct audit log entries have been created
@@ -2153,7 +2153,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1).not.toBeNull()
     expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const dbPermission2 = await prisma.permission.findUnique({
@@ -2164,7 +2164,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2).not.toBeNull()
     expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the correct derived permissions have been created in the database
@@ -2177,7 +2177,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
 
     const derivedPermission2 = await prisma.derivedPermission.findUnique({
@@ -2188,7 +2188,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2).not.toBeNull()
     expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const derivedPermission3 = await prisma.derivedPermission.findUnique({
@@ -2199,7 +2199,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3).not.toBeNull()
     expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     const derivedPermission4 = await prisma.derivedPermission.findUnique({
@@ -2210,7 +2210,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
         },
       },
     })
-    expect(derivedPermission4).toBeDefined()
+    expect(derivedPermission4).not.toBeNull()
     expect(derivedPermission4?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the correct audit log entries have been created
@@ -2296,7 +2296,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
 
     // get the pending sharing requests for user 1 and check their content
     const requests = await getCatalogSharingRequests(userOneCtx)
-    expect(requests).toBeDefined()
+    expect(requests).not.toBeNull()
     expect(requests!.length).toBe(3)
     const publicRequestUserThree = requests!.find(
       (request) => request.requestId === request1.id
@@ -2307,9 +2307,9 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const restrictedRequestUserThree = requests!.find(
       (request) => request.requestId === request3.id
     )
-    expect(publicRequestUserThree).toBeDefined()
-    expect(publicRequestUserFour).toBeDefined()
-    expect(restrictedRequestUserThree).toBeDefined()
+    expect(publicRequestUserThree).not.toBeNull()
+    expect(publicRequestUserFour).not.toBeNull()
+    expect(restrictedRequestUserThree).not.toBeNull()
     expect(publicRequestUserThree?.objectType).toBe(
       SharingObjectType.CATALOG_COLLECTION
     )
@@ -2336,7 +2336,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
 
     // get the pending sharing requests for user 2 and check their content
     const requests2 = await getCatalogSharingRequests(userTwoCtx)
-    expect(requests2).toBeDefined()
+    expect(requests2).not.toBeNull()
     expect(requests2!.length).toBe(2)
     const publicRequestUserThree2 = requests2!.find(
       (request) => request.requestId === request2.id
@@ -2344,8 +2344,8 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
     const publicRequestUserFour2 = requests2!.find(
       (request) => request.requestId === request5.id
     )
-    expect(publicRequestUserThree2).toBeDefined()
-    expect(publicRequestUserFour2).toBeDefined()
+    expect(publicRequestUserThree2).not.toBeNull()
+    expect(publicRequestUserFour2).not.toBeNull()
 
     expect(publicRequestUserThree2?.objectType).toBe(
       SharingObjectType.CATALOG_COLLECTION
@@ -2403,7 +2403,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
           id: assignment1.id,
         },
       })
-    expect(updatedAssignment1).toBeDefined()
+    expect(updatedAssignment1).not.toBeNull()
     expect(updatedAssignment1?.access).toBe(ObjectAccess.RESTRICTED)
     expect(updatedAssignment1?.answerCollectionId).toBe(AC1!.id)
     expect(updatedAssignment1?.catalogCollectionId).toBe(
@@ -2416,7 +2416,7 @@ describe('Unit tests for sharing functionalities of catalog collections', () => 
           id: assignment2.id,
         },
       })
-    expect(updatedAssignment2).toBeDefined()
+    expect(updatedAssignment2).not.toBeNull()
     expect(updatedAssignment2?.access).toBe(ObjectAccess.PUBLIC)
     expect(updatedAssignment2?.answerCollectionId).toBe(AC1!.id)
     expect(updatedAssignment2?.catalogCollectionId).toBe(publicCatalog.id)

--- a/packages/graphql/test/elementSharing.test.ts
+++ b/packages/graphql/test/elementSharing.test.ts
@@ -109,7 +109,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permission1).toBeDefined()
+    expect(permission1).not.toBeNull()
     expect(permission1!.permissionLevel).toBe(PermissionLevel.READ)
 
     const derivedPermission1 = await prisma.derivedPermission.findUnique({
@@ -120,7 +120,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1!.permissionLevel).toBe(PermissionLevel.READ)
 
     // verify that if all information is consistent, the permission level is changed and correctly propagated
@@ -143,7 +143,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permission2).toBeDefined()
+    expect(permission2).not.toBeNull()
     expect(permission2!.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const derivedPermission2 = await prisma.derivedPermission.findUnique({
@@ -154,7 +154,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2).not.toBeNull()
     expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.WRITE)
 
     // verify that the audit log entry has been created correctly
@@ -221,7 +221,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
     expect(derivedPermission1?.directPermissionId).toBeNull()
 
@@ -233,7 +233,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2).not.toBeNull()
     expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(derivedPermission2?.directPermissionId).toBe(directPermission.id)
 
@@ -245,7 +245,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3).not.toBeNull()
     expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.READ)
     expect(derivedPermission3?.directPermissionId).toBe(groupPermission.id)
 
@@ -269,7 +269,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(updatedDirectPermission).toBeDefined()
+    expect(updatedDirectPermission).not.toBeNull()
     expect(updatedDirectPermission!.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // OWNER for user 1, ADMIN for user 2, ADMIN for user 3
@@ -283,7 +283,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       }
     )
-    expect(updatedDerivedPermission1).toBeDefined()
+    expect(updatedDerivedPermission1).not.toBeNull()
     expect(updatedDerivedPermission1?.permissionLevel).toBe(
       PermissionLevel.OWNER
     )
@@ -298,7 +298,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       }
     )
-    expect(updatedDerivedPermission2).toBeDefined()
+    expect(updatedDerivedPermission2).not.toBeNull()
     expect(updatedDerivedPermission2?.permissionLevel).toBe(
       PermissionLevel.ADMIN
     )
@@ -313,7 +313,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       }
     )
-    expect(updatedDerivedPermission3).toBeDefined()
+    expect(updatedDerivedPermission3).not.toBeNull()
     expect(updatedDerivedPermission3?.permissionLevel).toBe(
       PermissionLevel.ADMIN
     )
@@ -626,7 +626,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permissionUserOne).toBeDefined()
+    expect(permissionUserOne).not.toBeNull()
     expect(permissionUserOne?.permissionLevel).toBe(PermissionLevel.OWNER)
     expect(permissionUserOne?.directPermissionId).toBeNull()
 
@@ -638,7 +638,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permissionUserTwo).toBeDefined()
+    expect(permissionUserTwo).not.toBeNull()
     expect(permissionUserTwo?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserTwo?.directPermissionId).toBe(groupPermission.id)
 
@@ -650,7 +650,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permissionUserThree).toBeDefined()
+    expect(permissionUserThree).not.toBeNull()
     expect(permissionUserThree?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserThree?.directPermissionId).toBe(groupPermission.id)
 
@@ -662,7 +662,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permissionUserFour).toBeDefined()
+    expect(permissionUserFour).not.toBeNull()
     expect(permissionUserFour?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserFour?.directPermissionId).toBe(groupPermission.id)
 
@@ -674,7 +674,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(permissionUserFive).toBeDefined()
+    expect(permissionUserFive).not.toBeNull()
     expect(permissionUserFive?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserFive?.directPermissionId).toBe(groupPermission.id)
 
@@ -688,7 +688,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(ACDerivedPermissionUserOne).toBeDefined()
+    expect(ACDerivedPermissionUserOne).not.toBeNull()
     expect(ACDerivedPermissionUserOne?.permissionLevel).toBe(
       PermissionLevel.OWNER
     )
@@ -704,7 +704,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(ACDerivedPermissionUserTwo).toBeDefined()
+    expect(ACDerivedPermissionUserTwo).not.toBeNull()
     expect(ACDerivedPermissionUserTwo?.permissionLevel).toBe(
       PermissionLevel.READ
     )
@@ -722,7 +722,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(ACDerivedPermissionUserThree).toBeDefined()
+    expect(ACDerivedPermissionUserThree).not.toBeNull()
     expect(ACDerivedPermissionUserThree?.permissionLevel).toBe(
       PermissionLevel.READ
     )
@@ -740,7 +740,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(ACDerivedPermissionUserFour).toBeDefined()
+    expect(ACDerivedPermissionUserFour).not.toBeNull()
     expect(ACDerivedPermissionUserFour?.permissionLevel).toBe(
       PermissionLevel.READ
     )
@@ -758,7 +758,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(ACDerivedPermissionUserFive).toBeDefined()
+    expect(ACDerivedPermissionUserFive).not.toBeNull()
     expect(ACDerivedPermissionUserFive?.permissionLevel).toBe(
       PermissionLevel.READ
     )
@@ -794,7 +794,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(persistentPermissionUserOne).toBeDefined()
+    expect(persistentPermissionUserOne).not.toBeNull()
     expect(persistentPermissionUserOne?.permissionLevel).toBe(
       PermissionLevel.OWNER
     )
@@ -809,7 +809,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(deletedPermissionUserTwo).toBeDefined()
+    expect(deletedPermissionUserTwo).not.toBeNull()
     expect(deletedPermissionUserTwo?.permissionLevel).toBe(PermissionLevel.READ)
     expect(deletedPermissionUserTwo?.directPermissionId).toBe(
       elementReadPermission.id
@@ -861,7 +861,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(persistentACPermissionUserOne).toBeDefined()
+    expect(persistentACPermissionUserOne).not.toBeNull()
     expect(persistentACPermissionUserOne?.permissionLevel).toBe(
       PermissionLevel.OWNER
     )
@@ -877,7 +877,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(persistentACPermissionUserTwo).toBeDefined()
+    expect(persistentACPermissionUserTwo).not.toBeNull()
     expect(persistentACPermissionUserTwo?.permissionLevel).toBe(
       PermissionLevel.READ
     )
@@ -895,7 +895,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
           },
         },
       })
-    expect(persistentACPermissionUserThree).toBeDefined()
+    expect(persistentACPermissionUserThree).not.toBeNull()
     expect(persistentACPermissionUserThree?.permissionLevel).toBe(
       PermissionLevel.READ
     )
@@ -1027,7 +1027,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1).not.toBeNull()
     expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const dbPermission2 = await prisma.permission.findUnique({
@@ -1038,7 +1038,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2).not.toBeNull()
     expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the correct derived permissions have been created in the database
@@ -1051,7 +1051,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
 
     const derivedPermission2 = await prisma.derivedPermission.findUnique({
@@ -1062,7 +1062,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2).not.toBeNull()
     expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const derivedPermission3 = await prisma.derivedPermission.findUnique({
@@ -1073,7 +1073,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3).not.toBeNull()
     expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     const derivedPermission4 = await prisma.derivedPermission.findUnique({
@@ -1084,7 +1084,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
         },
       },
     })
-    expect(derivedPermission4).toBeDefined()
+    expect(derivedPermission4).not.toBeNull()
     expect(derivedPermission4?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the correct audit log entries have been created
@@ -1207,7 +1207,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
       { id: SE.id },
       userOneCtx
     )
-    expect(directPermissions).toBeDefined()
+    expect(directPermissions).not.toBeNull()
     expect(directPermissions.length).toBe(2)
 
     const userPermission = directPermissions.find(
@@ -1216,8 +1216,8 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     const groupPermission = directPermissions.find(
       (permission) => permission.userGroupId === group.id
     )
-    expect(userPermission).toBeDefined()
-    expect(groupPermission).toBeDefined()
+    expect(userPermission).not.toBeNull()
+    expect(groupPermission).not.toBeNull()
     expect(userPermission?.permissionLevel).toBe(PermissionLevel.READ)
     expect(userPermission?.userId).toBe(userTwo.id)
     expect(userPermission?.permissionId).toBe(dbUserPermission.id)
@@ -1272,7 +1272,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
       { id: SE.id },
       userOneCtx
     )
-    expect(derivedPermissions).toBeDefined()
+    expect(derivedPermissions).not.toBeNull()
     expect(derivedPermissions.length).toBe(3)
 
     const permissionIds = derivedPermissions.map((p) => p.permissionId)
@@ -1289,9 +1289,9 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     const ADMINPermission = derivedPermissions.find(
       (permission) => permission.userId === userFour.id
     )
-    expect(READPermission).toBeDefined()
-    expect(WRITEPermission).toBeDefined()
-    expect(ADMINPermission).toBeDefined()
+    expect(READPermission).not.toBeNull()
+    expect(WRITEPermission).not.toBeNull()
+    expect(ADMINPermission).not.toBeNull()
     expect(READPermission!.permissionLevel).toBe(PermissionLevel.READ)
     expect(READPermission!.userId).toBe(userTwo.id)
     expect(READPermission!.permissionId).toBe(permission1.id)
@@ -1798,7 +1798,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
     // verify that the correct elements are returned when querying them for the addition to the catalog
     const elementsUserOne = await getCatalogElements(userOneCtx)
-    expect(elementsUserOne).toBeDefined()
+    expect(elementsUserOne).not.toBeNull()
     expect(elementsUserOne.length).toBe(2)
     const elementIds1 = elementsUserOne.map((element) => element.id)
     expect(elementIds1).toEqual(
@@ -1806,7 +1806,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     )
 
     const elementsUserTwo = await getCatalogElements(userTwoCtx)
-    expect(elementsUserTwo).toBeDefined()
+    expect(elementsUserTwo).not.toBeNull()
     expect(elementsUserTwo.length).toBe(2)
     const elementIds2 = elementsUserTwo.map((element) => element.id)
     expect(elementIds2).toEqual(
@@ -1814,13 +1814,13 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     )
 
     const elementsUserThree = await getCatalogElements(userThreeCtx)
-    expect(elementsUserThree).toBeDefined()
+    expect(elementsUserThree).not.toBeNull()
     expect(elementsUserThree.length).toBe(1)
     const elementIds3 = elementsUserThree.map((element) => element.id)
     expect(elementIds3).toEqual(expect.arrayContaining([String(SC.id)]))
 
     const elementsUserFour = await getCatalogElements(userFourCtx)
-    expect(elementsUserFour).toBeDefined()
+    expect(elementsUserFour).not.toBeNull()
     expect(elementsUserFour.length).toBe(0)
     const elementIds4 = elementsUserFour.map((element) => element.id)
     expect(elementIds4).toEqual(expect.arrayContaining([]))
@@ -2317,7 +2317,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     const pendingRequest = await prisma.accessRequest.findUnique({
       where: { id: request.id },
     })
-    expect(pendingRequest).toBeDefined()
+    expect(pendingRequest).not.toBeNull()
 
     // verify that such a request fails for users that have not requested access
     const failure = await cancelObjectSharingRequest(
@@ -2407,7 +2407,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
     // get the pending sharing requests for user 1 and check their content
     const requests = await getCatalogSharingRequests(userOneCtx)
-    expect(requests).toBeDefined()
+    expect(requests).not.toBeNull()
     expect(requests!.length).toBe(3)
     const publicRequestUserThree = requests!.find(
       (request) => request.requestId === request1.id
@@ -2418,9 +2418,9 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     const restrictedRequestUserThree = requests!.find(
       (request) => request.requestId === request3.id
     )
-    expect(publicRequestUserThree).toBeDefined()
-    expect(publicRequestUserFour).toBeDefined()
-    expect(restrictedRequestUserThree).toBeDefined()
+    expect(publicRequestUserThree).not.toBeNull()
+    expect(publicRequestUserFour).not.toBeNull()
+    expect(restrictedRequestUserThree).not.toBeNull()
     expect(publicRequestUserThree?.objectType).toBe(SharingObjectType.ELEMENT)
     expect(publicRequestUserThree?.requestId).toBe(request1.id)
     expect(publicRequestUserThree?.userId).toBe(userThree.id)
@@ -2443,7 +2443,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
     // get the pending sharing requests for user 2 and check their content
     const requests2 = await getCatalogSharingRequests(userTwoCtx)
-    expect(requests2).toBeDefined()
+    expect(requests2).not.toBeNull()
     expect(requests2!.length).toBe(2)
     const publicRequestUserThree2 = requests2!.find(
       (request) => request.requestId === request2.id
@@ -2451,8 +2451,8 @@ describe('Unit tests for sharing functionalities of elements (questions, content
     const publicRequestUserFour2 = requests2!.find(
       (request) => request.requestId === request5.id
     )
-    expect(publicRequestUserThree2).toBeDefined()
-    expect(publicRequestUserFour2).toBeDefined()
+    expect(publicRequestUserThree2).not.toBeNull()
+    expect(publicRequestUserFour2).not.toBeNull()
 
     expect(publicRequestUserThree2?.objectType).toBe(SharingObjectType.ELEMENT)
     expect(publicRequestUserThree2?.requestId).toBe(request2.id)

--- a/packages/graphql/test/elementSharing.test.ts
+++ b/packages/graphql/test/elementSharing.test.ts
@@ -87,7 +87,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   // ! Sharing functionalities for elements
   // #region
   it('Verify that the level of granted direct individual permissions can be modified', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC1!.id)
 
     // grant READ permissions to user 2
@@ -174,7 +174,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that the level of granted direct group permissions can be modified', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
     // create a user group with users 1, 2, and 3 (ADMIN)
@@ -335,7 +335,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Test the direct sharing functionality for elements with different permission levels for individual users', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
     // seed ADMIN and READ permissions on the answer collection for users 2 and 3
@@ -564,7 +564,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that direct group permissions on the element can be revoked without conditions and derived permissions are revoked as well', async () => {
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC!.id)
 
     // create a user group with users 1, 2, 3, 4, and 5 (OWNER)
@@ -943,7 +943,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Test the direct sharing functionality for elements with different permission levels for user groups', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
     // create a user group with users 1 (ADMIN), 2, and 3 and grant WRITE permissions on the element to them
@@ -1171,7 +1171,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that direct permissions on the elements are loaded correctly', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
     // grant READ permissions to user 2
@@ -1227,7 +1227,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that derived permissions on the element are loaded correctly', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
     // seed derived READ, WRITE and ADMIN permissions for user 2, 3 and 4
@@ -1305,7 +1305,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
   it('Verify that direct permissions to an element can be revoked, but might be replaced with derived permissions', async () => {
     // create answer collections for testing
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SC } = await seedElements(userOneCtx, AC1!.id)
 
     const permission1 = await prisma.permission.upsert({
@@ -1619,7 +1619,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that an element OWNER can transfer the corresponding rights and that derived permissions are created correctly', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
 
     // add direct admin permissions to user 4
@@ -1745,7 +1745,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   // ! Catalog functionalities for elements
   // #region
   it('Verify that only elements where a user has admin permissions are returned for the addition to the catalog', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SC, MC } = await seedElements(userOneCtx, AC1!.id)
 
     // grant admin permissions to users 2 and 3, and write permissions to user 4 on the single choice question
@@ -1828,7 +1828,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
   it('Test that elements can be added to a catalog collection by users with sufficient permissions', async () => {
     const { restrictedCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SC, MC } = await seedElements(userOneCtx, AC1!.id)
 
     // grand READ permissions on the selection question to user 2
@@ -2024,7 +2024,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
 
   it('Verify that user 5 can request access and import public elements in public catalog (incl. derived permissions on answer collections)', async () => {
     // create elements and catalog collections for testing
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE, CS } = await seedElements(userOneCtx, AC1!.id)
     const { publicCatalog, restrictedCatalog } =
       await seedCatalogCollections(userOneCtx)
@@ -2302,7 +2302,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that element sharing requests can be cancelled by the initiator', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE } = await seedElements(userOneCtx, AC1!.id)
     const request = await prisma.accessRequest.create({
       data: {
@@ -2355,7 +2355,7 @@ describe('Unit tests for sharing functionalities of elements (questions, content
   })
 
   it('Verify that access requests to answer collections are shown correctly to owners and admins', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const { SE, CS } = await seedElements(userOneCtx, AC1!.id)
 
     // create access requests for user 3 (on both questions) and user 4 (on the case study question)

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -204,7 +204,7 @@ export async function initializePrisma() {
  */
 export async function seedAnswerCollections(
   userContext
-): Promise<AnswerCollection[]> {
+): Promise<{ AC1: AnswerCollection; AC2: AnswerCollection }> {
   const collections = await Promise.all(
     [answerCollection1, answerCollection2].map((collection) =>
       createAnswerCollection(
@@ -221,12 +221,14 @@ export async function seedAnswerCollections(
   if (
     !collections ||
     collections.some((collection) => !collection) ||
-    collections.length !== 2
+    collections.length !== 2 ||
+    !collections[0] ||
+    !collections[1]
   ) {
     throw new Error('Failed to create answer collections')
   }
 
-  return collections as AnswerCollection[]
+  return { AC1: collections[0], AC2: collections[1] }
 }
 
 /**

--- a/packages/graphql/test/resourceSharing.test.ts
+++ b/packages/graphql/test/resourceSharing.test.ts
@@ -257,7 +257,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
     // get the pending sharing requests for user 1 and check their content
     const requests = await getCatalogSharingRequests(userOneCtx)
-    expect(requests).toBeDefined()
+    expect(requests).not.toBeNull()
     expect(requests!.length).toBe(3)
     const publicRequestUserThree = requests!.find(
       (request) => request.requestId === request1.id
@@ -268,9 +268,9 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     const restrictedRequestUserThree = requests!.find(
       (request) => request.requestId === request3.id
     )
-    expect(publicRequestUserThree).toBeDefined()
-    expect(publicRequestUserFour).toBeDefined()
-    expect(restrictedRequestUserThree).toBeDefined()
+    expect(publicRequestUserThree).not.toBeNull()
+    expect(publicRequestUserFour).not.toBeNull()
+    expect(restrictedRequestUserThree).not.toBeNull()
     expect(publicRequestUserThree?.objectType).toBe(
       SharingObjectType.ANSWER_COLLECTION
     )
@@ -297,7 +297,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
     // get the pending sharing requests for user 2 and check their content
     const requests2 = await getCatalogSharingRequests(userTwoCtx)
-    expect(requests2).toBeDefined()
+    expect(requests2).not.toBeNull()
     expect(requests2!.length).toBe(2)
     const publicRequestUserThree2 = requests2!.find(
       (request) => request.requestId === request2.id
@@ -305,8 +305,8 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     const publicRequestUserFour2 = requests2!.find(
       (request) => request.requestId === request5.id
     )
-    expect(publicRequestUserThree2).toBeDefined()
-    expect(publicRequestUserFour2).toBeDefined()
+    expect(publicRequestUserThree2).not.toBeNull()
+    expect(publicRequestUserFour2).not.toBeNull()
 
     expect(publicRequestUserThree2?.objectType).toBe(
       SharingObjectType.ANSWER_COLLECTION
@@ -533,7 +533,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     const pendingRequest = await prisma.accessRequest.findUnique({
       where: { id: request.id },
     })
-    expect(pendingRequest).toBeDefined()
+    expect(pendingRequest).not.toBeNull()
 
     // verify that such a request fails for users that have not requested access
     const failure = await cancelObjectSharingRequest(
@@ -798,7 +798,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       { collectionId: AC1!.id },
       userOneCtx
     )
-    expect(res1).toBeDefined()
+    expect(res1).not.toBeNull()
     expect(res1!.id).toEqual(AC1!.id)
     expect(res1!.name).toEqual(answerCollection1.name)
     expect(res1!.description).toEqual(answerCollection1.description)
@@ -809,7 +809,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       { collectionId: AC2!.id },
       userOneCtx
     )
-    expect(res2).toBeDefined()
+    expect(res2).not.toBeNull()
     expect(res2!.id).toEqual(AC2!.id)
     expect(res2!.name).toEqual(answerCollection2.name)
     expect(res2!.description).toEqual(answerCollection2.description)
@@ -831,7 +831,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
     // query the available answer collections for user 1
     const collections1 = await getCatalogAnswerCollections(userOneCtx)
-    expect(collections1).toBeDefined()
+    expect(collections1).not.toBeNull()
     expect(collections1!.length).toBe(2)
     expect(collections1!.map((c) => parseInt(c.id))).toEqual(
       expect.arrayContaining([AC1!.id, AC2!.id])
@@ -842,14 +842,14 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
     // query the available answer collections for user 2
     const collections2 = await getCatalogAnswerCollections(userTwoCtx)
-    expect(collections2).toBeDefined()
+    expect(collections2).not.toBeNull()
     expect(collections2!.length).toBe(1)
     expect(parseInt(collections2![0]!.id)).toBe(AC1!.id)
     expect(collections2![0]!.name).toBe(answerCollection1.name)
 
     // query that for any other user (e.g. user 3) no answer collections are returned
     const collections3 = await getCatalogAnswerCollections(userThreeCtx)
-    expect(collections3).toBeDefined()
+    expect(collections3).not.toBeNull()
     expect(collections3!.length).toBe(0)
   })
   // #endregion
@@ -878,7 +878,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(permission1).toBeDefined()
+    expect(permission1).not.toBeNull()
     expect(permission1!.permissionLevel).toBe(PermissionLevel.READ)
 
     const derivedPermission1 = await prisma.derivedPermission.findUnique({
@@ -889,7 +889,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1!.permissionLevel).toBe(PermissionLevel.READ)
 
     // verify that if all information is consistent, the permission level is changed and correctly propagated
@@ -912,7 +912,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(permission2).toBeDefined()
+    expect(permission2).not.toBeNull()
     expect(permission2!.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const derivedPermission2 = await prisma.derivedPermission.findUnique({
@@ -923,7 +923,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2).not.toBeNull()
     expect(derivedPermission2!.permissionLevel).toBe(PermissionLevel.WRITE)
 
     // verify that the audit log entry has been created correctly
@@ -983,7 +983,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         id: readPermission.id,
       },
     })
-    expect(updatedPermission).toBeDefined()
+    expect(updatedPermission).not.toBeNull()
     expect(updatedPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(updatedPermission?.answerCollectionId).toBe(AC1!.id)
     expect(updatedPermission?.userGroupId).toBe(group.id)
@@ -997,7 +997,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(ownerPerimission).toBeDefined()
+    expect(ownerPerimission).not.toBeNull()
     expect(ownerPerimission?.permissionLevel).toBe(PermissionLevel.OWNER)
 
     const userTwoPermission = await prisma.derivedPermission.findUnique({
@@ -1008,7 +1008,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(userTwoPermission).toBeDefined()
+    expect(userTwoPermission).not.toBeNull()
     expect(userTwoPermission?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const userThreePermission = await prisma.derivedPermission.findUnique({
@@ -1019,7 +1019,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(userThreePermission).toBeDefined()
+    expect(userThreePermission).not.toBeNull()
     expect(userThreePermission?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const userFourPermission = await prisma.derivedPermission.findUnique({
@@ -1387,7 +1387,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(permissionUserOne).toBeDefined()
+    expect(permissionUserOne).not.toBeNull()
     expect(permissionUserOne?.permissionLevel).toBe(PermissionLevel.OWNER)
     expect(permissionUserOne?.directPermissionId).toBeNull()
 
@@ -1399,7 +1399,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(permissionUserTwo).toBeDefined()
+    expect(permissionUserTwo).not.toBeNull()
     expect(permissionUserTwo?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserTwo?.directPermissionId).toBe(groupPermission.id)
 
@@ -1411,7 +1411,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(permissionUserThree).toBeDefined()
+    expect(permissionUserThree).not.toBeNull()
     expect(permissionUserThree?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserThree?.directPermissionId).toBe(groupPermission.id)
 
@@ -1423,7 +1423,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(permissionUserFour).toBeDefined()
+    expect(permissionUserFour).not.toBeNull()
     expect(permissionUserFour?.permissionLevel).toBe(PermissionLevel.WRITE)
     expect(permissionUserFour?.directPermissionId).toBe(groupPermission.id)
 
@@ -1454,7 +1454,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
           },
         },
       })
-    expect(persistentPermissionUserOne).toBeDefined()
+    expect(persistentPermissionUserOne).not.toBeNull()
     expect(persistentPermissionUserOne?.permissionLevel).toBe(
       PermissionLevel.OWNER
     )
@@ -1544,7 +1544,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       { id: AC1!.id },
       userOneCtx
     )
-    expect(directPermissions).toBeDefined()
+    expect(directPermissions).not.toBeNull()
     expect(directPermissions.length).toBe(2)
 
     const userPermission = directPermissions.find(
@@ -1553,8 +1553,8 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     const groupPermission = directPermissions.find(
       (permission) => permission.userGroupId === group.id
     )
-    expect(userPermission).toBeDefined()
-    expect(groupPermission).toBeDefined()
+    expect(userPermission).not.toBeNull()
+    expect(groupPermission).not.toBeNull()
     expect(userPermission?.permissionLevel).toBe(PermissionLevel.READ)
     expect(userPermission?.userId).toBe(userTwo.id)
     expect(userPermission?.permissionId).toBe(dbUserPermission.id)
@@ -1608,7 +1608,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
       { id: AC1!.id },
       userOneCtx
     )
-    expect(derivedPermissions).toBeDefined()
+    expect(derivedPermissions).not.toBeNull()
     expect(derivedPermissions.length).toBe(3)
 
     const permissionIds = derivedPermissions.map((p) => p.permissionId)
@@ -1625,9 +1625,9 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
     const ADMINPermission = derivedPermissions.find(
       (permission) => permission.userId === userFour.id
     )
-    expect(READPermission).toBeDefined()
-    expect(WRITEPermission).toBeDefined()
-    expect(ADMINPermission).toBeDefined()
+    expect(READPermission).not.toBeNull()
+    expect(WRITEPermission).not.toBeNull()
+    expect(ADMINPermission).not.toBeNull()
     expect(READPermission!.permissionLevel).toBe(PermissionLevel.READ)
     expect(READPermission!.userId).toBe(userTwo.id)
     expect(READPermission!.permissionId).toBe(permission1.id)
@@ -1978,7 +1978,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(dbPermission1).toBeDefined()
+    expect(dbPermission1).not.toBeNull()
     expect(dbPermission1?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const dbPermission2 = await prisma.permission.findUnique({
@@ -1989,7 +1989,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(dbPermission2).toBeDefined()
+    expect(dbPermission2).not.toBeNull()
     expect(dbPermission2?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the correct derived permissions have been created in the database
@@ -2002,7 +2002,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(derivedPermission1).toBeDefined()
+    expect(derivedPermission1).not.toBeNull()
     expect(derivedPermission1?.permissionLevel).toBe(PermissionLevel.OWNER)
 
     const derivedPermission2 = await prisma.derivedPermission.findUnique({
@@ -2013,7 +2013,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(derivedPermission2).toBeDefined()
+    expect(derivedPermission2).not.toBeNull()
     expect(derivedPermission2?.permissionLevel).toBe(PermissionLevel.WRITE)
 
     const derivedPermission3 = await prisma.derivedPermission.findUnique({
@@ -2024,7 +2024,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(derivedPermission3).toBeDefined()
+    expect(derivedPermission3).not.toBeNull()
     expect(derivedPermission3?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     const derivedPermission4 = await prisma.derivedPermission.findUnique({
@@ -2035,7 +2035,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
         },
       },
     })
-    expect(derivedPermission4).toBeDefined()
+    expect(derivedPermission4).not.toBeNull()
     expect(derivedPermission4?.permissionLevel).toBe(PermissionLevel.ADMIN)
 
     // verify that the correct audit log entries have been created

--- a/packages/graphql/test/resourceSharing.test.ts
+++ b/packages/graphql/test/resourceSharing.test.ts
@@ -136,7 +136,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   }
 
   it('Verify that permissions on answer collection determine allowed actions when included in top-level catalog collection', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // grant READ, WRITE and ADMIN permissions on the answer collection to users 2, 3, and 4
     await prisma.permission.createMany({
@@ -206,7 +206,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that access requests to answer collections are shown correctly to owners and admins', async () => {
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
 
     // create access requests for user 3 (on both) and user 4 (on the public catalog)
     // access requests for the publbic catalog should be linked to both user 1 (owner) and user 2 (admin)
@@ -327,7 +327,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
   it('Verify that user 5 can request access and import public answer collections in public catalog', async () => {
     // create answer collections and catalog collections for testing
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     await seedAnswerCollectionPermissions(prisma, AC1!.id, AC2!.id)
     const { publicCatalog, restrictedCatalog } =
       await seedCatalogCollections(userOneCtx)
@@ -519,7 +519,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that answer collection sharing requests can be cancelled by the initiator', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
     const request = await prisma.accessRequest.create({
       data: {
         permissionLevel: PermissionLevel.WRITE,
@@ -572,7 +572,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
   it('Test that answer collections can be added to a catalog collection by users with sufficient permissions', async () => {
     const { restrictedCatalog } = await seedCatalogCollections(userOneCtx)
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
 
     // grand READ permissions on the first answer collection to user 2
     await prisma.permission.create({
@@ -766,7 +766,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that the correct information is extracted for public / restricted answer collections in the catalog', async () => {
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     const { publicCatalog } = await seedCatalogCollections(userOneCtx)
 
     // add the answer collection to the top-level catalog collection
@@ -817,7 +817,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that the correct answer collections are fetched to be included in the catalog', async () => {
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
 
     // grant ADMIN permissions to user 2 on the first collection only
     await prisma.permission.create({
@@ -857,7 +857,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   // ! Sharing Operations for Answer Collections
   // #region
   it('Verify that the level of granted direct individual permissions can be modified', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // grant READ permissions to user 2
     await prisma.permission.create({
@@ -943,7 +943,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that the level of granted direct group permissions can be modified', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // create a user group with users 1, 2, and 3 (ADMIN)
     const group = await prisma.userGroup.create({
@@ -1050,7 +1050,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
 
   it('Verify that direct individual permissions to an answer collection can be revoked, but might be replaced with derived permissions', async () => {
     // create answer collections for testing
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     await seedAnswerCollectionPermissions(prisma, AC1!.id, AC2!.id)
 
     const permission1 = await prisma.permission.upsert({
@@ -1351,7 +1351,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that direct group permissions on an answer collection can be revoked without conditions', async () => {
-    const [AC] = await seedAnswerCollections(userOneCtx)
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
 
     // create a user group with users 1, 2, 3, and 4 (OWNER)
     const group = await prisma.userGroup.create({
@@ -1509,7 +1509,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that direct permissions on the answer collection are loaded correctly', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // grant READ permissions to user 2
     const dbUserPermission = await prisma.permission.create({
@@ -1564,7 +1564,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that derived permissions on the answer collection are loaded correctly', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // seed derived READ, WRITE and ADMIN permissions for user 2, 3 and 4
     const permission1 = await prisma.derivedPermission.create({
@@ -1640,7 +1640,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Verify that an answer collection OWNER can transfer the corresponding rights', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // add direct admin permissions to user 4
     await prisma.permission.create({
@@ -1752,7 +1752,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Test the direct sharing functionality for answer collections with different permission levels and individual users', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // try sharing the object with a user that does not exist
     const res1 = await shareObject(
@@ -1923,7 +1923,7 @@ describe('Unit tests for sharing functionalities of resources (e.g. answer colle
   })
 
   it('Test the direct sharing functionality for answer collections with different permission levels and user groups', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // create a user group with users 1 (ADMIN), 2, and 3 and grant WRITE permissions to them
     const group = await prisma.userGroup.create({

--- a/packages/graphql/test/resources.test.ts
+++ b/packages/graphql/test/resources.test.ts
@@ -132,8 +132,8 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Test that the creation of an answer collection fails gracefully if the name uniqueness constraint is violated', async () => {
-    const [dbAC] = await seedAnswerCollections(userOneCtx)
-    expect(dbAC).toBeTruthy()
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
+    expect(AC).toBeTruthy()
 
     const res = await createAnswerCollection(
       {
@@ -148,7 +148,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
 
   it('Verify that all users with access to the answer collection can use the query to include it in elements', async () => {
     // create answer collections for testing
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     await seedAnswerCollectionPermissions(prisma, AC1!.id, AC2!.id)
 
     // check availability of answer collection during element creation
@@ -166,7 +166,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
 
   it('Verify that all users with access to the answer collection can query its content', async () => {
     // create answer collections for testing
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     await seedAnswerCollectionPermissions(prisma, AC1!.id, AC2!.id)
 
     // check availability of answer collection during element creation
@@ -245,7 +245,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
 
   it('Verify that answer collection info is correctly loaded (including potential links to elements and templates impacting removability)', async () => {
     // create answer collections for testing
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
     await seedAnswerCollectionPermissions(prisma, AC1!.id, AC2!.id)
 
     // seed an element, owned by user 1 and shared with user 3
@@ -409,7 +409,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
 
   it('Verify that answer collection metadata updates are executed and stored correctly', async () => {
     // create answer collections for testing
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     const updatedName = 'Updated Name'
     const updatedDescription = 'Updated Description'
@@ -435,7 +435,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Verify that answer collections can be deleted when unused (hard deletion case)', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // connect the first answer collection to an element
     const element = await prisma.element.create({
@@ -510,7 +510,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Verify that answer collections can be deleted when unused (soft deletion case)', async () => {
-    const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+    const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
 
     // connect the first answer collection to an element of user 2
     const element = await prisma.element.create({
@@ -610,7 +610,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Verify that on deletion, all access requests, direct permissions and catalog collection assignments are removed', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // add an element for user 4 linked to the answer collection
     const element = await prisma.element.create({
@@ -752,7 +752,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Verify that own permission can only be removed if the answer collection is unused', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     // add an explicite permission for user 2 on the answer collection
     await prisma.permission.create({
@@ -893,7 +893,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Test the modification of answer collection entries', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     const dbAC1 = await prisma.answerCollection.findUnique({
       where: {
@@ -927,7 +927,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Test that the deletion of answer collection entries is possible if they are not used in an element', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     const dbAC1 = await prisma.answerCollection.findUnique({
       where: {
@@ -1024,7 +1024,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
   })
 
   it('Test the creation of a new answer collection entry for an existing answer collection', async () => {
-    const [AC1] = await seedAnswerCollections(userOneCtx)
+    const { AC1 } = await seedAnswerCollections(userOneCtx)
 
     const newEntry = 'New Entry'
     const createdEntry = await addAnswerCollectionOption(

--- a/packages/graphql/test/resources.test.ts
+++ b/packages/graphql/test/resources.test.ts
@@ -615,7 +615,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
     // add an element for user 4 linked to the answer collection
     const element = await prisma.element.create({
       data: {
-        type: ElementType.SC,
+        type: ElementType.SELECTION,
         name: 'Test Element',
         content: 'Test Element Content',
         options: {},
@@ -659,7 +659,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
     })
     expect(derivedPermission4).toBeTruthy()
     expect(derivedPermission4!.permissionLevel).toBe(PermissionLevel.READ)
-    expect(derivedPermission4!.directPermissionId).toBeDefined()
+    expect(derivedPermission4!.directPermissionId).toBeNull() // element owner - no direct permission id
     expect(derivedPermission4!.derived).toBeTruthy()
 
     // create an access request to the answer collection for user 3
@@ -734,7 +734,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
     expect(remainingDerivedPermission4!.permissionLevel).toBe(
       PermissionLevel.READ
     )
-    expect(remainingDerivedPermission4!.directPermissionId).toBeDefined()
+    expect(remainingDerivedPermission4!.directPermissionId).toBeNull() // element owner - no direct permission id
     expect(remainingDerivedPermission4!.derived).toBeTruthy()
 
     // verify that the access request has been removed
@@ -790,7 +790,7 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
     expect(derivedPermissionElement!.permissionLevel).toBe(
       PermissionLevel.WRITE
     )
-    expect(derivedPermissionElement!.directPermissionId).toBeDefined()
+    expect(derivedPermissionElement!.directPermissionId).not.toBeNull()
     expect(derivedPermissionElement!.derived).toBeFalsy()
 
     // verify that the answer collection cannot be removed from the account of user 2 (used in element)

--- a/packages/graphql/test/userGroups.test.ts
+++ b/packages/graphql/test/userGroups.test.ts
@@ -364,7 +364,7 @@ describe('Unit tests for user group management', () => {
       })
 
       // create an answer collection and grant permissions to the group
-      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
       await prisma.permission.create({
         data: {
           permissionLevel: PermissionLevel.WRITE,
@@ -596,7 +596,7 @@ describe('Unit tests for user group management', () => {
       })
 
       // create an answer collection and grant permissions to the group
-      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
       await prisma.permission.create({
         data: {
           permissionLevel: PermissionLevel.WRITE,
@@ -1233,7 +1233,7 @@ describe('Unit tests for user group management', () => {
       })
 
       // create an answer collection and grant permissions to the group
-      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
       await prisma.permission.create({
         data: {
           permissionLevel: PermissionLevel.WRITE,
@@ -2006,7 +2006,7 @@ describe('Unit tests for user group management', () => {
       })
 
       // create an answer collection and grant permissions to the group
-      const [AC1, AC2] = await seedAnswerCollections(userOneCtx)
+      const { AC1, AC2 } = await seedAnswerCollections(userOneCtx)
       await prisma.permission.create({
         data: {
           permissionLevel: PermissionLevel.WRITE,

--- a/packages/graphql/test/userGroups.test.ts
+++ b/packages/graphql/test/userGroups.test.ts
@@ -345,7 +345,7 @@ describe('Unit tests for user group management', () => {
       const updatedGroup = await prisma.userGroup.findUnique({
         where: { id: group.id },
       })
-      expect(updatedGroup).toBeDefined()
+      expect(updatedGroup).not.toBeNull()
       expect(updatedGroup?.ownerId).toBe(userOne.id)
     })
 

--- a/packages/util/src/permissions.ts
+++ b/packages/util/src/permissions.ts
@@ -168,6 +168,7 @@ export async function recomputeDerivedPermissions(
  * @param params.practiceQuizId - ID of the practice quiz to update access requests for
  * @param params.microLearningId - ID of the microlearning to update access requests for
  * @param params.groupActivityId - ID of the group activity to update access requests for
+ * @param params.objectSoftDeleted - Optional flag to signal the soft deletion of the object
  * @param params.userId - Optional user ID to limit the update to a specific user
  * @param prisma - Prisma transaction client for database operations
  * @returns Promise that resolves when the access request update completes
@@ -183,7 +184,7 @@ export async function updateAccessRequestInstances(
     practiceQuizId,
     microLearningId,
     groupActivityId,
-    // optional user to limit the required recomputation
+    objectSoftDeleted,
     userId,
   }: {
     catalogCollectionId?: string
@@ -194,6 +195,7 @@ export async function updateAccessRequestInstances(
     practiceQuizId?: string
     microLearningId?: string
     groupActivityId?: string
+    objectSoftDeleted?: boolean
     userId?: string
   } & (
     | { catalogCollectionId: string }
@@ -219,6 +221,24 @@ export async function updateAccessRequestInstances(
     typeof groupActivityId === 'undefined'
   ) {
     throw new Error('No object id defined for the update of access requests')
+  }
+
+  // if the object is soft-deleted, remove all access requests
+  if (objectSoftDeleted) {
+    await prisma.accessRequest.deleteMany({
+      where: {
+        catalogCollectionId,
+        answerCollectionId,
+        elementId,
+        courseId,
+        liveQuizId,
+        practiceQuizId,
+        microLearningId,
+        groupActivityId,
+      },
+    })
+
+    return
   }
 
   if (typeof userId !== 'undefined') {
@@ -751,6 +771,16 @@ async function recomputeCatalogCollectionPermissionsUser(
     maxAccessLevel = inversePermissionLevelMap[maxDirectPermission]
     parentPermissionId = directPermissionId
   } else {
+    if (updateAccessRequests) {
+      // remove any access requests that might have been created
+      await prisma.accessRequest.deleteMany({
+        where: {
+          catalogCollectionId: id,
+          objectAdminOrOwnerId: userId,
+        },
+      })
+    }
+
     // no permission found that would justify access
     return
   }
@@ -1072,9 +1102,6 @@ async function recomputeAnswerCollectionPermissionsUser(
         permissionLinkedTemplate?.directPermissionId ?? undefined
       derived = true // permission was derived from another element
     }
-  } else {
-    // no direct permission or derived access found that would justify access
-    return
   }
 
   // if the user still has access, add a corresponding derived permission
@@ -1108,7 +1135,11 @@ async function recomputeAnswerCollectionPermissionsUser(
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
     await updateAccessRequestInstances(
-      { answerCollectionId: id, userId },
+      {
+        answerCollectionId: id,
+        userId,
+        objectSoftDeleted: answerCollection.isDeleted,
+      },
       prisma
     )
   }
@@ -1268,7 +1299,10 @@ async function recomputeAnswerCollectionPermissionsObject(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ answerCollectionId: id }, prisma)
+    await updateAccessRequestInstances(
+      { answerCollectionId: id, objectSoftDeleted: answerCollection.isDeleted },
+      prisma
+    )
   }
 }
 // #endregion
@@ -1610,7 +1644,10 @@ async function recomputeElementPermissionsUser(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ elementId: id, userId }, prisma)
+    await updateAccessRequestInstances(
+      { elementId: id, userId, objectSoftDeleted: element.isDeleted },
+      prisma
+    )
   }
 
   // compute derived permissions for answer collections that are linked to the element (= PROPAGATION = MIN. REQUIRED)
@@ -1823,7 +1860,10 @@ async function recomputeElementPermissionsObject(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ elementId: id }, prisma)
+    await updateAccessRequestInstances(
+      { elementId: id, objectSoftDeleted: element.isDeleted },
+      prisma
+    )
   }
 
   // compute derived permissions for answer collections that are linked to the element (= PROPAGATION = MIN. REQUIRED)
@@ -1992,43 +2032,43 @@ async function recomputeLiveQuizPermissionsUser(
     coursePermissions: liveQuiz.course?.permissions ?? [],
   })
 
-  // if no valid derived permission was computed, return early
-  if (res === null) {
-    return
-  }
-
   // if the user still has access, add a corresponding derived permission
-  const { maxAccessLevel, parentPermissionId, derived } = res
-  if (typeof maxAccessLevel !== 'undefined') {
-    await prisma.derivedPermission.create({
-      data: {
-        permissionLevel: maxAccessLevel,
-        derived,
-        liveQuiz: {
-          connect: {
-            id,
+  if (res !== null) {
+    const { maxAccessLevel, parentPermissionId, derived } = res
+    if (typeof maxAccessLevel !== 'undefined') {
+      await prisma.derivedPermission.create({
+        data: {
+          permissionLevel: maxAccessLevel,
+          derived,
+          liveQuiz: {
+            connect: {
+              id,
+            },
+          },
+          directPermission:
+            typeof parentPermissionId !== 'undefined'
+              ? {
+                  connect: {
+                    id: parentPermissionId,
+                  },
+                }
+              : undefined,
+          user: {
+            connect: {
+              id: userId,
+            },
           },
         },
-        directPermission:
-          typeof parentPermissionId !== 'undefined'
-            ? {
-                connect: {
-                  id: parentPermissionId,
-                },
-              }
-            : undefined,
-        user: {
-          connect: {
-            id: userId,
-          },
-        },
-      },
-    })
+      })
+    }
   }
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ liveQuizId: id, userId }, prisma)
+    await updateAccessRequestInstances(
+      { liveQuizId: id, userId, objectSoftDeleted: liveQuiz.isDeleted },
+      prisma
+    )
   }
 
   // if the activity still exists and the user had ADMIN / OWNER permissions on it,
@@ -2142,7 +2182,10 @@ async function recomputeLiveQuizPermissionsObject(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ liveQuizId: id }, prisma)
+    await updateAccessRequestInstances(
+      { liveQuizId: id, objectSoftDeleted: liveQuiz.isDeleted },
+      prisma
+    )
   }
 
   // recompute the derived permissions on all elements contained in this activity
@@ -2304,43 +2347,43 @@ async function recomputePracticeQuizPermissionsUser(
     coursePermissions: practiceQuiz.course?.permissions ?? [],
   })
 
-  // if no valid derived permission was computed, return early
-  if (res === null) {
-    return
-  }
-
   // if the user still has access, add a corresponding derived permission
-  const { maxAccessLevel, parentPermissionId, derived } = res
-  if (typeof maxAccessLevel !== 'undefined') {
-    await prisma.derivedPermission.create({
-      data: {
-        permissionLevel: maxAccessLevel,
-        derived,
-        practiceQuiz: {
-          connect: {
-            id,
+  if (res !== null) {
+    const { maxAccessLevel, parentPermissionId, derived } = res
+    if (typeof maxAccessLevel !== 'undefined') {
+      await prisma.derivedPermission.create({
+        data: {
+          permissionLevel: maxAccessLevel,
+          derived,
+          practiceQuiz: {
+            connect: {
+              id,
+            },
+          },
+          directPermission:
+            typeof parentPermissionId !== 'undefined'
+              ? {
+                  connect: {
+                    id: parentPermissionId,
+                  },
+                }
+              : undefined,
+          user: {
+            connect: {
+              id: userId,
+            },
           },
         },
-        directPermission:
-          typeof parentPermissionId !== 'undefined'
-            ? {
-                connect: {
-                  id: parentPermissionId,
-                },
-              }
-            : undefined,
-        user: {
-          connect: {
-            id: userId,
-          },
-        },
-      },
-    })
+      })
+    }
   }
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ practiceQuizId: id, userId }, prisma)
+    await updateAccessRequestInstances(
+      { practiceQuizId: id, userId, objectSoftDeleted: practiceQuiz.isDeleted },
+      prisma
+    )
   }
 
   // if the activity still exists and the user had ADMIN / OWNER permissions on it,
@@ -2456,7 +2499,10 @@ async function recomputePracticeQuizPermissionsObject(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ practiceQuizId: id }, prisma)
+    await updateAccessRequestInstances(
+      { practiceQuizId: id, objectSoftDeleted: practiceQuiz.isDeleted },
+      prisma
+    )
   }
 
   // recompute the derived permissions on all elements contained in this activity
@@ -2618,43 +2664,47 @@ async function recomputeMicroLearningPermissionsUser(
     coursePermissions: microLearning.course?.permissions ?? [],
   })
 
-  // if no valid derived permission was computed, return early
-  if (res === null) {
-    return
-  }
-
   // if the user still has access, add a corresponding derived permission
-  const { maxAccessLevel, parentPermissionId, derived } = res
-  if (typeof maxAccessLevel !== 'undefined') {
-    await prisma.derivedPermission.create({
-      data: {
-        permissionLevel: maxAccessLevel,
-        derived,
-        microLearning: {
-          connect: {
-            id,
+  if (res !== null) {
+    const { maxAccessLevel, parentPermissionId, derived } = res
+    if (typeof maxAccessLevel !== 'undefined') {
+      await prisma.derivedPermission.create({
+        data: {
+          permissionLevel: maxAccessLevel,
+          derived,
+          microLearning: {
+            connect: {
+              id,
+            },
+          },
+          directPermission:
+            typeof parentPermissionId !== 'undefined'
+              ? {
+                  connect: {
+                    id: parentPermissionId,
+                  },
+                }
+              : undefined,
+          user: {
+            connect: {
+              id: userId,
+            },
           },
         },
-        directPermission:
-          typeof parentPermissionId !== 'undefined'
-            ? {
-                connect: {
-                  id: parentPermissionId,
-                },
-              }
-            : undefined,
-        user: {
-          connect: {
-            id: userId,
-          },
-        },
-      },
-    })
+      })
+    }
   }
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ microLearningId: id, userId }, prisma)
+    await updateAccessRequestInstances(
+      {
+        microLearningId: id,
+        userId,
+        objectSoftDeleted: microLearning.isDeleted,
+      },
+      prisma
+    )
   }
 
   // if the activity still exists and the user had ADMIN / OWNER permissions on it,
@@ -2770,7 +2820,10 @@ async function recomputeMicroLearningPermissionsObject(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ microLearningId: id }, prisma)
+    await updateAccessRequestInstances(
+      { microLearningId: id, objectSoftDeleted: microLearning.isDeleted },
+      prisma
+    )
   }
 
   // recompute the derived permissions on all elements contained in this activity
@@ -2932,43 +2985,47 @@ async function recomputeGroupActivityPermissionsUser(
     coursePermissions: groupActivity.course?.permissions ?? [],
   })
 
-  // if no valid derived permission was computed, return early
-  if (res === null) {
-    return
-  }
-
   // if the user still has access, add a corresponding derived permission
-  const { maxAccessLevel, parentPermissionId, derived } = res
-  if (typeof maxAccessLevel !== 'undefined') {
-    await prisma.derivedPermission.create({
-      data: {
-        permissionLevel: maxAccessLevel,
-        derived,
-        groupActivity: {
-          connect: {
-            id,
+  if (res !== null) {
+    const { maxAccessLevel, parentPermissionId, derived } = res
+    if (typeof maxAccessLevel !== 'undefined') {
+      await prisma.derivedPermission.create({
+        data: {
+          permissionLevel: maxAccessLevel,
+          derived,
+          groupActivity: {
+            connect: {
+              id,
+            },
+          },
+          directPermission:
+            typeof parentPermissionId !== 'undefined'
+              ? {
+                  connect: {
+                    id: parentPermissionId,
+                  },
+                }
+              : undefined,
+          user: {
+            connect: {
+              id: userId,
+            },
           },
         },
-        directPermission:
-          typeof parentPermissionId !== 'undefined'
-            ? {
-                connect: {
-                  id: parentPermissionId,
-                },
-              }
-            : undefined,
-        user: {
-          connect: {
-            id: userId,
-          },
-        },
-      },
-    })
+      })
+    }
   }
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ groupActivityId: id, userId }, prisma)
+    await updateAccessRequestInstances(
+      {
+        groupActivityId: id,
+        userId,
+        objectSoftDeleted: groupActivity.isDeleted,
+      },
+      prisma
+    )
   }
 
   // if the activity still exists and the user had ADMIN / OWNER permissions on it,
@@ -3084,7 +3141,10 @@ async function recomputeGroupActivityPermissionsObject(
 
   // if the corresponding flag is set, update the access requests for the object
   if (updateAccessRequests) {
-    await updateAccessRequestInstances({ groupActivityId: id }, prisma)
+    await updateAccessRequestInstances(
+      { groupActivityId: id, objectSoftDeleted: groupActivity.isDeleted },
+      prisma
+    )
   }
 
   // recompute the derived permissions on all elements contained in this activity
@@ -3237,8 +3297,6 @@ async function recomputeCoursePermissionsUser(
 
     maxAccessLevel = inversePermissionLevelMap[maxDirectPermission]
     parentPermissionId = directPermissionId
-  } else {
-    return
   }
 
   // if the user has access, add a corresponding derived permission


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Access requests are now automatically removed when objects are soft-deleted, ensuring better synchronization between permissions and access requests.
  - Improved consistency in updating and cleaning up access requests when admin or owner permissions are changed or revoked.

- **Tests**
  - Added comprehensive tests covering access request handling for permission changes, admin updates, and object deletions across multiple object types.
  - Updated test assertions to explicitly check for non-null values and refined test data destructuring for improved clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->