### PR TITLE
chore(apps/frontend-manage): make sure element edit form inputs are disabled for user with read permissions on shared element

### DIFF
--- a/apps/frontend-manage/src/components/questions/Element.tsx
+++ b/apps/frontend-manage/src/components/questions/Element.tsx
@@ -311,6 +311,7 @@ function Element({
       )}
       {isModificationModalOpen && (
         <ElementEditModal
+          inputsDisabled={!element.isEditor}
           handleSetIsOpen={setModificationModalOpen}
           triggerSuccessToast={triggerSuccessToast}
           isOpen={isModificationModalOpen}
@@ -318,7 +319,7 @@ function Element({
           mode={ElementEditMode.EDIT}
         />
       )}
-      {isDuplicationModalOpen && element.isEditor && (
+      {isDuplicationModalOpen && (
         <ElementEditModal
           handleSetIsOpen={setDuplicationModalOpen}
           triggerSuccessToast={triggerSuccessToast}

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementContentInput.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementContentInput.tsx
@@ -6,6 +6,7 @@ import ContentInput from '../../common/ContentInput'
 import { ElementFormTypes } from './types'
 
 interface ElementContentInputProps {
+  disabled?: boolean
   values: ElementFormTypes
   setFieldValue: (
     field: string,
@@ -15,6 +16,7 @@ interface ElementContentInputProps {
 }
 
 function ElementContentInput({
+  disabled = false,
   values,
   setFieldValue,
 }: ElementContentInputProps) {
@@ -92,13 +94,14 @@ function ElementContentInput({
               tooltip={t(tooltipMap[values.type])}
             />
             <ContentInput
+              disabled={disabled}
               error={meta.error}
               touched={meta.touched}
               content={field.value || '<br>'}
               onChange={(newValue: string) =>
                 setFieldValue('content', newValue)
               }
-              showToolbarOnFocus={false}
+              showToolbarOnFocus={disabled} // show toolbar only when not disabled
               placeholder={t(placeholderMap[values.type])}
               key={`${values.type}-content`}
               data={{ cy: 'insert-question-text' }}

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
@@ -27,6 +27,7 @@ import useValidationSchema from './useValidationSchema'
 
 function ElementEditForm({
   isTemplate = false,
+  inputsDisabled = false,
   templateId,
   open,
   onClose,
@@ -44,6 +45,8 @@ function ElementEditForm({
   includeTemplateUpdates,
   setIncludeTemplateUpdates,
 }: {
+  // flag to disable inputs (edit mode and read permissions)
+  inputsDisabled?: boolean
   // flag to highlight template mode
   isTemplate?: boolean
   templateId?: string
@@ -123,20 +126,22 @@ function ElementEditForm({
             onClose={() => onClose()}
             escapeDisabled={true}
             onPrimaryAction={
-              <Button
-                primary
-                type="submit"
-                loading={isSubmitting}
-                disabled={!isValid}
-                className={{ root: 'mt-2' }}
-                form="question-manipulation-form"
-                data={{ cy: 'save-new-question' }}
-              >
-                <Button.Label>{t('shared.generic.save')}</Button.Label>
-              </Button>
+              !inputsDisabled ? (
+                <Button
+                  primary
+                  type="submit"
+                  loading={isSubmitting}
+                  disabled={!isValid}
+                  className={{ root: 'mt-2' }}
+                  form="question-manipulation-form"
+                  data={{ cy: 'save-new-question' }}
+                >
+                  <Button.Label>{t('shared.generic.save')}</Button.Label>
+                </Button>
+              ) : undefined
             }
             onSecondaryAction={
-              !isTemplate ? (
+              !isTemplate && !inputsDisabled ? (
                 <Button
                   className={{ root: 'mt-2' }}
                   onClick={() => onClose()}
@@ -147,11 +152,13 @@ function ElementEditForm({
               ) : undefined
             }
           >
-            <AutoSaveMonitor
-              values={values}
-              initialValuesString={JSON.stringify(initialValues)}
-              setAutoSavedElement={setAutoSavedElement}
-            />
+            {!inputsDisabled && (
+              <AutoSaveMonitor
+                values={values}
+                initialValuesString={JSON.stringify(initialValues)}
+                setAutoSavedElement={setAutoSavedElement}
+              />
+            )}
             <ElementTypeMonitor
               elementType={values.type ?? ElementType.Sc}
               setElementDataTypename={setElementDataTypename}
@@ -162,15 +169,18 @@ function ElementEditForm({
                 <Form className="w-full" id="question-manipulation-form">
                   <ElementInformationFields
                     isTemplate={isTemplate}
+                    inputsDisabled={inputsDisabled}
                     mode={mode}
                     values={values}
                     isSubmitting={isSubmitting}
                   />
                   <ElementContentInput
+                    disabled={inputsDisabled}
                     values={values}
                     setFieldValue={setFieldValue}
                   />
                   <ElementExplanationField
+                    disabled={inputsDisabled}
                     values={values}
                     setFieldValue={setFieldValue}
                   />
@@ -181,6 +191,7 @@ function ElementEditForm({
                     values.type !== ElementType.Flashcard && (
                       <ElementformScoringSection
                         isTemplate={isTemplate}
+                        disabled={inputsDisabled}
                         values={values}
                         setFieldValue={setFieldValue}
                         isSubmitting={isSubmitting}
@@ -189,35 +200,45 @@ function ElementEditForm({
 
                   <div className="mt-4 flex flex-row gap-4">
                     <OptionsLabel type={values.type} />
-
                     <AnswerFeedbackSetting
-                      disabled={isTemplate}
+                      disabled={isTemplate || inputsDisabled}
                       values={values}
                     />
-                    <DisplayModeSetting type={values.type} />
+                    <DisplayModeSetting
+                      disabled={inputsDisabled}
+                      type={values.type}
+                    />
                   </div>
 
                   {values.type === ElementType.Sc ||
                   values.type === ElementType.Mc ||
                   values.type === ElementType.Kprim ? (
                     <ChoicesOptions
+                      inputsDisabled={inputsDisabled}
                       values={values}
                       setFieldValue={setFieldValue}
                     />
                   ) : null}
 
                   {values.type === ElementType.Numerical && (
-                    <NumericalOptions values={values} />
+                    <NumericalOptions
+                      inputsDisabled={inputsDisabled}
+                      values={values}
+                    />
                   )}
 
                   {values.type === ElementType.FreeText && (
-                    <FreeTextOptions values={values} />
+                    <FreeTextOptions
+                      inputsDisabled={inputsDisabled}
+                      values={values}
+                    />
                   )}
 
                   {values.type === ElementType.Selection && (
                     <SelectionOptions
                       templateId={templateId}
                       isTemplate={isTemplate}
+                      inputsDisabled={inputsDisabled}
                       values={values}
                       setAnswerCollectionEntries={setAnswerCollectionEntries}
                     />
@@ -227,6 +248,7 @@ function ElementEditForm({
                     <CaseStudyOptions
                       templateId={templateId}
                       isTemplate={isTemplate}
+                      inputsDisabled={inputsDisabled}
                       setFieldValue={setFieldValue}
                       setFieldTouched={setFieldTouched}
                       hasSampleSolution={values.options.hasSampleSolution}
@@ -246,7 +268,7 @@ function ElementEditForm({
               />
             </div>
 
-            {mode === ElementEditMode.EDIT && elementId && (
+            {mode === ElementEditMode.EDIT && elementId && !inputsDisabled && (
               <InstanceUpdateSwitch
                 elementId={elementId}
                 hasSampleSolution={

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
@@ -36,6 +36,7 @@ export enum ElementEditMode {
 }
 
 interface ElementEditModalProps {
+  inputsDisabled?: boolean
   isOpen: boolean
   handleSetIsOpen: (open: boolean) => void
   triggerSuccessToast: () => void
@@ -44,6 +45,7 @@ interface ElementEditModalProps {
 }
 
 function ElementEditModal({
+  inputsDisabled = false,
   isOpen,
   handleSetIsOpen,
   triggerSuccessToast,
@@ -120,6 +122,7 @@ function ElementEditModal({
     <ElementEditForm
       mode={mode}
       elementId={elementId}
+      inputsDisabled={inputsDisabled}
       loading={loadingQuestion}
       initialValues={formikInitialValues}
       open={isOpen}

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementExplanationField.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementExplanationField.tsx
@@ -6,6 +6,7 @@ import ContentInput from '../../common/ContentInput'
 import { ElementFormTypes } from './types'
 
 interface ElementExplanationFieldProps {
+  disabled?: boolean
   values: ElementFormTypes
   setFieldValue: (
     field: string,
@@ -15,6 +16,7 @@ interface ElementExplanationFieldProps {
 }
 
 function ElementExplanationField({
+  disabled,
   values,
   setFieldValue,
 }: ElementExplanationFieldProps) {
@@ -47,6 +49,8 @@ function ElementExplanationField({
               tooltip={t('manage.elements.explanationTooltip')}
             />
             <ContentInput
+              key={`${values.type}-explanation`}
+              disabled={disabled}
               error={meta.error}
               touched={meta.touched}
               content={field.value || '<br>'}
@@ -54,7 +58,7 @@ function ElementExplanationField({
                 setFieldValue('explanation', newValue)
               }
               placeholder={t('manage.elements.explanationPlaceholder')}
-              key={`${values.type}-explanation`}
+              showToolbarOnFocus={disabled} // show toolbar only when not disabled
               data={{ cy: 'insert-question-explanation' }}
             />
           </>

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementFormScoringSection.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementFormScoringSection.tsx
@@ -10,11 +10,13 @@ import { ElementFormTypes } from './types'
 
 function ElementformScoringSection({
   isTemplate,
+  disabled,
   values,
   setFieldValue,
   isSubmitting,
 }: {
   isTemplate: boolean
+  disabled: boolean
   values: ElementFormTypes
   setFieldValue: (
     field: string,
@@ -51,7 +53,10 @@ function ElementformScoringSection({
           </Link>
         </div>
 
-        <SampleSolutionSetting disabled={isTemplate} type={values.type} />
+        <SampleSolutionSetting
+          disabled={isTemplate || disabled}
+          type={values.type}
+        />
       </div>
 
       <div className="mt-2 flex flex-col lg:flex-row lg:gap-4">
@@ -71,11 +76,11 @@ function ElementformScoringSection({
             </div>
           </div>
           <Switch
+            disabled={isSubmitting || disabled}
             checked={values.basePoints}
             onCheckedChange={() =>
               setFieldValue('basePoints', !values.basePoints)
             }
-            disabled={isSubmitting}
             className={{
               root: 'mt-2 self-center',
             }}
@@ -105,7 +110,7 @@ function ElementformScoringSection({
               <MultiplierSelector
                 withoutLabel
                 name="pointsMultiplier"
-                disabled={isSubmitting}
+                disabled={isSubmitting || disabled}
                 className={{
                   trigger: 'mt-1 h-8 w-full',
                 }}

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementInformationFields.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementInformationFields.tsx
@@ -17,6 +17,7 @@ interface ElementInformationFieldsProps {
   mode: ElementEditMode
   values: ElementFormTypes
   isSubmitting: boolean
+  inputsDisabled?: boolean
 }
 
 function ElementInformationFields({
@@ -24,6 +25,7 @@ function ElementInformationFields({
   mode,
   values,
   isSubmitting,
+  inputsDisabled = false,
 }: ElementInformationFieldsProps) {
   const t = useTranslations()
   const statusOptions = useStatusOptions()
@@ -36,7 +38,7 @@ function ElementInformationFields({
           name="type"
           required={mode === ElementEditMode.CREATE}
           contentPosition="popper"
-          disabled={mode === ElementEditMode.EDIT || isTemplate}
+          disabled={mode === ElementEditMode.EDIT || isTemplate || isSubmitting}
           label={t('manage.elements.elementType')}
           placeholder={t('manage.elements.selectQuestionType')}
           items={questionTypeOptions}
@@ -48,6 +50,7 @@ function ElementInformationFields({
           <FormikSelectField
             name="status"
             contentPosition="popper"
+            disabled={inputsDisabled || isSubmitting}
             label={t('manage.elements.questionStatus')}
             placeholder={t('manage.elements.selectQuestionStatus')}
             items={statusOptions}
@@ -61,6 +64,7 @@ function ElementInformationFields({
         <FormikTextField
           name="name"
           required
+          disabled={inputsDisabled || isSubmitting}
           label={t('manage.elements.elementTitle')}
           tooltip={t('manage.elements.titleTooltip')}
           className={{
@@ -80,7 +84,7 @@ function ElementInformationFields({
               tooltip={t('manage.elements.tagsTooltip')}
             />
             <Suspense fallback={<Loader />}>
-              <SuspendedTagInput />
+              <SuspendedTagInput disabled={inputsDisabled || isSubmitting} />
             </Suspense>
           </div>
         ) : null}

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCasesFields.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCasesFields.tsx
@@ -21,6 +21,7 @@ import { ElementFormTypes, ElementFormTypesCaseStudy } from '../types'
 import CaseStudyCaseDeletionButton from './CaseStudyCaseDeletionButton'
 
 export interface CaseStudySetterProps {
+  inputsDisabled: boolean
   setFieldValue: (
     field: string,
     value: any,
@@ -39,6 +40,7 @@ interface CaseStudyCasesFieldsProps extends CaseStudySetterProps {
 }
 
 function CaseStudyCasesFields({
+  inputsDisabled,
   setFieldValue,
   setFieldTouched,
   hasSampleSolution,
@@ -63,14 +65,17 @@ function CaseStudyCasesFields({
                   <H3>
                     {t('shared.generic.case')} {ix + 1}
                   </H3>
-                  <CaseStudyCaseDeletionButton
-                    hasSampleSolution={hasSampleSolution}
-                    onConfirm={() => remove(ix)}
-                    index={ix}
-                  />
+                  {!inputsDisabled ? (
+                    <CaseStudyCaseDeletionButton
+                      hasSampleSolution={hasSampleSolution}
+                      onConfirm={() => remove(ix)}
+                      index={ix}
+                    />
+                  ) : null}
                 </div>
                 <FormikTextField
                   required
+                  disabled={inputsDisabled}
                   name={`options.cases.${ix}.title`}
                   label={t('manage.elements.caseTitle')}
                   tooltip={t('manage.elements.caseStudyCaseTitleTooltip')}
@@ -97,6 +102,7 @@ function CaseStudyCasesFields({
                       <ContentInput
                         error={meta.error}
                         touched={meta.touched}
+                        disabled={inputsDisabled}
                         content={field.value || '<br>'}
                         onChange={(newValue: string) => {
                           setFieldValue(
@@ -111,7 +117,7 @@ function CaseStudyCasesFields({
                         placeholder={t(
                           'manage.elements.caseDescriptionPlaceholder'
                         )}
-                        showToolbarOnFocus={false}
+                        showToolbarOnFocus={inputsDisabled}
                         className={{ content: 'max-w-none' }}
                         data={{ cy: `case-description-${ix}` }}
                       />
@@ -172,6 +178,7 @@ function CaseStudyCasesFields({
                                     <div className="flex gap-4">
                                       <FormikNumberField
                                         required
+                                        disabled={inputsDisabled}
                                         precision={
                                           criterion.mode === 'steps'
                                             ? 0
@@ -193,6 +200,7 @@ function CaseStudyCasesFields({
                                       />
                                       <FormikNumberField
                                         required
+                                        disabled={inputsDisabled}
                                         precision={
                                           criterion.mode === 'steps'
                                             ? 0
@@ -227,19 +235,21 @@ function CaseStudyCasesFields({
                 <hr className="border-uzh-grey-40 mt-4 w-full border-2" />
               </div>
             ))}
-            <Button
-              type="button"
-              onClick={() =>
-                push({ id: nanoid(), name: undefined, description: '' })
-              }
-              className={{
-                root: 'border-primary-80 h-9 font-semibold',
-              }}
-              data={{ cy: 'add-new-case' }}
-            >
-              <Button.Icon icon={faPlus} />
-              <Button.Label>{t('manage.elements.addCase')}</Button.Label>
-            </Button>
+            {!inputsDisabled ? (
+              <Button
+                type="button"
+                onClick={() =>
+                  push({ id: nanoid(), name: undefined, description: '' })
+                }
+                className={{
+                  root: 'border-primary-80 h-9 font-semibold',
+                }}
+                data={{ cy: 'add-new-case' }}
+              >
+                <Button.Icon icon={faPlus} />
+                <Button.Label>{t('manage.elements.addCase')}</Button.Label>
+              </Button>
+            ) : null}
           </div>
         )}
       </FieldArray>

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCollectionSelection.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCollectionSelection.tsx
@@ -14,6 +14,7 @@ import useSelectedAnswerEntry from './useSelectedAnswerEntry'
 
 function CaseStudyCollectionSelection({
   loading,
+  disabled,
   isTemplate,
   collections,
   setSelectedItems,
@@ -22,6 +23,7 @@ function CaseStudyCollectionSelection({
   refetchAnswerCollections,
 }: {
   loading: boolean
+  disabled: boolean
   isTemplate: boolean
   collections: Pick<AnswerCollection, 'id' | 'name' | 'entries'>[]
   setSelectedItems: Dispatch<SetStateAction<{ id: number; name: string }[]>>
@@ -70,6 +72,7 @@ function CaseStudyCollectionSelection({
       <div className="flex flex-row items-end gap-2">
         <SelectField
           required
+          disabled={disabled || loading}
           value={collectionField.value}
           onChange={(value) => {
             if (hasSampleSolution && selectedAnswers.length > 0) {
@@ -100,7 +103,7 @@ function CaseStudyCollectionSelection({
           }}
         />
         <Button
-          disabled={loading}
+          disabled={disabled || loading}
           onClick={async () => await refetchAnswerCollections()}
           className={{ root: 'h-9 w-9' }}
           data={{ cy: 'refresh-answer-collections' }}
@@ -123,6 +126,7 @@ function CaseStudyCollectionSelection({
           <Select
             isClearable
             isMulti
+            isDisabled={disabled || loading}
             value={selectedAnswers}
             options={collectionAnswers}
             menuPlacement="auto"

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCriteriaFields.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCriteriaFields.tsx
@@ -17,7 +17,7 @@ import {
 } from '../types'
 import CaseStudyCriterionModeMonitor from './CaseStudyCriterionModeMonitor'
 
-function CaseStudyCriteriaFields() {
+function CaseStudyCriteriaFields({ disabled }: { disabled: boolean }) {
   const t = useTranslations()
   const [criteriaField, _, criteriaHelpers] =
     useField<ElementFormTypesCaseStudyCriterion[]>('options.criteria')
@@ -56,56 +56,59 @@ function CaseStudyCriteriaFields() {
                         ? t('manage.elements.caseStudyRangeCriterion')
                         : t('manage.elements.caseStudyStepCriterion')}
                     </div>
-                    <Button
-                      destructive
-                      onClick={() => {
-                        const removedCriterionId =
-                          criteriaField.value?.[index]?.id
-                        remove(index)
+                    {!disabled ? (
+                      <Button
+                        destructive
+                        onClick={() => {
+                          const removedCriterionId =
+                            criteriaField.value?.[index]?.id
+                          remove(index)
 
-                        // Remove all solutions for this criterion
-                        const newCases = casesField.value?.map((caseItem) => {
-                          if (
-                            !('solutions' in caseItem) ||
-                            !caseItem.solutions
-                          ) {
-                            return caseItem
-                          }
+                          // Remove all solutions for this criterion
+                          const newCases = casesField.value?.map((caseItem) => {
+                            if (
+                              !('solutions' in caseItem) ||
+                              !caseItem.solutions
+                            ) {
+                              return caseItem
+                            }
 
-                          const newSolutions = Object.fromEntries(
-                            Object.entries(caseItem.solutions).map(
-                              ([itemIdString, itemSolutions]) => {
-                                const newItemSolutions = Object.fromEntries(
-                                  Object.entries(itemSolutions).filter(
-                                    ([criterionId, _]) =>
-                                      criterionId !== removedCriterionId
+                            const newSolutions = Object.fromEntries(
+                              Object.entries(caseItem.solutions).map(
+                                ([itemIdString, itemSolutions]) => {
+                                  const newItemSolutions = Object.fromEntries(
+                                    Object.entries(itemSolutions).filter(
+                                      ([criterionId, _]) =>
+                                        criterionId !== removedCriterionId
+                                    )
                                   )
-                                )
-                                return [itemIdString, newItemSolutions]
-                              }
+                                  return [itemIdString, newItemSolutions]
+                                }
+                              )
                             )
-                          )
 
-                          return {
-                            ...caseItem,
-                            solutions: newSolutions,
-                          }
-                        })
+                            return {
+                              ...caseItem,
+                              solutions: newSolutions,
+                            }
+                          })
 
-                        casesHelpers.setValue(newCases)
-                      }}
-                      className={{
-                        root: 'h-7 w-7',
-                      }}
-                      data={{ cy: `remove-criterion-${index}` }}
-                    >
-                      <FontAwesomeIcon icon={faTrashCan} />
-                    </Button>
+                          casesHelpers.setValue(newCases)
+                        }}
+                        className={{
+                          root: 'h-7 w-7',
+                        }}
+                        data={{ cy: `remove-criterion-${index}` }}
+                      >
+                        <FontAwesomeIcon icon={faTrashCan} />
+                      </Button>
+                    ) : null}
                   </div>
 
                   <FormikTextField
                     required
                     hideError
+                    disabled={disabled}
                     name={`options.criteria.${index}.name`}
                     label={t('shared.generic.name')}
                     tooltip={t('manage.elements.caseStudyCriteriaNameTooltip')}
@@ -123,6 +126,7 @@ function CaseStudyCriteriaFields() {
                       <FormikNumberField
                         required
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.min`}
                         label={t('shared.generic.minimumShort')}
                         tooltip={t(
@@ -137,6 +141,7 @@ function CaseStudyCriteriaFields() {
                       <FormikNumberField
                         required
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.max`}
                         label={t('shared.generic.maximumShort')}
                         tooltip={t(
@@ -151,6 +156,7 @@ function CaseStudyCriteriaFields() {
                       <FormikNumberField
                         required
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.step`}
                         label={t('shared.generic.step')}
                         tooltip={t(
@@ -164,6 +170,7 @@ function CaseStudyCriteriaFields() {
                       />
                       <FormikTextField
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.unit`}
                         label={t('shared.generic.unit')}
                         tooltip={t(
@@ -184,6 +191,7 @@ function CaseStudyCriteriaFields() {
                       <FormikTextField
                         required
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.labels.min`}
                         label={t('shared.generic.lowerEnd')}
                         placeholder={t('shared.generic.textInput')}
@@ -199,6 +207,7 @@ function CaseStudyCriteriaFields() {
                       />
                       <FormikTextField
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.labels.mid`}
                         label={t('shared.generic.midValue')}
                         placeholder={t('shared.generic.textInput')}
@@ -215,6 +224,7 @@ function CaseStudyCriteriaFields() {
                       <FormikTextField
                         required
                         hideError
+                        disabled={disabled}
                         name={`options.criteria.${index}.labels.max`}
                         label={t('shared.generic.upperEnd')}
                         placeholder={t('shared.generic.textInput')}
@@ -231,6 +241,7 @@ function CaseStudyCriteriaFields() {
                       <NumberField
                         required
                         hideError
+                        disabled={disabled}
                         value={
                           criteriaField.value[index].max &&
                           criteriaField.value[index].min
@@ -271,52 +282,58 @@ function CaseStudyCriteriaFields() {
                   )}
                 </div>
               ))}
-              <div className="mt-1 flex flex-col gap-2 sm:flex-row">
-                <Button
-                  onClick={() =>
-                    push({
-                      id: nanoid(),
-                      mode: 'range',
-                      name: undefined,
-                      min: undefined,
-                      max: undefined,
-                      step: undefined,
-                      unit: undefined,
-                    })
-                  }
-                  className={{ root: 'border-primary-80 h-9 w-full sm:w-1/2' }}
-                  data={{ cy: 'add-range-criterion' }}
-                >
-                  <Button.Icon icon={faPlus} />
-                  <Button.Label>
-                    {t('manage.elements.addRangeCriterion')}
-                  </Button.Label>
-                </Button>
-                <Button
-                  onClick={() =>
-                    push({
-                      id: nanoid(),
-                      mode: 'steps',
-                      name: undefined,
-                      min: 1,
-                      max: 5,
-                      step: 1,
-                      unit: undefined,
-                      labels: {
+              {!disabled ? (
+                <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                  <Button
+                    onClick={() =>
+                      push({
+                        id: nanoid(),
+                        mode: 'range',
+                        name: undefined,
                         min: undefined,
                         max: undefined,
-                      },
-                    })
-                  }
-                  className={{ root: 'border-primary-80 h-9 w-full sm:w-1/2' }}
-                  data={{ cy: 'add-steps-criterion' }}
-                >
-                  <Button.Icon icon={faPlus} />
-                  <Button.Label>
-                    {t('manage.elements.addStepsCriterion')}
-                  </Button.Label>
-                </Button>
-              </div>
+                        step: undefined,
+                        unit: undefined,
+                      })
+                    }
+                    className={{
+                      root: 'border-primary-80 h-9 w-full sm:w-1/2',
+                    }}
+                    data={{ cy: 'add-range-criterion' }}
+                  >
+                    <Button.Icon icon={faPlus} />
+                    <Button.Label>
+                      {t('manage.elements.addRangeCriterion')}
+                    </Button.Label>
+                  </Button>
+                  <Button
+                    onClick={() =>
+                      push({
+                        id: nanoid(),
+                        mode: 'steps',
+                        name: undefined,
+                        min: 1,
+                        max: 5,
+                        step: 1,
+                        unit: undefined,
+                        labels: {
+                          min: undefined,
+                          max: undefined,
+                        },
+                      })
+                    }
+                    className={{
+                      root: 'border-primary-80 h-9 w-full sm:w-1/2',
+                    }}
+                    data={{ cy: 'add-steps-criterion' }}
+                  >
+                    <Button.Icon icon={faPlus} />
+                    <Button.Label>
+                      {t('manage.elements.addStepsCriterion')}
+                    </Button.Label>
+                  </Button>
+                </div>
+              ) : null}
             </>
           )}
         </FieldArray>

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyOptions.tsx
@@ -23,6 +23,7 @@ interface CaseStudyOptionsProps extends CaseStudySetterProps {
 function CaseStudyOptions({
   templateId,
   isTemplate,
+  inputsDisabled = false,
   setFieldValue,
   setFieldTouched,
   hasSampleSolution,
@@ -67,6 +68,7 @@ function CaseStudyOptions({
     <div className="flex flex-col gap-4">
       <CaseStudyCollectionSelection
         loading={loading}
+        disabled={inputsDisabled}
         isTemplate={isTemplate}
         collections={collections}
         setSelectedItems={setSelectedItems}
@@ -77,9 +79,10 @@ function CaseStudyOptions({
         }
       />
       <hr className="border-uzh-grey-40 my-2 w-full border-2" />
-      <CaseStudyCriteriaFields />
+      <CaseStudyCriteriaFields disabled={inputsDisabled} />
       <hr className="border-uzh-grey-40 my-2 w-full border-2" />
       <CaseStudyCasesFields
+        inputsDisabled={inputsDisabled}
         setFieldTouched={setFieldTouched}
         setFieldValue={setFieldValue}
         hasSampleSolution={hasSampleSolution}

--- a/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/ChoicesOptions.tsx
@@ -20,6 +20,7 @@ import ContentInput from '../../../common/ContentInput'
 import { ElementFormTypes, ElementFormTypesChoices } from '../types'
 
 interface ChoicesOptionsProps {
+  inputsDisabled?: boolean
   values: ElementFormTypesChoices
   setFieldValue: (
     field: string,
@@ -29,6 +30,7 @@ interface ChoicesOptionsProps {
 }
 
 function ChoicesOptions({
+  inputsDisabled,
   values,
   setFieldValue,
 }: ChoicesOptionsProps): JSX.Element {
@@ -83,6 +85,7 @@ function ChoicesOptions({
                     {({ field, meta }: FastFieldProps) => (
                       <ContentInput
                         key={`${values.type}-choice-${values.options.choices[index].id}`}
+                        disabled={inputsDisabled}
                         error={meta.error}
                         touched={meta.touched}
                         content={field.value}
@@ -111,6 +114,7 @@ function ChoicesOptions({
                       <FastField name={`options.choices.${index}.correct`}>
                         {({ field }: FieldProps) => (
                           <Switch
+                            disabled={inputsDisabled}
                             checked={field.value || false}
                             label=""
                             className={{
@@ -133,7 +137,7 @@ function ChoicesOptions({
                   <div className="ml-2 flex flex-col">
                     <Button
                       className={{ root: 'px-auto py-0.5' }}
-                      disabled={index === 0}
+                      disabled={index === 0 || inputsDisabled}
                       onClick={() => move(index, index - 1)}
                       data={{
                         cy: `move-answer-option-ix-${index}-up`,
@@ -147,7 +151,10 @@ function ChoicesOptions({
                     </Button>
                     <Button
                       className={{ root: 'px-auto py-0.5' }}
-                      disabled={index === values.options.choices.length - 1}
+                      disabled={
+                        index === values.options.choices.length - 1 ||
+                        inputsDisabled
+                      }
                       onClick={() => move(index, index + 1)}
                       data={{
                         cy: `move-answer-option-ix-${index}-down`,
@@ -162,6 +169,7 @@ function ChoicesOptions({
                   </div>
                   <Button
                     destructive
+                    disabled={inputsDisabled}
                     onClick={() => remove(index)}
                     className={{
                       root: 'ml-1 h-10 w-10',
@@ -216,6 +224,7 @@ function ChoicesOptions({
                         {({ field, meta }: FastFieldProps) => (
                           <ContentInput
                             key={`${values.type}-feedback-${values.options.choices[index].id}`}
+                            disabled={inputsDisabled}
                             error={meta.error}
                             touched={meta.touched}
                             content={field.value || '<br>'}
@@ -245,33 +254,35 @@ function ChoicesOptions({
               </div>
             ))}
 
-            <Button
-              fluid
-              className={{
-                root: twMerge(
-                  'border-uzh-grey-100 border border-solid font-bold',
+            {!inputsDisabled ? (
+              <Button
+                fluid
+                className={{
+                  root: twMerge(
+                    'border-uzh-grey-100 border border-solid font-bold',
+                    values.type === ElementType.Kprim &&
+                      values.options.choices.length >= 4 &&
+                      'cursor-not-allowed opacity-50'
+                  ),
+                }}
+                disabled={
                   values.type === ElementType.Kprim &&
-                    values.options.choices.length >= 4 &&
-                    'cursor-not-allowed opacity-50'
-                ),
-              }}
-              disabled={
-                values.type === ElementType.Kprim &&
-                values.options.choices.length >= 4
-              }
-              onClick={() =>
-                push({
-                  id: nanoid(),
-                  ix: values.options.choices.length,
-                  value: '<br>',
-                  correct: false,
-                  feedback: '',
-                })
-              }
-              data={{ cy: 'add-new-answer' }}
-            >
-              <Button.Label>{t('manage.elements.addAnswer')}</Button.Label>
-            </Button>
+                  values.options.choices.length >= 4
+                }
+                onClick={() =>
+                  push({
+                    id: nanoid(),
+                    ix: values.options.choices.length,
+                    value: '<br>',
+                    correct: false,
+                    feedback: '',
+                  })
+                }
+                data={{ cy: 'add-new-answer' }}
+              >
+                <Button.Label>{t('manage.elements.addAnswer')}</Button.Label>
+              </Button>
+            ) : null}
           </div>
         )
       }}

--- a/apps/frontend-manage/src/components/questions/manipulation/options/DisplayModeSetting.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/DisplayModeSetting.tsx
@@ -2,15 +2,18 @@ import { ElementDisplayMode, ElementType } from '@klicker-uzh/graphql/dist/ops'
 import { FormikSelectField } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
-interface DisplayModeSettingProps {
+function DisplayModeSetting({
+  type,
+  disabled,
+}: {
   type: ElementType
-}
-
-function DisplayModeSetting({ type }: DisplayModeSettingProps) {
+  disabled: boolean
+}) {
   const t = useTranslations()
 
   return [ElementType.Sc, ElementType.Mc].includes(type) ? (
     <FormikSelectField
+      disabled={disabled}
       contentPosition="popper"
       name="options.displayMode"
       items={Object.values(ElementDisplayMode).map((mode) => ({

--- a/apps/frontend-manage/src/components/questions/manipulation/options/FreeTextOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/FreeTextOptions.tsx
@@ -8,16 +8,18 @@ import { useTranslations } from 'next-intl'
 import { ElementFormTypesFreeText } from '../types'
 
 interface FreeTextOptionsProps {
+  inputsDisabled?: boolean
   values: ElementFormTypesFreeText
 }
 
-function FreeTextOptions({ values }: FreeTextOptionsProps) {
+function FreeTextOptions({ inputsDisabled, values }: FreeTextOptionsProps) {
   const t = useTranslations()
 
   return (
     <div className="flex flex-col">
       <div className="mb-4 flex flex-row items-center">
         <FormikNumberField
+          disabled={inputsDisabled}
           name="options.restrictions.maxLength"
           label={t('manage.elements.maximumLength')}
           className={{
@@ -41,6 +43,7 @@ function FreeTextOptions({ values }: FreeTextOptionsProps) {
                     >
                       <FormikTextField
                         required
+                        disabled={inputsDisabled}
                         name={`options.solutions.${index}`}
                         label={t('manage.elements.possibleSolutionN', {
                           number: String(index + 1),
@@ -49,31 +52,35 @@ function FreeTextOptions({ values }: FreeTextOptionsProps) {
                         placeholder={t('shared.generic.solution')}
                         data={{ cy: `set-solution-ix-${index}` }}
                       />
-                      <Button
-                        destructive
-                        onClick={() => remove(index)}
-                        className={{
-                          root: 'h-9',
-                        }}
-                        data={{
-                          cy: `delete-solution-ix-${index}`,
-                        }}
-                      >
-                        {t('shared.generic.delete')}
-                      </Button>
+                      {!inputsDisabled ? (
+                        <Button
+                          destructive
+                          onClick={() => remove(index)}
+                          className={{
+                            root: 'h-9',
+                          }}
+                          data={{
+                            cy: `delete-solution-ix-${index}`,
+                          }}
+                        >
+                          {t('shared.generic.delete')}
+                        </Button>
+                      ) : null}
                     </div>
                   ))
                 : null}
-              <Button
-                fluid
-                className={{
-                  root: 'mt-1 h-8 border-gray-300 font-bold',
-                }}
-                onClick={() => push('')}
-                data={{ cy: 'add-solution-value' }}
-              >
-                {t('manage.elements.addSolution')}
-              </Button>
+              {!inputsDisabled ? (
+                <Button
+                  fluid
+                  className={{
+                    root: 'mt-1 h-8 border-gray-300 font-bold',
+                  }}
+                  onClick={() => push('')}
+                  data={{ cy: 'add-solution-value' }}
+                >
+                  {t('manage.elements.addSolution')}
+                </Button>
+              ) : null}
             </div>
           )}
         </FieldArray>

--- a/apps/frontend-manage/src/components/questions/manipulation/options/NumericalExactSolutionsInput.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/NumericalExactSolutionsInput.tsx
@@ -4,9 +4,11 @@ import { useTranslations } from 'next-intl'
 import { ElementFormTypesNumerical } from '../types'
 
 function NumericalExactSolutionsInput({
+  disabled,
   exactSolutions,
   precision,
 }: {
+  disabled?: boolean
   exactSolutions: ElementFormTypesNumerical['options']['exactSolutions']
   precision?: string | null
 }) {
@@ -31,6 +33,7 @@ function NumericalExactSolutionsInput({
                 <FormikNumberField
                   hideError
                   required={index === 0}
+                  disabled={disabled}
                   name={`options.exactSolutions.${index}`}
                   label={t('shared.generic.value')}
                   placeholder={`${t('shared.generic.value')} ${index + 1}`}
@@ -39,30 +42,34 @@ function NumericalExactSolutionsInput({
                     cy: `set-exact-solution-${index}`,
                   }}
                 />
-                <Button
-                  destructive
-                  onClick={() => remove(index)}
-                  className={{
-                    root: 'h-9',
-                  }}
-                  data={{
-                    cy: `delete-exact-solution-${index}`,
-                  }}
-                >
-                  {t('shared.generic.delete')}
-                </Button>
+                {!disabled ? (
+                  <Button
+                    destructive
+                    onClick={() => remove(index)}
+                    className={{
+                      root: 'h-9',
+                    }}
+                    data={{
+                      cy: `delete-exact-solution-${index}`,
+                    }}
+                  >
+                    {t('shared.generic.delete')}
+                  </Button>
+                ) : null}
               </div>
             ))}
-            <Button
-              fluid
-              className={{
-                root: 'mt-1 h-8 border-gray-300 font-bold',
-              }}
-              onClick={() => push(undefined)}
-              data={{ cy: 'add-exact-solution' }}
-            >
-              {t('manage.elements.addExactSolution')}
-            </Button>
+            {!disabled ? (
+              <Button
+                fluid
+                className={{
+                  root: 'mt-1 h-8 border-gray-300 font-bold',
+                }}
+                onClick={() => push(undefined)}
+                data={{ cy: 'add-exact-solution' }}
+              >
+                {t('manage.elements.addExactSolution')}
+              </Button>
+            ) : null}
           </div>
         )}
       </FieldArray>

--- a/apps/frontend-manage/src/components/questions/manipulation/options/NumericalOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/NumericalOptions.tsx
@@ -6,10 +6,11 @@ import NumericalSolutionRangesInput from './NumericalSolutionRangesInput'
 import NumericalSolutionTypeSwitch from './NumericalSolutionTypeSwitch'
 
 interface NumericalOptionsProps {
+  inputsDisabled?: boolean
   values: ElementFormTypesNumerical
 }
 
-function NumericalOptions({ values }: NumericalOptionsProps) {
+function NumericalOptions({ inputsDisabled, values }: NumericalOptionsProps) {
   const t = useTranslations()
 
   return (
@@ -17,6 +18,7 @@ function NumericalOptions({ values }: NumericalOptionsProps) {
       <div className="w-full">
         <div className="mb-2 flex flex-row items-center gap-2">
           <FormikNumberField
+            disabled={inputsDisabled}
             name="options.restrictions.min"
             label={t('shared.generic.min')}
             placeholder={t('shared.generic.minLong')}
@@ -24,6 +26,7 @@ function NumericalOptions({ values }: NumericalOptionsProps) {
             hideError
           />
           <FormikNumberField
+            disabled={inputsDisabled}
             name="options.restrictions.max"
             label={t('shared.generic.max')}
             placeholder={t('shared.generic.maxLong')}
@@ -31,12 +34,14 @@ function NumericalOptions({ values }: NumericalOptionsProps) {
             hideError
           />
           <FormikTextField
+            disabled={inputsDisabled}
             name="options.unit"
             label={t('shared.generic.unit')}
             placeholder="CHF"
             data={{ cy: 'set-numerical-unit' }}
           />
           <FormikNumberField
+            disabled={inputsDisabled}
             name="options.accuracy"
             label={t('shared.generic.precision')}
             precision={0}
@@ -47,18 +52,21 @@ function NumericalOptions({ values }: NumericalOptionsProps) {
       </div>
       {values.options.hasSampleSolution && (
         <NumericalSolutionTypeSwitch
+          disabled={inputsDisabled}
           solutionType={values.options.solutionType}
         />
       )}
       {values.options.hasSampleSolution &&
         values.options.solutionType === 'range' && (
           <NumericalSolutionRangesInput
+            disabled={inputsDisabled}
             solutionRanges={values.options.solutionRanges}
           />
         )}
       {values.options.hasSampleSolution &&
         values.options.solutionType === 'exact' && (
           <NumericalExactSolutionsInput
+            disabled={inputsDisabled}
             exactSolutions={values.options.exactSolutions}
             precision={String(values.options.accuracy)}
           />

--- a/apps/frontend-manage/src/components/questions/manipulation/options/NumericalSolutionRangesInput.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/NumericalSolutionRangesInput.tsx
@@ -4,8 +4,10 @@ import { useTranslations } from 'next-intl'
 import { ElementFormTypesNumerical } from '../types'
 
 function NumericalSolutionRangesInput({
+  disabled,
   solutionRanges,
 }: {
+  disabled?: boolean
   solutionRanges: ElementFormTypesNumerical['options']['solutionRanges']
 }) {
   const t = useTranslations()
@@ -29,6 +31,7 @@ function NumericalSolutionRangesInput({
                   >
                     <FormikNumberField
                       required={index === 0}
+                      disabled={disabled}
                       name={`options.solutionRanges.${index}.min`}
                       label={t('shared.generic.min')}
                       placeholder={t('shared.generic.minLong')}
@@ -38,6 +41,7 @@ function NumericalSolutionRangesInput({
                     />
                     <FormikNumberField
                       required={index === 0}
+                      disabled={disabled}
                       name={`options.solutionRanges.${index}.max`}
                       label={t('shared.generic.max')}
                       placeholder={t('shared.generic.maxLong')}
@@ -45,34 +49,38 @@ function NumericalSolutionRangesInput({
                         cy: `set-solution-range-max-${index}`,
                       }}
                     />
-                    <Button
-                      destructive
-                      onClick={() => remove(index)}
-                      className={{ root: 'h-9' }}
-                      data={{
-                        cy: `delete-solution-range-ix-${index}`,
-                      }}
-                    >
-                      {t('shared.generic.delete')}
-                    </Button>
+                    {!disabled ? (
+                      <Button
+                        destructive
+                        onClick={() => remove(index)}
+                        className={{ root: 'h-9' }}
+                        data={{
+                          cy: `delete-solution-range-ix-${index}`,
+                        }}
+                      >
+                        {t('shared.generic.delete')}
+                      </Button>
+                    ) : null}
                   </div>
                 ))
               : null}
-            <Button
-              fluid
-              className={{
-                root: 'mt-1 h-8 border-gray-300 font-bold',
-              }}
-              onClick={() =>
-                push({
-                  min: undefined,
-                  max: undefined,
-                })
-              }
-              data={{ cy: 'add-solution-range' }}
-            >
-              {t('manage.elements.addSolutionRange')}
-            </Button>
+            {!disabled ? (
+              <Button
+                fluid
+                className={{
+                  root: 'mt-1 h-8 border-gray-300 font-bold',
+                }}
+                onClick={() =>
+                  push({
+                    min: undefined,
+                    max: undefined,
+                  })
+                }
+                data={{ cy: 'add-solution-range' }}
+              >
+                {t('manage.elements.addSolutionRange')}
+              </Button>
+            ) : null}
           </div>
         )}
       </FieldArray>

--- a/apps/frontend-manage/src/components/questions/manipulation/options/NumericalSolutionTypeSwitch.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/NumericalSolutionTypeSwitch.tsx
@@ -5,8 +5,10 @@ import { twMerge } from 'tailwind-merge'
 import { ElementFormTypesNumerical } from '../types'
 
 function NumericalSolutionTypeSwitch({
+  disabled,
   solutionType,
 }: {
+  disabled?: boolean
   solutionType: ElementFormTypesNumerical['options']['solutionType']
 }) {
   const t = useTranslations()
@@ -22,6 +24,7 @@ function NumericalSolutionTypeSwitch({
       />
       <div className="flex flex-row">
         <Button
+          disabled={disabled}
           onClick={() => helpers.setValue('range')}
           className={{
             root: twMerge(
@@ -36,6 +39,7 @@ function NumericalSolutionTypeSwitch({
           <Button.Label>{t('manage.elements.solutionRanges')}</Button.Label>
         </Button>
         <Button
+          disabled={disabled}
           onClick={() => helpers.setValue('exact')}
           className={{
             root: twMerge(

--- a/apps/frontend-manage/src/components/questions/manipulation/options/SelectionOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/SelectionOptions.tsx
@@ -23,6 +23,7 @@ import useSelectedAnswerEntry from './useSelectedAnswerEntry'
 interface SelectionOptionsProps {
   templateId?: string
   isTemplate: boolean
+  inputsDisabled?: boolean
   values: ElementFormTypesSelection
   setAnswerCollectionEntries: Dispatch<
     SetStateAction<{ id: number; value: string }[]>
@@ -32,6 +33,7 @@ interface SelectionOptionsProps {
 function SelectionOptions({
   templateId,
   isTemplate,
+  inputsDisabled,
   values,
   setAnswerCollectionEntries,
 }: SelectionOptionsProps) {
@@ -93,6 +95,7 @@ function SelectionOptions({
         <div className="flex flex-row items-end gap-1">
           <FormikSelectField
             required
+            disabled={inputsDisabled}
             name="options.answerCollection"
             label={t('manage.elements.answerCollection')}
             labelType="small"
@@ -111,7 +114,7 @@ function SelectionOptions({
             }}
           />
           <Button
-            disabled={loading}
+            disabled={loading || inputsDisabled}
             onClick={async () => await refetch()}
             className={{ root: 'h-9 w-9' }}
             data={{ cy: 'refresh-answer-collections' }}
@@ -126,6 +129,7 @@ function SelectionOptions({
 
         <FormikNumberField
           required
+          disabled={inputsDisabled}
           min={1}
           name="options.numberOfInputs"
           label={t('manage.elements.numberOfInputs')}
@@ -148,6 +152,7 @@ function SelectionOptions({
             <Select
               isClearable
               isMulti
+              isDisabled={inputsDisabled}
               value={selectedAnswers}
               options={collectionAnswers}
               menuPlacement="auto"

--- a/apps/frontend-manage/src/components/questions/tags/SuspendedTagInput.tsx
+++ b/apps/frontend-manage/src/components/questions/tags/SuspendedTagInput.tsx
@@ -5,10 +5,9 @@ import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import Creatable from 'react-select/creatable'
 
-function SuspendedTagInput() {
+function SuspendedTagInput({ disabled }: { disabled: boolean }) {
   const t = useTranslations()
   const [field, _, helpers] = useField<string[]>('tags')
-
   const { data } = useSuspenseQuery(GetUserTagsDocument)
 
   const tags = useMemo(
@@ -28,6 +27,7 @@ function SuspendedTagInput() {
     <Creatable
       isClearable
       isMulti
+      isDisabled={disabled}
       value={tags}
       options={options}
       classNames={{

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -1205,7 +1205,7 @@ export default defineConfig({
               })
 
               if (!practiceQuiz) {
-                throw new Error(`Live quiz ${activityName} not found`)
+                throw new Error(`Practice quiz ${activityName} not found`)
               }
 
               await prisma.practiceQuiz.update({
@@ -1218,7 +1218,7 @@ export default defineConfig({
               })
 
               if (!microLearning) {
-                throw new Error(`Live quiz ${activityName} not found`)
+                throw new Error(`Microlearning ${activityName} not found`)
               }
 
               await prisma.microLearning.update({
@@ -1231,7 +1231,7 @@ export default defineConfig({
               })
 
               if (!groupActivity) {
-                throw new Error(`Live quiz ${activityName} not found`)
+                throw new Error(`Group activity ${activityName} not found`)
               }
 
               await prisma.groupActivity.update({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global mechanism to disable all input fields and interactive controls in question editing forms and modals, enabling a read-only mode for non-editors.
  - Inputs and action buttons across various question option components (choices, free text, numerical, selection, case study, etc.) are now conditionally disabled or hidden based on user permissions.

- **Bug Fixes**
  - Corrected error messages for missing activity types to accurately reflect the specific activity (practice quiz, microlearning, group activity) in system notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->