### PR TITLE
chore(cypress): add end-to-end testing for group activity sharing functionalities

### DIFF
--- a/apps/frontend-manage/src/components/activities/overview/ActivityListEntry.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityListEntry.tsx
@@ -111,6 +111,7 @@ function ActivityListEntry({
 
             {activity.status !== PublicationStatus.Template &&
               activity.status !== PublicationStatus.Ended &&
+              activity.status !== PublicationStatus.Graded &&
               activity.isEditor && (
                 <FontAwesomeIcon
                   icon={faPencil}

--- a/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
+++ b/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
@@ -2648,9 +2648,17 @@ describe('Create and solve a group activity', function () {
       this.data.sharing.ga1,
       this.data.sharing.ga2,
       this.data.sharing.ga3,
-      this.data.sharing.ga4,
-      this.data.sharing.ga5,
     ]).each((quiz) => {
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${quiz}"]`).realClick()
+      cy.get(`[data-cy="remove-group-activity-${quiz}"]`).click()
+      cy.get('[data-cy="confirm-deletion-final"]').click()
+      cy.get('[data-cy="confirm-derived-access"]').click()
+      cy.get('[data-cy="confirm-dependency-access"]').click()
+      cy.get('[data-cy="confirmation-modal-confirm"]').click()
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+      cy.get('[data-cy="confirmation-modal-close"]').should('not.exist')
+    })
+    cy.wrap([this.data.sharing.ga4, this.data.sharing.ga5]).each((quiz) => {
       cy.get(`[data-cy="remove-group-activity-${quiz}"]`).click()
       cy.get('[data-cy="confirm-deletion-final"]').click()
       cy.get('[data-cy="confirm-derived-access"]').click()

--- a/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
+++ b/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
@@ -2006,21 +2006,21 @@ describe('Create and solve a group activity', function () {
     )
 
     if (!groupPermission) {
-      cy.get(`[data-cy="remove-group-activity-${data.sharing.ga4}"]`).should(
+      cy.get(`[data-cy="remove-group-activity-${data.sharing.ga5}"]`).should(
         'exist'
       )
       cy.get(
-        `[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`
+        `[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga5}"]`
       ).realClick()
-      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga5}"]`).should(
         'exist'
       )
-      cy.get(`[data-cy="activity-name-${data.sharing.ga4}"]`).realClick() // close dropdown
+      cy.get(`[data-cy="activity-name-${data.sharing.ga5}"]`).realClick() // close dropdown
     } else {
-      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga5}"]`).should(
         'exist'
       )
-      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`).should(
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga5}"]`).should(
         'not.exist'
       )
     }

--- a/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
+++ b/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
@@ -24,8 +24,8 @@ describe('Create and solve a group activity', function () {
     cy.fixture('questions.json').then((questionData) => {
       this.data = questionData
     })
-    cy.fixture('S-group-activity.json').then((liveQuizData) => {
-      this.data = { ...this.data, ...liveQuizData }
+    cy.fixture('S-group-activity.json').then((groupActivityData) => {
+      this.data = { ...this.data, ...groupActivityData }
     })
   })
 
@@ -1436,18 +1436,6 @@ describe('Create and solve a group activity', function () {
       cy.visit(Cypress.env('URL_MANAGE'))
     })
   })
-
-  it('Cleanup: Delete all created elements and the created answer collection', function () {
-    cy.loginLecturer()
-
-    cy.deleteAllElements()
-    cy.get('[data-cy="analytics"]').should('exist')
-    cy.get('[data-cy="resources"]').click()
-    cy.get('[data-cy="answer-collections"]').click()
-    cy.deleteAnswerCollection({
-      collectionName: this.data.collection.name,
-    })
-  })
   // #endregion
 
   // ! Part 6: Miscellaneous
@@ -1494,6 +1482,1202 @@ describe('Create and solve a group activity', function () {
       'contain',
       this.data.group.message2
     )
+  })
+  // #endregion
+
+  // ! Part 7: Group Activity Sharing
+  // #region
+  function verifyGroupActivityDetailsModalContent(
+    activityName: string,
+    data: any
+  ) {
+    cy.get(`[data-cy="activity-name-${activityName}"]`).click()
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.SCML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.MCML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.KPML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.NRML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.FTML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.SEML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.CSML.title.substring(0, 20)
+    )
+    cy.get('[data-cy="activity-details-modal"]').contains(
+      data.CT.title.substring(0, 20)
+    )
+    cy.get('[data-cy="close-activity-details-modal"]').click()
+  }
+
+  function verifyGroupActivityOwnerPermissions(data: any) {
+    // for a draft group activity the following options should be available: publish, edit, share, delete
+    cy.get(`[data-cy="publish-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="edit-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga1}"]`).realClick()
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="activity-name-${data.sharing.ga1}"]`).realClick() // close dropdown
+    verifyGroupActivityDetailsModalContent(data.sharing.ga1, data)
+
+    // for a scheduled group activity the following options should be available: start, share, unpublish, delete
+    cy.get(`[data-cy="start-group-activity-${data.sharing.ga2}-now"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="unpublish-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga2}"]`).realClick()
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="activity-name-${data.sharing.ga2}"]`).realClick() // close dropdown
+    verifyGroupActivityDetailsModalContent(data.sharing.ga2, data)
+
+    // for a running group activity the following options should be available: extend, end, share, delete
+    cy.get(`[data-cy="extend-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="end-group-activity-${data.sharing.ga3}"]`).should('exist')
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga3}"]`).realClick()
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="activity-name-${data.sharing.ga3}"]`).realClick() // close dropdown
+    verifyGroupActivityDetailsModalContent(data.sharing.ga3, data)
+
+    // for a completed group activity the following options should be available: grade, share, delete
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`).should(
+      'not.exist'
+    )
+
+    verifyGroupActivityDetailsModalContent(data.sharing.ga4, data)
+
+    // for a graded group activity the following options should be available: grade, share, delete
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga5}"]`).should(
+      'not.exist'
+    )
+
+    verifyGroupActivityDetailsModalContent(data.sharing.ga5, data)
+  }
+
+  function verifyGroupActivityREADPermissions(
+    data: any,
+    groupPermission: boolean
+  ) {
+    cy.loginIndividualCatalyst()
+
+    // elements should not be shared for users with READ permissions on activity
+    cy.wrap([
+      data.SCML.title,
+      data.MCML.title,
+      data.KPML.title,
+      data.NRML.title,
+      data.FTML.title,
+      data.SEML.title,
+      data.CSML.title,
+      data.CT.title,
+    ]).each((title) => {
+      cy.get(`[data-cy="element-item-${title}"]`).should('not.exist')
+    })
+
+    // open the activity overview and check the actions on all shared activities
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('exist')
+      cy.get(`[data-cy="change-activity-name-${quiz}"]`).should('not.exist')
+    })
+
+    // for a any group activity the following options should be available: remove
+    cy.wrap([
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]).each((quiz: string) => {
+      cy.get(`[data-cy="remove-group-activity-${quiz}"]`).should(
+        groupPermission ? 'not.exist' : 'exist'
+      )
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+      verifyGroupActivityDetailsModalContent(quiz, data)
+    })
+  }
+
+  function verifyGroupActivityEXECUTEPermissions(
+    data: any,
+    groupPermission: boolean
+  ) {
+    cy.loginInstitutionalCatalyst()
+
+    // elements should not be shared for users with EXECUTE permissions on activity
+    cy.wrap([
+      data.SCML.title,
+      data.MCML.title,
+      data.KPML.title,
+      data.NRML.title,
+      data.FTML.title,
+      data.SEML.title,
+      data.CSML.title,
+      data.CT.title,
+    ]).each((title) => {
+      cy.get(`[data-cy="element-item-${title}"]`).should('not.exist')
+    })
+
+    // open the activity overview and check the actions on all shared activities
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('exist')
+      cy.get(`[data-cy="change-activity-name-${quiz}"]`).should('not.exist')
+    })
+
+    // for a draft group activity the following options should be available: publish, remove
+    cy.get(`[data-cy="publish-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga1}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga1}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga1, data)
+
+    // for a scheduled group activity the following options should be available: start, unpublish, remove
+    cy.get(`[data-cy="start-group-activity-${data.sharing.ga2}-now"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="unpublish-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga2}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga2}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga2, data)
+
+    // for a running group activity the following options should be available: extend, end, remove
+    cy.get(`[data-cy="extend-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="end-group-activity-${data.sharing.ga3}"]`).should('exist')
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga3}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga3}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga3, data)
+
+    // for a completed group activity the following options should be available: grade, remove
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga4}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga4, data)
+
+    // for a graded group activity the following options should be available: grade, remove
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga5}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga5}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga5, data)
+  }
+
+  function verifyGroupActivityWRITEPermissions(
+    data: any,
+    groupPermission: boolean
+  ) {
+    cy.loginInstitutionalCatalyst2()
+
+    // elements should not be shared for users with WRITE permissions on activity
+    cy.wrap([
+      data.SCML.title,
+      data.MCML.title,
+      data.KPML.title,
+      data.NRML.title,
+      data.FTML.title,
+      data.SEML.title,
+      data.CSML.title,
+      data.CT.title,
+    ]).each((title) => {
+      cy.get(`[data-cy="element-item-${title}"]`).should('not.exist')
+    })
+
+    // open the activity overview and check the actions on all shared activities
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([data.sharing.ga1, data.sharing.ga2, data.sharing.ga3]).each(
+      (quiz) => {
+        cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('exist')
+        cy.get(`[data-cy="change-activity-name-${quiz}"]`).should('exist')
+      }
+    )
+
+    // name change action not available for eneded or graded activities
+    cy.wrap([data.sharing.ga4, data.sharing.ga5]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('exist')
+      cy.get(`[data-cy="change-activity-name-${quiz}"]`).should('not.exist')
+    })
+
+    // for a draft group activity the following options should be available: publish, edit, remove
+    cy.get(`[data-cy="publish-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="edit-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga1}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga1}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga1, data)
+
+    // for a scheduled group activity the following options should be available: start, unpublish, remove
+    cy.get(`[data-cy="start-group-activity-${data.sharing.ga2}-now"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="unpublish-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga2}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga2}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga2, data)
+
+    // for a running group activity the following options should be available: extend, end, remove
+    cy.get(`[data-cy="extend-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="end-group-activity-${data.sharing.ga3}"]`).should('exist')
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga3}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga3}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga3, data)
+
+    // for a completed group activity the following options should be available: grade, remove
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga4}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga4, data)
+
+    // for a graded group activity the following options should be available: grade, remove
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga5}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga5}"]`).should(
+      'not.exist'
+    )
+    verifyGroupActivityDetailsModalContent(data.sharing.ga5, data)
+  }
+
+  function verifyGroupActivityADMINPermissions(
+    data: any,
+    groupPermission: boolean
+  ) {
+    cy.loginInstitutionalCatalyst3()
+
+    // elements should be shared for users with ADMIN permissions on activity
+    cy.wrap([
+      data.SCML.title,
+      data.MCML.title,
+      data.KPML.title,
+      data.NRML.title,
+      data.FTML.title,
+      data.SEML.title,
+      data.CSML.title,
+      data.CT.title,
+    ]).each((title) => {
+      cy.get(`[data-cy="element-item-${title}"]`).should('exist')
+    })
+
+    // open the activity overview and check the actions on all shared activities
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([data.sharing.ga1, data.sharing.ga2, data.sharing.ga3]).each(
+      (quiz) => {
+        cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('exist')
+        cy.get(`[data-cy="change-activity-name-${quiz}"]`).should('exist')
+      }
+    )
+
+    // name change action not available for eneded or graded activities
+    cy.wrap([data.sharing.ga4, data.sharing.ga5]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('exist')
+      cy.get(`[data-cy="change-activity-name-${quiz}"]`).should('not.exist')
+    })
+
+    // for a draft group activity the following options should be available: publish, edit, share, remove, delete
+    cy.get(`[data-cy="publish-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="edit-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga1}"]`).realClick()
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga1}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga1}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="activity-name-${data.sharing.ga1}"]`).realClick() // close dropdown
+    verifyGroupActivityDetailsModalContent(data.sharing.ga1, data)
+
+    // for a scheduled group activity the following options should be available: start, share, unpublish, remove, delete
+    cy.get(`[data-cy="start-group-activity-${data.sharing.ga2}-now"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="unpublish-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga2}"]`).realClick()
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga2}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga2}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="activity-name-${data.sharing.ga2}"]`).realClick() // close dropdown
+    verifyGroupActivityDetailsModalContent(data.sharing.ga2, data)
+
+    // for a running group activity the following options should be available: extend, end, share, remove, delete
+    cy.get(`[data-cy="extend-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="end-group-activity-${data.sharing.ga3}"]`).should('exist')
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga3}"]`).realClick()
+    cy.get(`[data-cy="remove-group-activity-${data.sharing.ga3}"]`).should(
+      groupPermission ? 'not.exist' : 'exist'
+    )
+    cy.get(`[data-cy="delete-group-activity-${data.sharing.ga3}"]`).should(
+      'exist'
+    )
+
+    cy.get(`[data-cy="activity-name-${data.sharing.ga3}"]`).realClick() // close dropdown
+    verifyGroupActivityDetailsModalContent(data.sharing.ga3, data)
+
+    // for a completed group activity the following options should be available: grade, share, remove, delete
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga4}"]`).should(
+      'exist'
+    )
+
+    if (!groupPermission) {
+      cy.get(`[data-cy="remove-group-activity-${data.sharing.ga4}"]`).should(
+        'exist'
+      )
+      cy.get(
+        `[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`
+      ).realClick()
+      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+        'exist'
+      )
+      cy.get(`[data-cy="activity-name-${data.sharing.ga4}"]`).realClick() // close dropdown
+    } else {
+      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+        'exist'
+      )
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`).should(
+        'not.exist'
+      )
+    }
+
+    verifyGroupActivityDetailsModalContent(data.sharing.ga4, data)
+
+    // for a graded group activity the following options should be available: grade, share, remove, delete
+    cy.get(`[data-cy="grade-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+    cy.get(`[data-cy="share-group-activity-${data.sharing.ga5}"]`).should(
+      'exist'
+    )
+
+    if (!groupPermission) {
+      cy.get(`[data-cy="remove-group-activity-${data.sharing.ga4}"]`).should(
+        'exist'
+      )
+      cy.get(
+        `[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`
+      ).realClick()
+      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+        'exist'
+      )
+      cy.get(`[data-cy="activity-name-${data.sharing.ga4}"]`).realClick() // close dropdown
+    } else {
+      cy.get(`[data-cy="delete-group-activity-${data.sharing.ga4}"]`).should(
+        'exist'
+      )
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${data.sharing.ga4}"]`).should(
+        'not.exist'
+      )
+    }
+
+    verifyGroupActivityDetailsModalContent(data.sharing.ga5, data)
+  }
+
+  function verifyREADPermissionsRevoked(data: any) {
+    cy.loginIndividualCatalyst()
+    cy.get('[data-cy="activities"]').click()
+
+    // previously shared group activities should no longer be visible
+    cy.wrap([
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+    })
+  }
+
+  function verifyEXECUTEPermissionsRevoked(data: any) {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="activities"]').click()
+
+    // previously shared group activities should no longer be visible
+    cy.wrap([
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+    })
+  }
+
+  function verifyWRITEPermissionsRevoked(data: any) {
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="activities"]').click()
+
+    // previously shared group activities should no longer be visible
+    cy.wrap([
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+    })
+  }
+
+  function verifyADMINPermissionsRevoked(data: any) {
+    cy.loginInstitutionalCatalyst3()
+
+    // previously indirectly shared elements should no longer be visible
+    cy.wrap([
+      data.SCML.title,
+      data.MCML.title,
+      data.KPML.title,
+      data.NRML.title,
+      data.FTML.title,
+      data.SEML.title,
+      data.CSML.title,
+      data.CT.title,
+    ]).each((element) => {
+      cy.get(`[data-cy="element-item-${element}"]`).should('not.exist')
+    })
+
+    // previously shared group activities should no longer be visible
+    cy.get('[data-cy="activities"]').click()
+    const quizzes = [
+      data.sharing.ga1,
+      data.sharing.ga2,
+      data.sharing.ga3,
+      data.sharing.ga4,
+      data.sharing.ga5,
+    ]
+    cy.wrap(quizzes).each((quiz) => {
+      cy.get(`[data-cy="activity-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+    })
+  }
+
+  it('Create five different group activities and make sure that all required actions are shown to the object owner', function () {
+    cy.loginLecturer()
+
+    // create five different group activities
+    for (let i = 1; i <= 5; i++) {
+      cy.createGroupActivity({
+        name: this.data.sharing[`ga${i}`],
+        displayName: this.data.sharing[`ga${i}Display`],
+        courseName: this.data.seededCourse,
+        scheduledStartDate: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .slice(0, 16),
+        scheduledEndDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .slice(0, 16),
+        task: 'TASK',
+        clues: [
+          {
+            type: 'text',
+            name: 'Clue 1',
+            displayName: 'First Hint',
+            content: 'Lorem ipsum dolor sit amet',
+          },
+          {
+            type: 'text',
+            name: 'Clue 2',
+            displayName: 'Second Hint',
+            content: 'Consectetur adipiscing elit',
+          },
+        ],
+        stack: {
+          elements: [
+            this.data.SCML.title,
+            this.data.MCML.title,
+            this.data.KPML.title,
+            this.data.NRML.title,
+            this.data.FTML.title,
+            this.data.SEML.title,
+            this.data.CSML.title,
+            this.data.CT.title,
+          ],
+        },
+      })
+      cy.get('[data-cy="create-new-activity"]').click()
+    }
+
+    // change the status of the second group activity to scheduled
+    cy.task('changeActivityStatus', {
+      activityName: this.data.sharing.ga2,
+      activityType: 'GROUP_ACTIVITY',
+      status: 'SCHEDULED',
+    }).then((result: boolean) => {
+      // check if the modification was successful
+      if (result === false) {
+        throw new Error(
+          'Group activity to change status was not found in the database'
+        )
+      }
+    })
+
+    // change the status of the third group activity to published
+    cy.task('changeActivityStatus', {
+      activityName: this.data.sharing.ga3,
+      activityType: 'GROUP_ACTIVITY',
+      status: 'PUBLISHED',
+    }).then((result: boolean) => {
+      // check if the modification was successful
+      if (result === false) {
+        throw new Error(
+          'Group activity to change status was not found in the database'
+        )
+      }
+    })
+
+    // change the status of the fourth group activity to ended
+    cy.task('changeActivityStatus', {
+      activityName: this.data.sharing.ga4,
+      activityType: 'GROUP_ACTIVITY',
+      status: 'ENDED',
+    }).then((result: boolean) => {
+      // check if the modification was successful
+      if (result === false) {
+        throw new Error(
+          'Group activity to change status was not found in the database'
+        )
+      }
+    })
+
+    // change the status of the fifth group activity to graded
+    cy.task('changeActivityStatus', {
+      activityName: this.data.sharing.ga5,
+      activityType: 'GROUP_ACTIVITY',
+      status: 'GRADED',
+    }).then((result: boolean) => {
+      // check if the modification was successful
+      if (result === false) {
+        throw new Error(
+          'Group activity to change status was not found in the database'
+        )
+      }
+    })
+    cy.reload()
+
+    // verify that the owner sees all the correct actions
+    cy.get('[data-cy="activities"]').click()
+    verifyGroupActivityOwnerPermissions(this.data)
+  })
+
+  it('Share the group activities individual with different users and different permissions', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+
+    // grant READ, EXECUTE, WRITE and ADMIN permissions on all group activities to the users 2, 3, 4 and 5, respectively
+    cy.wrap([
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+
+      // grant READ permission to user 2
+      cy.get('[data-cy="new-permission-username-or-email"]').type(
+        Cypress.env('LECTURER_IND_SHORTNAME')
+      )
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-READ"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsREAD
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsREAD)
+
+      // grant EXECUTE permission to user 3
+      cy.get('[data-cy="new-permission-username-or-email"]').type(
+        Cypress.env('LECTURER_INST_SHORTNAME')
+      )
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-EXECUTE"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsEXECUTE
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${Cypress.env('LECTURER_INST_SHORTNAME')}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsEXECUTE)
+
+      // grand WRITE permissions to user 4
+      cy.get('[data-cy="new-permission-username-or-email"]').type(
+        Cypress.env('LECTURER_INST2_SHORTNAME')
+      )
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-WRITE"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsWRITE
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_INST2_SHORTNAME')}"]`
+      )
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsWRITE)
+
+      // grant ADMIN permissions to user 5
+      cy.get('[data-cy="new-permission-username-or-email"]').type(
+        Cypress.env('LECTURER_INST3_SHORTNAME')
+      )
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-ADMIN"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsADMIN
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_INST3_SHORTNAME')}"]`
+      )
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsADMIN)
+
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
+  })
+
+  it('Log in as the user with READ permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityREADPermissions(this.data, false)
+  })
+
+  it('Log in as the user with EXECUTE permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityEXECUTEPermissions(this.data, false)
+  })
+
+  it('Log in as the user with WRITE permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityWRITEPermissions(this.data, false)
+  })
+
+  it('Log in as the user with ADMIN permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityADMINPermissions(this.data, false)
+  })
+
+  it('Revoke the direct individual permissions for all users through the activity owner account', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+
+    const quizzes = [
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]
+    const users = [
+      Cypress.env('LECTURER_IND_SHORTNAME'),
+      Cypress.env('LECTURER_INST_SHORTNAME'),
+      Cypress.env('LECTURER_INST2_SHORTNAME'),
+      Cypress.env('LECTURER_INST3_SHORTNAME'),
+    ]
+
+    cy.wrap(quizzes).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+
+      // revoke permissions for users 2, 3, 4 and 5
+      cy.wrap(users).each((user) => {
+        cy.get(`[data-cy="permission-${user}"]`).should('exist')
+        cy.get(`[data-cy="revoke-permission-${user}"]`).click()
+        cy.get('[data-cy="confirm-revocation"]').click()
+        cy.get(`[data-cy="permission-${user}"]`).should('not.exist')
+      })
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
+  })
+
+  it('Verify that user with previous READ permissions can no longer see / access the activity', function () {
+    verifyREADPermissionsRevoked(this.data)
+  })
+
+  it('Verify that user with previous EXECUTE permissions can no longer see / access the activity', function () {
+    verifyEXECUTEPermissionsRevoked(this.data)
+  })
+
+  it('Verify that user with previous WRITE permissions can no longer see / access the activity', function () {
+    verifyWRITEPermissionsRevoked(this.data)
+  })
+
+  it('Verify that user with previous ADMIN permissions can no longer see / access the activity', function () {
+    verifyADMINPermissionsRevoked(this.data)
+  })
+
+  it('Create user groups with users 2, 3, 4, and 5 as members, admins or owners and share the group activities with them', function () {
+    // create user groups with users 1 & 2 / 3 as member / admin
+    cy.loginLecturer()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.sharing.group1)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_IND_SHORTNAME')) // pro1 is added as admin
+    cy.get('[data-cy="member-admin-0"]').realClick()
+    cy.get('[data-cy="submit-create-user-group"]').click()
+    cy.get(`[data-cy="user-group-${this.data.sharing.group1}"]`).should('exist')
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.sharing.group2)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_INST_SHORTNAME')) // pro2 is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+    cy.get(`[data-cy="user-group-${this.data.sharing.group2}"]`).should('exist')
+
+    // create user group with users 1 and 4 with user 4 as owner
+    cy.loginInstitutionalCatalyst2()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.sharing.group3)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_EMAIL')) // lecturer is added as member
+    cy.get('[data-cy="submit-create-user-group"]').click()
+    cy.get(`[data-cy="user-group-${this.data.sharing.group3}"]`).should('exist')
+
+    // create user group with users 1 and 5 with user 5 as owner
+    cy.loginInstitutionalCatalyst3()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="user-groups"]').click()
+
+    cy.get('[data-cy="create-user-group"]').click()
+    cy.get('[data-cy="user-group-name"]').click().type(this.data.sharing.group4)
+    cy.get('[data-cy="member-shortname-email-0"]')
+      .click()
+      .type(Cypress.env('LECTURER_EMAIL')) // lecturer is added as admin
+    cy.get('[data-cy="member-admin-0"]').realClick()
+    cy.get('[data-cy="submit-create-user-group"]').click()
+    cy.get(`[data-cy="user-group-${this.data.sharing.group4}"]`).should('exist')
+    cy.logoutUser()
+
+    // share the group activities with the user groups with READ, EXECUTE, WRITE and ADMIN permissions
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+
+      // grant READ permission to user group 1
+      cy.get('[data-cy="new-permission-user-group"]').click()
+      cy.get(`[data-cy="user-group-${this.data.sharing.group1}"]`).click()
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-READ"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsREAD
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${this.data.sharing.group1}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsREAD)
+
+      // grant EXECUTE permission to user group 2
+      cy.get('[data-cy="new-permission-user-group"]').click()
+      cy.get(`[data-cy="user-group-${this.data.sharing.group2}"]`).click()
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-EXECUTE"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsEXECUTE
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${this.data.sharing.group2}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsEXECUTE)
+
+      // grand WRITE permissions to user group 3
+      cy.get('[data-cy="new-permission-user-group"]').click()
+      cy.get(`[data-cy="user-group-${this.data.sharing.group3}"]`).click()
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-WRITE"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsWRITE
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${this.data.sharing.group3}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsWRITE)
+
+      // grant ADMIN permissions to user group 4
+      cy.get('[data-cy="new-permission-user-group"]').click()
+      cy.get(`[data-cy="user-group-${this.data.sharing.group4}"]`).click()
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-ADMIN"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsADMIN
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${this.data.sharing.group4}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsADMIN)
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
+  })
+
+  it('Log in as the user with READ permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityREADPermissions(this.data, true)
+  })
+
+  it('Log in as the user with EXECUTE permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityEXECUTEPermissions(this.data, true)
+  })
+
+  it('Log in as the user with WRITE permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityWRITEPermissions(this.data, true)
+  })
+
+  it('Log in as the user with ADMIN permissions on all activities and check that the correct actions are available', function () {
+    verifyGroupActivityADMINPermissions(this.data, true)
+  })
+
+  it('Revoke the direct group permissions for all users through the activity owner account', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+
+    const quizzes = [
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]
+    const groups = [
+      this.data.sharing.group1,
+      this.data.sharing.group2,
+      this.data.sharing.group3,
+      this.data.sharing.group4,
+    ]
+
+    cy.wrap(quizzes).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+
+      // revoke permissions for all user groups
+      cy.wrap(groups).each((group) => {
+        cy.get(`[data-cy="permission-${group}"]`).should('exist')
+        cy.get(`[data-cy="revoke-permission-${group}"]`).click()
+        cy.get('[data-cy="confirm-revocation"]').click()
+        cy.get(`[data-cy="permission-${group}"]`).should('not.exist')
+      })
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
+  })
+
+  it('Verify that user with previous READ permissions can no longer see / access the activity', function () {
+    verifyREADPermissionsRevoked(this.data)
+  })
+
+  it('Verify that user with previous EXECUTE permissions can no longer see / access the activity', function () {
+    verifyEXECUTEPermissionsRevoked(this.data)
+  })
+
+  it('Verify that user with previous WRITE permissions can no longer see / access the activity', function () {
+    verifyWRITEPermissionsRevoked(this.data)
+  })
+
+  it('Verify that user with previous ADMIN permissions can no longer see / access the activity', function () {
+    verifyADMINPermissionsRevoked(this.data)
+  })
+
+  it("Transfer ownership of all group activities to user 'pro1' using the username", function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+
+    cy.wrap([
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+
+      // share the course with WRITE permissions with user pro1
+      cy.get('[data-cy="new-permission-username-or-email"]').type(
+        Cypress.env('LECTURER_IND_SHORTNAME')
+      )
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-WRITE"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsWRITE
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsWRITE)
+
+      // transfer ownership to user pro1
+      cy.get('[data-cy="transfer-ownership"]').click()
+      cy.get('[data-cy="new-owner-username-email-input"]').type(
+        Cypress.env('LECTURER_IND_SHORTNAME')
+      )
+      cy.get('[data-cy="confirm-ownership-transfer"]').click()
+
+      // verify that the correct permissions are displayed
+      cy.get('[data-cy="transfer-ownership"]').should('not.exist')
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
+      ).should('not.exist')
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_SHORTNAME')}"]`
+      ).contains(messages.manage.sharing.permissionsADMIN)
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
+  })
+
+  it("Verify that user 'pro1' is the new owner and transfer the ownership back to the main user", function () {
+    cy.loginIndividualCatalyst()
+
+    // verify that the new owner sees all the correct actions
+    cy.get('[data-cy="activities"]').click()
+    verifyGroupActivityOwnerPermissions(this.data)
+
+    // transfer the ownership of all quizzes back to the main user
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+
+      // grant a WRITE permission to the main user (should change the existing permission in this case)
+      cy.get('[data-cy="new-permission-username-or-email"]').type(
+        Cypress.env('LECTURER_SHORTNAME')
+      )
+      cy.get('[data-cy="new-permission-access-level"]').click()
+      cy.get('[data-cy="permission-level-WRITE"]').click()
+      cy.get('[data-cy="new-permission-access-level"]').contains(
+        messages.manage.sharing.permissionsWRITE
+      )
+      cy.get('[data-cy="new-permission-submit"]').click()
+      cy.get(`[data-cy="permission-${Cypress.env('LECTURER_SHORTNAME')}"]`)
+        .should('exist')
+        .contains(messages.manage.sharing.permissionsWRITE)
+
+      // transfer ownership back to the main user
+      cy.get('[data-cy="transfer-ownership"]').click()
+      cy.get('[data-cy="new-owner-username-email-input"]').type(
+        Cypress.env('LECTURER_SHORTNAME')
+      )
+      cy.get('[data-cy="confirm-ownership-transfer"]').click()
+
+      // verify that the correct permissions are displayed
+      cy.get('[data-cy="transfer-ownership"]').should('not.exist')
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_SHORTNAME')}"]`
+      ).should('not.exist')
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
+      ).contains(messages.manage.sharing.permissionsADMIN)
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
+  })
+
+  it("Remove the shared group activities from user 'pro1' using the removal functionality", function () {
+    cy.loginIndividualCatalyst()
+
+    // remove the shared group activities from user pro1
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${quiz}"]`).realClick()
+      cy.get(`[data-cy="remove-group-activity-${quiz}"]`).click()
+      cy.get('[data-cy="confirm-deletion-final"]').click()
+      cy.get('[data-cy="confirm-derived-access"]').click()
+      cy.get('[data-cy="confirm-dependency-access"]').click()
+      cy.get('[data-cy="confirmation-modal-confirm"]').click()
+      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${quiz}"]`).should('not.exist')
+      cy.get('[data-cy="confirmation-modal-close"]').should('not.exist')
+    })
+    cy.logoutUser()
+
+    // verify in the main user account that the corresponding permissions were removed
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+    cy.wrap([
+      this.data.sharing.ga1,
+      this.data.sharing.ga2,
+      this.data.sharing.ga3,
+      this.data.sharing.ga4,
+      this.data.sharing.ga5,
+    ]).each((quiz) => {
+      cy.get(`[data-cy="share-group-activity-${quiz}"]`).click()
+      cy.get(
+        `[data-cy="permission-${Cypress.env('LECTURER_IND_SHORTNAME')}"]`
+      ).should('not.exist')
+      cy.get(`[data-cy="close-share-object"]`).click()
+    })
   })
   // #endregion
 })

