### PR TITLE
fix(packages/graphql): resolve permission validation issues on element instances when editing or duplicating activity

### DIFF
--- a/apps/frontend-manage/src/components/activities/ElementCreation.tsx
+++ b/apps/frontend-manage/src/components/activities/ElementCreation.tsx
@@ -210,6 +210,8 @@ function ElementCreation({
                   ? {
                       ...dataLiveQuiz.liveQuiz,
                       name: `${dataLiveQuiz.liveQuiz.name} (Copy)`,
+                      // do not link previous course during duplication -> might not be available to user / not running anymore
+                      course: { id: '' },
                     }
                   : dataLiveQuiz.liveQuiz
                 : undefined
@@ -231,6 +233,8 @@ function ElementCreation({
                   ? ({
                       ...dataMicroLearning.getSingleMicroLearning,
                       name: `${dataMicroLearning.getSingleMicroLearning.name} (Copy)`,
+                      // do not link previous course during duplication -> might not be available to user / not running anymore
+                      course: { id: '' },
                     } as MicroLearning)
                   : (dataMicroLearning.getSingleMicroLearning as MicroLearning)
                 : undefined
@@ -253,6 +257,8 @@ function ElementCreation({
                   ? ({
                       ...dataPracticeQuiz.getSinglePracticeQuiz,
                       name: `${dataPracticeQuiz.getSinglePracticeQuiz.name} (Copy)`,
+                      // do not link previous course during duplication -> might not be available to user / not running anymore
+                      course: { id: '' },
                     } as PracticeQuiz)
                   : (dataPracticeQuiz.getSinglePracticeQuiz as PracticeQuiz)
                 : initialDataPracticeQuiz

--- a/apps/frontend-manage/src/components/activities/actions/usePracticeQuizActions.ts
+++ b/apps/frontend-manage/src/components/activities/actions/usePracticeQuizActions.ts
@@ -176,12 +176,15 @@ function usePracticeQuizActions({
     ],
     [
       t,
-      router,
       practiceQuiz,
+      href,
+      evaluationHref,
+      router,
       setPublishModal,
-      setDeletionModal,
-      setSharingModal,
       setCopyToast,
+      setSharingModal,
+      unpublishPracticeQuiz,
+      setDeletionModal,
     ]
   )
 

--- a/apps/frontend-manage/src/components/sharing/ExistingPermissionEntries.tsx
+++ b/apps/frontend-manage/src/components/sharing/ExistingPermissionEntries.tsx
@@ -168,6 +168,7 @@ function ExistingPermissionEntries({
                 }}
                 className={{
                   trigger: 'h-7 text-sm text-gray-900',
+                  item: 'text-sm',
                 }}
                 data={{
                   cy: permission.username

--- a/packages/graphql/src/services/groups.ts
+++ b/packages/graphql/src/services/groups.ts
@@ -1033,7 +1033,6 @@ export async function manipulateGroupActivity(
         },
       },
     },
-    owner: { connect: { id: ctx.user.sub } },
     course: { connect: { id: courseId } },
   }
 
@@ -1073,7 +1072,10 @@ export async function manipulateGroupActivity(
 
     const upsertedActivity = await prisma.groupActivity.upsert({
       where: { id: id ?? newId },
-      create: createOrUpdateJSON,
+      create: {
+        ...createOrUpdateJSON,
+        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+      },
       update: createOrUpdateJSON,
     })
 

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -416,7 +416,6 @@ export async function splitActivityInstances(
   const persistentInstances = await ctx.prisma.elementInstance.findMany({
     where: {
       id: { in: persistentInstanceIds },
-      owner: { id: ctx.user.sub },
     },
   })
 
@@ -435,7 +434,18 @@ export async function splitActivityInstances(
   const duplicationInstances = await ctx.prisma.elementInstance.findMany({
     where: {
       id: { in: duplicateInstanceIds },
-      owner: { id: ctx.user.sub },
+      // for duplication of an activity, ADMIN permissions on the activity are required -> propagates to element
+      // verify that user has at least ADMIN permissions on the element linked to this instance
+      element: {
+        permissions: {
+          some: {
+            userId: ctx.user.sub,
+            permissionLevel: {
+              in: [PermissionLevel.ADMIN, PermissionLevel.OWNER],
+            },
+          },
+        },
+      },
     },
   })
 
@@ -600,7 +610,6 @@ export async function manipulateLiveQuiz(
         },
       })),
     },
-    owner: { connect: { id: ctx.user.sub } },
   }
 
   const activity = await ctx.prisma.$transaction(async (prisma) => {
@@ -641,6 +650,7 @@ export async function manipulateLiveQuiz(
       create: {
         ...createOrUpdateJSON,
         course: courseId !== null ? { connect: { id: courseId } } : undefined,
+        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
       },
       update: {
         ...createOrUpdateJSON,

--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -273,7 +273,6 @@ export async function manipulateMicroLearning(
         }
       }),
     },
-
     course: { connect: { id: courseId } },
   }
 

--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -273,12 +273,8 @@ export async function manipulateMicroLearning(
         }
       }),
     },
-    owner: {
-      connect: { id: ctx.user.sub },
-    },
-    course: {
-      connect: { id: courseId },
-    },
+
+    course: { connect: { id: courseId } },
   }
 
   const activity = await ctx.prisma.$transaction(async (prisma) => {
@@ -320,7 +316,10 @@ export async function manipulateMicroLearning(
 
     const upsertedMicrolearning = await prisma.microLearning.upsert({
       where: { id: id ?? uuidv4() },
-      create: createOrUpdateJSON,
+      create: {
+        ...createOrUpdateJSON,
+        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+      },
       update: createOrUpdateJSON,
       include: {
         course: true,

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -289,7 +289,6 @@ export async function manipulatePracticeQuiz(
         },
       })),
     },
-    owner: { connect: { id: ctx.user.sub } },
     course: { connect: { id: courseId } },
   }
 
@@ -327,7 +326,10 @@ export async function manipulatePracticeQuiz(
 
     const upsertedQuiz = await prisma.practiceQuiz.upsert({
       where: { id: id ?? uuidv4() },
-      create: createOrUpdateJSON,
+      create: {
+        ...createOrUpdateJSON,
+        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+      },
       update: createOrUpdateJSON,
       include: {
         course: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the appearance of the permission level selector dropdown by reducing the text size.

- **Bug Fixes**
  - Adjusted ownership assignment for group activities, live quizzes, microlearnings, and practice quizzes so that the owner is only set during creation, not during updates.
  - Updated permission checks for duplicating element instances to require appropriate user permissions instead of relying solely on ownership.

- **New Features**
  - When duplicating LiveQuiz, MicroLearning, and PracticeQuiz activities, the duplicated item is no longer linked to the original course, preventing unintended associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->