### PR TITLE
enhance(apps/frontend-manage): store filters and sorting states from library in local storage

### DIFF
--- a/apps/frontend-manage/src/components/questions/tags/SuspendedTags.tsx
+++ b/apps/frontend-manage/src/components/questions/tags/SuspendedTags.tsx
@@ -5,7 +5,9 @@ import {
   Tag,
   UpdateTagOrderingDocument,
 } from '@klicker-uzh/graphql/dist/ops'
-import useSortingAndFiltering from '@lib/hooks/useSortingAndFiltering'
+import useSortingAndFiltering, {
+  SORTING_FILTERING_INITIAL,
+} from '@lib/hooks/useSortingAndFiltering'
 import { TextField, UserNotification } from '@uzh-bf/design-system'
 import * as JsSearch from 'js-search'
 import { useTranslations } from 'next-intl'
@@ -40,7 +42,7 @@ function SuspendedTags({ showUntagged, activeTags, handleTagClick }: Props) {
     refetchQueries: [{ query: GetUserTagsDocument }],
   })
 
-  const { handleSearch } = useSortingAndFiltering()
+  const { handleSearch } = useSortingAndFiltering(SORTING_FILTERING_INITIAL)
 
   const filteredTags = useMemo(() => {
     if (data?.userTags) {

--- a/apps/frontend-manage/src/components/questions/tags/TagList.tsx
+++ b/apps/frontend-manage/src/components/questions/tags/TagList.tsx
@@ -35,6 +35,7 @@ import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { Button, Switch } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import React, { Suspense, useMemo, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
 import SuspendedTags from './SuspendedTags'
 import TagHeader from './TagHeader'
 import TagItem from './TagItem'
@@ -136,6 +137,7 @@ function TagList({
         activeSharingTypes?.length !== 2 ||
         !activeSharingTypes.includes(SharingType.Owned) ||
         !activeSharingTypes.includes(SharingType.Shared) ||
+        !activeSharingTypes.includes(SharingType.Dependency) ||
         sampleSolution ||
         answerFeedbacks ||
         showUntagged
@@ -295,7 +297,9 @@ function TagList({
       </div>
 
       <Button
-        className={{ root: 'mt-2 h-8 text-sm' }}
+        className={{
+          root: twMerge('mt-2 h-8 text-sm', !resetDisabled && 'border-red-600'),
+        }}
         disabled={resetDisabled}
         onClick={(): void => handleReset()}
         data={{ cy: 'reset-question-pool-filters' }}

--- a/apps/frontend-manage/src/lib/hooks/useSortingAndFiltering.ts
+++ b/apps/frontend-manage/src/lib/hooks/useSortingAndFiltering.ts
@@ -64,7 +64,11 @@ export const SORTING_FILTERING_INITIAL: FilterSortType = {
   filters: {
     status: undefined,
     type: undefined,
-    sharingType: [SharingType.Owned, SharingType.Shared],
+    sharingType: [
+      SharingType.Owned,
+      SharingType.Shared,
+      SharingType.Dependency,
+    ],
     archive: false,
     untagged: false,
     tags: [],

--- a/apps/frontend-manage/src/lib/hooks/useSortingAndFiltering.ts
+++ b/apps/frontend-manage/src/lib/hooks/useSortingAndFiltering.ts
@@ -60,7 +60,7 @@ type ReducerAction = {
   by?: SortyByType
 }
 
-const INITIAL_STATE: FilterSortType = {
+export const SORTING_FILTERING_INITIAL: FilterSortType = {
   filters: {
     status: undefined,
     type: undefined,
@@ -226,15 +226,15 @@ function reducer(state: FilterSortType, action: ReducerAction): FilterSortType {
       }
 
     case QuestionPoolReducerActionType.RESET:
-      return { ...state, filters: INITIAL_STATE.filters }
+      return { ...state, filters: SORTING_FILTERING_INITIAL.filters }
 
     default:
       return state
   }
 }
 
-function useSortingAndFiltering() {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+function useSortingAndFiltering(initialValue: FilterSortType) {
+  const [state, dispatch] = useReducer(reducer, initialValue)
 
   return {
     ...state,

--- a/apps/frontend-manage/src/pages/activities.tsx
+++ b/apps/frontend-manage/src/pages/activities.tsx
@@ -21,7 +21,11 @@ function Activities() {
   const [searchInput, setSearchInput] = useState('')
   const [filters, setFilters] = useState<ActivityOverviewFilterType>({
     status: [],
-    sharingType: [SharingType.Owned, SharingType.Shared],
+    sharingType: [
+      SharingType.Owned,
+      SharingType.Shared,
+      SharingType.Dependency,
+    ],
     type: undefined,
   })
   const { loading: loadingActivities, data: dataActivities } = useQuery(

--- a/apps/frontend-manage/src/pages/index.tsx
+++ b/apps/frontend-manage/src/pages/index.tsx
@@ -40,6 +40,7 @@ import RecoveryPrompt from '../components/questions/manipulation/RecoveryPrompt'
 import TagList from '../components/questions/tags/TagList'
 import SuspendedFirstLoginModal from '../components/user/SuspendedFirstLoginModal'
 import useSortingAndFiltering, {
+  SORTING_FILTERING_INITIAL,
   SortyByType,
 } from '../lib/hooks/useSortingAndFiltering'
 
@@ -80,6 +81,22 @@ function Index() {
     data: dataQuestions,
   } = useQuery(GetUserElementsDocument)
 
+  // initialize the sorting and filtering state from local storage (if available)
+  const [storedFiltering, _] = useState(() => {
+    // only try to access localStorage if we're on the client
+    if (typeof window !== 'undefined') {
+      try {
+        const savedFilters = localStorage.getItem('library-sorting-filters')
+        if (savedFilters) {
+          return JSON.parse(savedFilters)
+        }
+      } catch (error) {
+        console.error('Error loading stored filters from localStorage', error)
+      }
+    }
+    return SORTING_FILTERING_INITIAL
+  })
+
   const {
     filters,
     sort,
@@ -91,8 +108,28 @@ function Index() {
     handleToggleArchive,
     toggleSampleSolutionFilter,
     toggleAnswerFeedbackFilter,
-  } = useSortingAndFiltering()
+  } = useSortingAndFiltering(storedFiltering)
 
+  // if the filters or sorting state changes, save it to local storage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const newState = { filters, sort }
+        // only save if there are actual changes
+        const currentStored = localStorage.getItem('library-sorting-filters')
+        if (!currentStored || JSON.stringify(newState) !== currentStored) {
+          localStorage.setItem(
+            'library-sorting-filters',
+            JSON.stringify(newState)
+          )
+        }
+      } catch (error) {
+        console.error('Error saving filters to localStorage', error)
+      }
+    }
+  }, [filters, sort])
+
+  // on initial render, preload the pages that might be visited next
   useEffect((): void => {
     router.prefetch('/quizzes/running')
     router.prefetch('/quizzes')

--- a/cypress/cypress/e2e/N-course-workflow.cy.ts
+++ b/cypress/cypress/e2e/N-course-workflow.cy.ts
@@ -784,7 +784,6 @@ describe('Test course creation and editing functionalities', function () {
   // #region
   function verifyCourseReadPermissions({ data }: { data: any }) {
     // check that the elements used in the activities are not visible to the user
-    cy.get('[data-cy="element-sharing-filter-DEPENDENCY"]').click()
     cy.wrap([
       data.SCML.title,
       data.NRML.title,
@@ -803,7 +802,6 @@ describe('Test course creation and editing functionalities', function () {
 
     // verify that all activities are shown on the activity overview
     cy.get('[data-cy="activities"]').click()
-    cy.get('[data-cy="sharing-filter-DEPENDENCY"]').click()
     cy.get(`[data-cy="activity-LIVE_QUIZ-${data.sharing.liveQuiz}"]`).should(
       'exist'
     )
@@ -875,7 +873,6 @@ describe('Test course creation and editing functionalities', function () {
 
   function verifyCourseExecutePermissions({ data }: { data: any }) {
     // check that the elements used in the activities are not visible to the user
-    cy.get('[data-cy="element-sharing-filter-DEPENDENCY"]').click()
     cy.wrap([
       data.SCML.title,
       data.NRML.title,
@@ -894,7 +891,6 @@ describe('Test course creation and editing functionalities', function () {
 
     // verify that all activities are shown on the activity overview
     cy.get('[data-cy="activities"]').click()
-    cy.get('[data-cy="sharing-filter-DEPENDENCY"]').click()
     cy.get(`[data-cy="activity-LIVE_QUIZ-${data.sharing.liveQuiz}"]`).should(
       'exist'
     )
@@ -972,7 +968,6 @@ describe('Test course creation and editing functionalities', function () {
     propagation: boolean
   }) {
     // check that the elements used in the activities are not visible to the user
-    cy.get('[data-cy="element-sharing-filter-DEPENDENCY"]').click()
     cy.wrap([
       data.SCML.title,
       data.NRML.title,
@@ -991,7 +986,6 @@ describe('Test course creation and editing functionalities', function () {
 
     // verify that all activities are shown on the activity overview
     cy.get('[data-cy="activities"]').click()
-    cy.get('[data-cy="sharing-filter-DEPENDENCY"]').click()
     cy.get(`[data-cy="activity-LIVE_QUIZ-${data.sharing.liveQuiz}"]`).should(
       'exist'
     )
@@ -1101,7 +1095,6 @@ describe('Test course creation and editing functionalities', function () {
     checkBadge: boolean
   }) {
     // check that the elements used in the activities are not visible to the user
-    cy.get('[data-cy="element-sharing-filter-DEPENDENCY"]').click()
     cy.wrap([
       data.SCML.title,
       data.NRML.title,
@@ -1123,7 +1116,6 @@ describe('Test course creation and editing functionalities', function () {
 
     // verify that all activities are shown on the activity overview
     cy.get('[data-cy="activities"]').click()
-    cy.get('[data-cy="sharing-filter-DEPENDENCY"]').click()
     cy.get(`[data-cy="activity-LIVE_QUIZ-${data.sharing.liveQuiz}"]`).should(
       'exist'
     )

--- a/cypress/cypress/e2e/O-live-quiz-workflow.cy.ts
+++ b/cypress/cypress/e2e/O-live-quiz-workflow.cy.ts
@@ -2317,7 +2317,6 @@ describe('Different live-quiz workflows', function () {
     cy.loginInstitutionalCatalyst3()
 
     // elements should be shared for users with ADMIN permissions on activity
-    cy.get('[data-cy="element-sharing-filter-DEPENDENCY"]').click()
     cy.wrap([
       data.SCML.title,
       data.MCML.title,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sorting and filtering settings on the library page now persist between sessions using local storage.
  - The "Dependency" sharing type is now included in initial filters for activities and library views.

- **Improvements**
  - Reset button in tag lists now visually indicates when it is enabled.
  - Filtering and sorting logic has been updated for greater flexibility.

- **Tests**
  - End-to-end tests have been streamlined by removing unnecessary filter interactions related to "Dependency" sharing type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->