--- a/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
+++ b/cypress/cypress/e2e/S-group-activity-workflow.cy.ts
@@ -2651,7 +2651,6 @@ describe('Create and solve a group activity', function () {
       this.data.sharing.ga4,
       this.data.sharing.ga5,
     ]).each((quiz) => {
-      cy.get(`[data-cy="actions-GROUP_ACTIVITY-${quiz}"]`).realClick()
       cy.get(`[data-cy="remove-group-activity-${quiz}"]`).click()
       cy.get('[data-cy="confirm-deletion-final"]').click()
       cy.get('[data-cy="confirm-derived-access"]').click()

--- a/cypress/cypress/fixtures/S-group-activity.json
+++ b/cypress/cypress/fixtures/S-group-activity.json
@@ -105,5 +105,21 @@
         "content": "Content 3"
       }
     ]
+  },
+  "sharing": {
+    "ga1": "Sharing Group Activity 1",
+    "ga1Display": "Sharing Group Activity 1 (Display)",
+    "ga2": "Sharing Group Activity 2",
+    "ga2Display": "Sharing Group Activity 2 (Display)",
+    "ga3": "Sharing Group Activity 3",
+    "ga3Display": "Sharing Group Activity 3 (Display)",
+    "ga4": "Sharing Group Activity 4",
+    "ga4Display": "Sharing Group Activity 4 (Display)",
+    "ga5": "Sharing Group Activity 5",
+    "ga5Display": "Sharing Group Activity 5 (Display)",
+    "group1": "Group 1",
+    "group2": "Group 2",
+    "group3": "Group 3",
+    "group4": "Group 4"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The edit icon is no longer shown for activities with the "Graded" status, preventing editing of graded activities.

- **Tests**
  - Added comprehensive tests for group activity sharing, including permission management, ownership transfers, and access revocation for both users and groups.
  - Introduced new helper functions to verify permissions and modal content in group activity workflows.

- **Chores**
  - Expanded test fixture data to include sharing-related group activities and group labels for improved test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->