### PR TITLE
enhance: update permission module with optional propagation of permissions to element level

### DIFF
--- a/apps/frontend-manage/src/components/sharing/ObjectSharingModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/ObjectSharingModal.tsx
@@ -45,6 +45,14 @@ function ObjectSharingModal({
   const [removalFailure, setRemovalFailure] = useState(false)
   const [showDerivedPermissions, setShowDerivedPermissions] = useState(false)
 
+  // boolean to determine whether to show the propagation option on the permissions
+  const showPropagationSetting =
+    objectType === SharingObjectType.Course ||
+    objectType === SharingObjectType.LiveQuiz ||
+    objectType === SharingObjectType.PracticeQuiz ||
+    objectType === SharingObjectType.MicroLearning ||
+    objectType === SharingObjectType.GroupActivity
+
   // get all permissions that have already been granted for this object
   const { permissions, loading: permissionsLoading } = useObjectPermissions({
     objectId,
@@ -109,7 +117,7 @@ function ObjectSharingModal({
 
         <PropagatedPermissionsTable
           objectType={objectType}
-          showPropagationSetting={objectType === SharingObjectType.Course}
+          showPropagationSetting={showPropagationSetting}
         />
 
         <div className="mt-8">
@@ -119,7 +127,7 @@ function ObjectSharingModal({
             permissionsLoading={permissionsLoading}
             changeLoading={permissionChanging}
             isOwner={isOwner}
-            showPropagationSetting={objectType === SharingObjectType.Course}
+            showPropagationSetting={showPropagationSetting}
             onPermissionLevelChange={async ({
               permissionId,
               newPermissionLevel,

--- a/apps/frontend-manage/src/components/sharing/useObjectPropagatedPermissions.ts
+++ b/apps/frontend-manage/src/components/sharing/useObjectPropagatedPermissions.ts
@@ -30,10 +30,11 @@ function useObjectPropagatedPermissions({
       },
     ]
   } else if (
-    objectType === SharingObjectType.LiveQuiz ||
-    objectType === SharingObjectType.PracticeQuiz ||
-    objectType === SharingObjectType.MicroLearning ||
-    objectType === SharingObjectType.GroupActivity
+    propagation === false &&
+    (objectType === SharingObjectType.LiveQuiz ||
+      objectType === SharingObjectType.PracticeQuiz ||
+      objectType === SharingObjectType.MicroLearning ||
+      objectType === SharingObjectType.GroupActivity)
   ) {
     return [
       {
@@ -52,6 +53,35 @@ function useObjectPropagatedPermissions({
           undefined,
           undefined,
           undefined,
+          PermissionLevel.Read,
+          PermissionLevel.Read,
+        ],
+      },
+    ]
+  } else if (
+    propagation === true &&
+    (objectType === SharingObjectType.LiveQuiz ||
+      objectType === SharingObjectType.PracticeQuiz ||
+      objectType === SharingObjectType.MicroLearning ||
+      objectType === SharingObjectType.GroupActivity)
+  ) {
+    return [
+      {
+        object: t('shared.types.ELEMENT'),
+        permissions: [
+          PermissionLevel.Read,
+          PermissionLevel.Read,
+          PermissionLevel.Write,
+          PermissionLevel.Admin,
+          PermissionLevel.Admin,
+        ],
+      },
+      {
+        object: t('shared.types.ANSWER_COLLECTION'),
+        permissions: [
+          PermissionLevel.Read,
+          PermissionLevel.Read,
+          PermissionLevel.Read,
           PermissionLevel.Read,
           PermissionLevel.Read,
         ],

--- a/packages/graphql/test/activityPermissions.test.ts
+++ b/packages/graphql/test/activityPermissions.test.ts
@@ -2046,9 +2046,17 @@ describe('Unit tests covering the creation of derived permissions for activities
         propagation,
       },
     })
-    const activityWRITEPermissions = await prisma.permission.create({
+    const activityEXECUTEPermissions = await prisma.permission.create({
       data: {
         userId: userThree.id,
+        liveQuizId: activity.id,
+        permissionLevel: PermissionLevel.EXECUTE,
+        propagation,
+      },
+    })
+    const activityWRITEPermissions = await prisma.permission.create({
+      data: {
+        userId: userFour.id,
         liveQuizId: activity.id,
         permissionLevel: PermissionLevel.WRITE,
         propagation,
@@ -2056,17 +2064,9 @@ describe('Unit tests covering the creation of derived permissions for activities
     })
     const activityADMINPermissions = await prisma.permission.create({
       data: {
-        userId: userFour.id,
-        liveQuizId: activity.id,
-        permissionLevel: PermissionLevel.ADMIN,
-        propagation,
-      },
-    })
-    const activityEXECUTEPermissions = await prisma.permission.create({
-      data: {
         userId: userFive.id,
         liveQuizId: activity.id,
-        permissionLevel: PermissionLevel.EXECUTE,
+        permissionLevel: PermissionLevel.ADMIN,
         propagation,
       },
     })
@@ -2075,7 +2075,10 @@ describe('Unit tests covering the creation of derived permissions for activities
     await recomputeDerivedPermissions({ liveQuizId: activity.id }, prisma)
 
     // verify that the correct derived permission entries have been created on the activity (min. required = propagation enabled)
-    // user 2 (no access), user 3 (no access), user 4 (ADMIN - activity), user 5 (no access)
+    // user 2 (no access when min. required, READ access when propagation enabled),
+    // user 3 (no access when min. required, READ access when propagation enabled),
+    // user 4 (no access when min. required, WRITE access when propagation enabled),
+    // user 5 (ADMIN access - min. required = propagated)
     const derivedPermissionUserTwo = await prisma.derivedPermission.findUnique({
       where: {
         elementId_userId: {
@@ -2084,7 +2087,19 @@ describe('Unit tests covering the creation of derived permissions for activities
         },
       },
     })
-    expect(derivedPermissionUserTwo).toBeNull()
+
+    if (propagation) {
+      expect(derivedPermissionUserTwo).toBeTruthy()
+      expect(derivedPermissionUserTwo!.permissionLevel).toBe(
+        PermissionLevel.READ
+      )
+      expect(derivedPermissionUserTwo!.directPermissionId).toBe(
+        activityREADPermissions.id
+      )
+      expect(derivedPermissionUserTwo!.derived).toBeTruthy()
+    } else {
+      expect(derivedPermissionUserTwo).toBeNull()
+    }
 
     const derivedPermissionUserThree =
       await prisma.derivedPermission.findUnique({
@@ -2095,7 +2110,19 @@ describe('Unit tests covering the creation of derived permissions for activities
           },
         },
       })
-    expect(derivedPermissionUserThree).toBeNull()
+
+    if (propagation) {
+      expect(derivedPermissionUserThree).toBeTruthy()
+      expect(derivedPermissionUserThree!.permissionLevel).toBe(
+        PermissionLevel.READ
+      )
+      expect(derivedPermissionUserThree!.directPermissionId).toBe(
+        activityEXECUTEPermissions.id
+      )
+      expect(derivedPermissionUserThree!.derived).toBeTruthy()
+    } else {
+      expect(derivedPermissionUserThree).toBeNull()
+    }
 
     const derivedPermissionUserFour = await prisma.derivedPermission.findUnique(
       {
@@ -2107,14 +2134,19 @@ describe('Unit tests covering the creation of derived permissions for activities
         },
       }
     )
-    expect(derivedPermissionUserFour).toBeTruthy()
-    expect(derivedPermissionUserFour!.permissionLevel).toBe(
-      PermissionLevel.ADMIN
-    )
-    expect(derivedPermissionUserFour!.directPermissionId).toBe(
-      activityADMINPermissions.id
-    )
-    expect(derivedPermissionUserFour!.derived).toBeTruthy()
+
+    if (propagation) {
+      expect(derivedPermissionUserFour).toBeTruthy()
+      expect(derivedPermissionUserFour!.permissionLevel).toBe(
+        PermissionLevel.WRITE
+      )
+      expect(derivedPermissionUserFour!.directPermissionId).toBe(
+        activityWRITEPermissions.id
+      )
+      expect(derivedPermissionUserFour!.derived).toBeTruthy()
+    } else {
+      expect(derivedPermissionUserFour).toBeNull()
+    }
 
     const derivedPermissionUserFive = await prisma.derivedPermission.findUnique(
       {
@@ -2126,7 +2158,15 @@ describe('Unit tests covering the creation of derived permissions for activities
         },
       }
     )
-    expect(derivedPermissionUserFive).toBeNull()
+
+    expect(derivedPermissionUserFive).toBeTruthy()
+    expect(derivedPermissionUserFive!.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedPermissionUserFive!.directPermissionId).toBe(
+      activityADMINPermissions.id
+    )
+    expect(derivedPermissionUserFive!.derived).toBeTruthy()
   }
 
   it('LQ: Verify that minimum required permissions are correctly granted on elements for individual users', async () => {
@@ -2164,7 +2204,7 @@ describe('Unit tests covering the creation of derived permissions for activities
         name: 'User Group 4',
         ownerId: userOne.id,
         members: {
-          connect: [{ id: userThree.id }, { id: userFour.id }],
+          connect: [{ id: userFour.id }],
         },
       },
     })
@@ -2173,7 +2213,7 @@ describe('Unit tests covering the creation of derived permissions for activities
         name: 'User Group 5',
         ownerId: userOne.id,
         members: {
-          connect: [{ id: userFour.id }, { id: userFive.id }],
+          connect: [{ id: userFive.id }],
         },
       },
     })
@@ -2187,9 +2227,17 @@ describe('Unit tests covering the creation of derived permissions for activities
         propagation,
       },
     })
-    const activityWRITEPermissions = await prisma.permission.create({
+    const activityEXECUTEPermissions = await prisma.permission.create({
       data: {
         userGroupId: userGroup3.id,
+        liveQuizId: activity.id,
+        permissionLevel: PermissionLevel.EXECUTE,
+        propagation,
+      },
+    })
+    const activityWRITEPermissions = await prisma.permission.create({
+      data: {
+        userGroupId: userGroup4.id,
         liveQuizId: activity.id,
         permissionLevel: PermissionLevel.WRITE,
         propagation,
@@ -2197,17 +2245,9 @@ describe('Unit tests covering the creation of derived permissions for activities
     })
     const activityADMINPermissions = await prisma.permission.create({
       data: {
-        userGroupId: userGroup4.id,
-        liveQuizId: activity.id,
-        permissionLevel: PermissionLevel.ADMIN,
-        propagation,
-      },
-    })
-    const activityEXECUTEPermissions = await prisma.permission.create({
-      data: {
         userGroupId: userGroup5.id,
         liveQuizId: activity.id,
-        permissionLevel: PermissionLevel.EXECUTE,
+        permissionLevel: PermissionLevel.ADMIN,
         propagation,
       },
     })
@@ -2216,7 +2256,10 @@ describe('Unit tests covering the creation of derived permissions for activities
     await recomputeDerivedPermissions({ liveQuizId: activity.id }, prisma)
 
     // verify that the correct derived permission entries have been created on the activity (min. required = propagation enabled)
-    // user 2 (no access), user 3 (ADMIN - activity), user 4 (ADMIN - activity), user 5 (no access)
+    // user 2 (no access when min. required, READ access when propagation enabled),
+    // user 3 (no access when min. required, READ access when propagation enabled),
+    // user 4 (no access when min. required, WRITE access when propagation enabled),
+    // user 5 (ADMIN access - min. required = propagated)
     const derivedPermissionUserTwo = await prisma.derivedPermission.findUnique({
       where: {
         elementId_userId: {
@@ -2225,7 +2268,19 @@ describe('Unit tests covering the creation of derived permissions for activities
         },
       },
     })
-    expect(derivedPermissionUserTwo).toBeNull()
+
+    if (propagation) {
+      expect(derivedPermissionUserTwo).toBeTruthy()
+      expect(derivedPermissionUserTwo!.permissionLevel).toBe(
+        PermissionLevel.READ
+      )
+      expect(derivedPermissionUserTwo!.directPermissionId).toBe(
+        activityREADPermissions.id
+      )
+      expect(derivedPermissionUserTwo!.derived).toBeTruthy()
+    } else {
+      expect(derivedPermissionUserTwo).toBeNull()
+    }
 
     const derivedPermissionUserThree =
       await prisma.derivedPermission.findUnique({
@@ -2236,14 +2291,19 @@ describe('Unit tests covering the creation of derived permissions for activities
           },
         },
       })
-    expect(derivedPermissionUserThree).toBeTruthy()
-    expect(derivedPermissionUserThree!.permissionLevel).toBe(
-      PermissionLevel.ADMIN
-    )
-    expect(derivedPermissionUserThree!.directPermissionId).toBe(
-      activityADMINPermissions.id
-    )
-    expect(derivedPermissionUserThree!.derived).toBeTruthy()
+
+    if (propagation) {
+      expect(derivedPermissionUserThree).toBeTruthy()
+      expect(derivedPermissionUserThree!.permissionLevel).toBe(
+        PermissionLevel.READ
+      )
+      expect(derivedPermissionUserThree!.directPermissionId).toBe(
+        activityEXECUTEPermissions.id
+      )
+      expect(derivedPermissionUserThree!.derived).toBeTruthy()
+    } else {
+      expect(derivedPermissionUserThree).toBeNull()
+    }
 
     const derivedPermissionUserFour = await prisma.derivedPermission.findUnique(
       {
@@ -2255,14 +2315,19 @@ describe('Unit tests covering the creation of derived permissions for activities
         },
       }
     )
-    expect(derivedPermissionUserFour).toBeTruthy()
-    expect(derivedPermissionUserFour!.permissionLevel).toBe(
-      PermissionLevel.ADMIN
-    )
-    expect(derivedPermissionUserFour!.directPermissionId).toBe(
-      activityADMINPermissions.id
-    )
-    expect(derivedPermissionUserFour!.derived).toBeTruthy()
+
+    if (propagation) {
+      expect(derivedPermissionUserFour).toBeTruthy()
+      expect(derivedPermissionUserFour!.permissionLevel).toBe(
+        PermissionLevel.WRITE
+      )
+      expect(derivedPermissionUserFour!.directPermissionId).toBe(
+        activityWRITEPermissions.id
+      )
+      expect(derivedPermissionUserFour!.derived).toBeTruthy()
+    } else {
+      expect(derivedPermissionUserFour).toBeNull()
+    }
 
     const derivedPermissionUserFive = await prisma.derivedPermission.findUnique(
       {
@@ -2274,7 +2339,14 @@ describe('Unit tests covering the creation of derived permissions for activities
         },
       }
     )
-    expect(derivedPermissionUserFive).toBeNull()
+    expect(derivedPermissionUserFive).toBeTruthy()
+    expect(derivedPermissionUserFive!.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedPermissionUserFive!.directPermissionId).toBe(
+      activityADMINPermissions.id
+    )
+    expect(derivedPermissionUserFive!.derived).toBeTruthy()
   }
 
   it('LQ: Verify that minimum required permissions are correctly granted on elements for user groups', async () => {

--- a/packages/graphql/test/activitySharing.test.ts
+++ b/packages/graphql/test/activitySharing.test.ts
@@ -652,7 +652,7 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
 
   // ! Sharing Operations for Live Quizzes (incl. Templates)
   // #region
-  it('Test that live quizzes can be shared with individual users through the corresponding service function', async () => {
+  it('Test that live quizzes can be shared with individual users through the corresponding service function (without propagation)', async () => {
     const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC, SE } = await seedElements(userOneCtx, AC.id)
     const liveQuiz = await seedLiveQuiz(
@@ -871,6 +871,39 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     expect(adminElementPermissions!.derived).toBe(true)
 
     // verify that for the user with derived ADMIN permissions, corresponding permissions have also been created on the answer collection
+    const noReadAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(noReadAnswerCollectionPermission).toBeNull()
+
+    const noExecuteAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(noExecuteAnswerCollectionPermission).toBeNull()
+
+    const noWriteAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userFour.id,
+          },
+        },
+      })
+    expect(noWriteAnswerCollectionPermission).toBeNull()
+
     const adminAnswerCollectionPermission =
       await prisma.derivedPermission.findUnique({
         where: {
@@ -947,7 +980,7 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     )
   })
 
-  it('Test that live quizzes can be shared with groups through the corresponding service function', async () => {
+  it('Test that live quizzes can be shared with groups through the corresponding service function (without propagation)', async () => {
     const { AC1: AC } = await seedAnswerCollections(userOneCtx)
     const { SC, SE } = await seedElements(userOneCtx, AC.id)
     const liveQuiz = await seedLiveQuiz(
@@ -1275,6 +1308,783 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       directGroupAdminPermission!.id
     )
     expect(derivedACPermissionUserFive!.derived).toBe(true)
+
+    // verify that proper audit log entries were created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group1.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.READ} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user group ${group1.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group2.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.EXECUTE} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user group ${group2.id}.`
+    )
+
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group3.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user group ${group3.id}.`
+    )
+
+    const auditLogEntry4 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserGroupId: group4.id,
+      },
+    })
+    expect(auditLogEntry4).toBeTruthy()
+    expect(auditLogEntry4!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user group ${group4.id}.`
+    )
+  })
+
+  it('Test that live quizzes can be shared with individual users through the corresponding service function (with propagation)', async () => {
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
+    const { SC, SE } = await seedElements(userOneCtx, AC.id)
+    const liveQuiz = await seedLiveQuiz(
+      {
+        elements: [
+          { id: SC.id, type: ElementType.SC },
+          { id: SE.id, type: ElementType.SELECTION },
+        ],
+      },
+      userOneCtx
+    )
+
+    // directly share the live quiz with users 2, 3, 4, and 5 with READ, EXECUTE, WRITE, and ADMIN permissions
+    await shareObject(
+      {
+        permissionLevel: PermissionLevel.READ,
+        shortnameOrEmail: userTwo.shortname,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    await shareObject(
+      {
+        permissionLevel: PermissionLevel.EXECUTE,
+        shortnameOrEmail: userThree.shortname,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    await shareObject(
+      {
+        permissionLevel: PermissionLevel.WRITE,
+        shortnameOrEmail: userFour.email,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    await shareObject(
+      {
+        permissionLevel: PermissionLevel.ADMIN,
+        shortnameOrEmail: userFive.email,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+
+    // verify that the correct direct permissions were created
+    const directReadPermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(directReadPermission).toBeTruthy()
+    expect(directReadPermission!.permissionLevel).toEqual(PermissionLevel.READ)
+
+    const directExecutePermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(directExecutePermission).toBeTruthy()
+    expect(directExecutePermission!.permissionLevel).toEqual(
+      PermissionLevel.EXECUTE
+    )
+
+    const directWritePermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(directWritePermission).toBeTruthy()
+    expect(directWritePermission!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+
+    const directAdminPermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userFive.id,
+        },
+      },
+    })
+    expect(directAdminPermission).toBeTruthy()
+    expect(directAdminPermission!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+
+    // verify that the correct derived permissions were created for the live quiz
+    const derivedReadPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(derivedReadPermission).toBeTruthy()
+    expect(derivedReadPermission!.permissionLevel).toEqual(PermissionLevel.READ)
+    expect(derivedReadPermission!.directPermissionId).toBe(
+      directReadPermission!.id
+    )
+    expect(derivedReadPermission!.derived).toBe(false)
+
+    const derivedExecutePermission = await prisma.derivedPermission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(derivedExecutePermission).toBeTruthy()
+    expect(derivedExecutePermission!.permissionLevel).toEqual(
+      PermissionLevel.EXECUTE
+    )
+    expect(derivedExecutePermission!.directPermissionId).toBe(
+      directExecutePermission!.id
+    )
+    expect(derivedExecutePermission!.derived).toBe(false)
+
+    const derivedWritePermission = await prisma.derivedPermission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(derivedWritePermission).toBeTruthy()
+    expect(derivedWritePermission!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+    expect(derivedWritePermission!.directPermissionId).toBe(
+      directWritePermission!.id
+    )
+    expect(derivedWritePermission!.derived).toBe(false)
+
+    const derivedAdminPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        liveQuizId_userId: {
+          liveQuizId: liveQuiz.id,
+          userId: userFive.id,
+        },
+      },
+    })
+    expect(derivedAdminPermission).toBeTruthy()
+    expect(derivedAdminPermission!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedAdminPermission!.directPermissionId).toBe(
+      directAdminPermission!.id
+    )
+    expect(derivedAdminPermission!.derived).toBe(false)
+
+    // verify that for all users the correct derived permissions were created on the contained elements
+    // READ -> READ, EXECUTE -> READ, WRITE -> WRITE, ADMIN -> ADMIN, OWNER -> ADMIN
+    const readElementPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SC.id,
+          userId: userTwo.id,
+        },
+      },
+    })
+    expect(readElementPermission).toBeTruthy()
+    expect(readElementPermission!.permissionLevel).toEqual(PermissionLevel.READ)
+    expect(readElementPermission!.directPermissionId).toBe(
+      directReadPermission!.id
+    )
+    expect(readElementPermission!.derived).toBe(true)
+
+    const executeElementPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SC.id,
+          userId: userThree.id,
+        },
+      },
+    })
+    expect(executeElementPermission).toBeTruthy()
+    expect(executeElementPermission!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(executeElementPermission!.directPermissionId).toBe(
+      directExecutePermission!.id
+    )
+    expect(executeElementPermission!.derived).toBe(true)
+
+    const writeElementPermission = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SC.id,
+          userId: userFour.id,
+        },
+      },
+    })
+    expect(writeElementPermission).toBeTruthy()
+    expect(writeElementPermission!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+    expect(writeElementPermission!.directPermissionId).toBe(
+      directWritePermission!.id
+    )
+    expect(writeElementPermission!.derived).toBe(true)
+
+    const adminElementPermissions = await prisma.derivedPermission.findUnique({
+      where: {
+        elementId_userId: {
+          elementId: SC.id,
+          userId: userFive.id,
+        },
+      },
+    })
+    expect(adminElementPermissions).toBeTruthy()
+    expect(adminElementPermissions!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+    expect(adminElementPermissions!.directPermissionId).toBe(
+      directAdminPermission!.id
+    )
+    expect(adminElementPermissions!.derived).toBe(true)
+
+    // verify that all users also received derived permissions on the answer collection
+    const readAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(readAnswerCollectionPermission).toBeTruthy()
+    expect(readAnswerCollectionPermission!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(readAnswerCollectionPermission!.directPermissionId).toBe(
+      directReadPermission!.id
+    )
+    expect(readAnswerCollectionPermission!.derived).toBe(true)
+
+    const executeAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(executeAnswerCollectionPermission).toBeTruthy()
+    expect(executeAnswerCollectionPermission!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(executeAnswerCollectionPermission!.directPermissionId).toBe(
+      directExecutePermission!.id
+    )
+    expect(executeAnswerCollectionPermission!.derived).toBe(true)
+
+    const writeAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userFour.id,
+          },
+        },
+      })
+    expect(writeAnswerCollectionPermission).toBeTruthy()
+    expect(writeAnswerCollectionPermission!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(writeAnswerCollectionPermission!.directPermissionId).toBe(
+      directWritePermission!.id
+    )
+    expect(writeAnswerCollectionPermission!.derived).toBe(true)
+
+    const adminAnswerCollectionPermission =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userFive.id,
+          },
+        },
+      })
+    expect(adminAnswerCollectionPermission).toBeTruthy()
+    expect(adminAnswerCollectionPermission!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(adminAnswerCollectionPermission!.directPermissionId).toBe(
+      directAdminPermission!.id
+    )
+    expect(adminAnswerCollectionPermission!.derived).toBe(true)
+
+    // verify that proper audit log entries were created
+    const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserId: userTwo.id,
+      },
+    })
+    expect(auditLogEntry1).toBeTruthy()
+    expect(auditLogEntry1!.message).toBe(
+      `Direct permission with level ${PermissionLevel.READ} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user ${userTwo.id}.`
+    )
+
+    const auditLogEntry2 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserId: userThree.id,
+      },
+    })
+    expect(auditLogEntry2).toBeTruthy()
+    expect(auditLogEntry2!.message).toBe(
+      `Direct permission with level ${PermissionLevel.EXECUTE} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user ${userThree.id}.`
+    )
+
+    const auditLogEntry3 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserId: userFour.id,
+      },
+    })
+    expect(auditLogEntry3).toBeTruthy()
+    expect(auditLogEntry3!.message).toBe(
+      `Direct permission with level ${PermissionLevel.WRITE} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user ${userFour.id}.`
+    )
+
+    const auditLogEntry4 = await prisma.auditLogEntry.findFirst({
+      where: {
+        type: AuditLogType.PERMISSION_GRANTED,
+        objectType: ObjectType.LIVE_QUIZ,
+        objectId: liveQuiz.id,
+        sourceUserId: userOne.id,
+        targetUserId: userFive.id,
+      },
+    })
+    expect(auditLogEntry4).toBeTruthy()
+    expect(auditLogEntry4!.message).toBe(
+      `Direct permission with level ${PermissionLevel.ADMIN} granted for ${ObjectType.LIVE_QUIZ} (ID ${liveQuiz.id}) by owner / admin ${userOne.id} to user ${userFive.id}.`
+    )
+  })
+
+  it('Test that live quizzes can be shared with groups through the corresponding service function (with propagation)', async () => {
+    const { AC1: AC } = await seedAnswerCollections(userOneCtx)
+    const { SC, SE } = await seedElements(userOneCtx, AC.id)
+    const liveQuiz = await seedLiveQuiz(
+      {
+        elements: [
+          { id: SC.id, type: ElementType.SC },
+          { id: SE.id, type: ElementType.SELECTION },
+        ],
+      },
+      userOneCtx
+    )
+
+    // create user groups with users 1 and 2, 2 and 3, 4, and 4 and 5 respectively
+    const group1 = await prisma.userGroup.create({
+      data: {
+        name: 'Group 1',
+        ownerId: userOne.id,
+        members: {
+          connect: [{ id: userTwo.id }],
+        },
+      },
+    })
+    const group2 = await prisma.userGroup.create({
+      data: {
+        name: 'Group 2',
+        ownerId: userTwo.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userThree.id }],
+        },
+      },
+    })
+    const group3 = await prisma.userGroup.create({
+      data: {
+        name: 'Group 3',
+        ownerId: userTwo.id,
+        members: {
+          connect: [{ id: userOne.id }, { id: userFour.id }],
+        },
+      },
+    })
+    const group4 = await prisma.userGroup.create({
+      data: {
+        name: 'Group 4',
+        ownerId: userFive.id,
+        members: {
+          connect: [{ id: userFour.id }, { id: userOne.id }],
+        },
+      },
+    })
+
+    // directly share the live quiz with groups 1, 2, 3, and 4 with READ, EXECUTE, WRITE, and ADMIN permissions
+    const res1 = await shareObject(
+      {
+        permissionLevel: PermissionLevel.READ,
+        userGroupId: group1.id,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res1).toBeTruthy()
+
+    const res2 = await shareObject(
+      {
+        permissionLevel: PermissionLevel.EXECUTE,
+        userGroupId: group2.id,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res2).toBeTruthy()
+
+    const res3 = await shareObject(
+      {
+        permissionLevel: PermissionLevel.WRITE,
+        userGroupId: group3.id,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res3).toBeTruthy()
+
+    const res4 = await shareObject(
+      {
+        permissionLevel: PermissionLevel.ADMIN,
+        userGroupId: group4.id,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res4).toBeTruthy()
+
+    // verify that the correct direct permissions were created
+    const directGroupReadPermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userGroupId: {
+          liveQuizId: liveQuiz.id,
+          userGroupId: group1.id,
+        },
+      },
+    })
+    expect(directGroupReadPermission).toBeTruthy()
+    expect(directGroupReadPermission!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+
+    const directGroupExecutePermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userGroupId: {
+          liveQuizId: liveQuiz.id,
+          userGroupId: group2.id,
+        },
+      },
+    })
+    expect(directGroupExecutePermission).toBeTruthy()
+    expect(directGroupExecutePermission!.permissionLevel).toEqual(
+      PermissionLevel.EXECUTE
+    )
+
+    const directGroupWritePermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userGroupId: {
+          liveQuizId: liveQuiz.id,
+          userGroupId: group3.id,
+        },
+      },
+    })
+    expect(directGroupWritePermission).toBeTruthy()
+    expect(directGroupWritePermission!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+
+    const directGroupAdminPermission = await prisma.permission.findUnique({
+      where: {
+        liveQuizId_userGroupId: {
+          liveQuizId: liveQuiz.id,
+          userGroupId: group4.id,
+        },
+      },
+    })
+    expect(directGroupAdminPermission).toBeTruthy()
+    expect(directGroupAdminPermission!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+
+    // verify that the correct derived permissions were created for the live quiz
+    // OWNER (user 1), ADMIN (users 4 and 5), WRITE (user 2), EXECUTE (user 3)
+    const derivedLQPermissionUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(derivedLQPermissionUserOne).toBeTruthy()
+    expect(derivedLQPermissionUserOne!.permissionLevel).toEqual(
+      PermissionLevel.OWNER
+    )
+    expect(derivedLQPermissionUserOne!.directPermissionId).toBeNull()
+    expect(derivedLQPermissionUserOne!.derived).toBe(false)
+
+    const derivedLQPermissionUserTwo =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(derivedLQPermissionUserTwo).toBeTruthy()
+    expect(derivedLQPermissionUserTwo!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+    expect(derivedLQPermissionUserTwo!.directPermissionId).toBe(
+      directGroupWritePermission!.id
+    )
+    expect(derivedLQPermissionUserTwo!.derived).toBe(false)
+
+    const derivedLQPermissionUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(derivedLQPermissionUserThree).toBeTruthy()
+    expect(derivedLQPermissionUserThree!.permissionLevel).toEqual(
+      PermissionLevel.EXECUTE
+    )
+    expect(derivedLQPermissionUserThree!.directPermissionId).toBe(
+      directGroupExecutePermission!.id
+    )
+    expect(derivedLQPermissionUserThree!.derived).toBe(false)
+
+    const derivedLQPermissionUserFour =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userFour.id,
+          },
+        },
+      })
+    expect(derivedLQPermissionUserFour).toBeTruthy()
+    expect(derivedLQPermissionUserFour!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedLQPermissionUserFour!.directPermissionId).toBe(
+      directGroupAdminPermission!.id
+    )
+    expect(derivedLQPermissionUserFour!.derived).toBe(false)
+
+    const derivedLQPermissionUserFive =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userFive.id,
+          },
+        },
+      })
+    expect(derivedLQPermissionUserFive).toBeTruthy()
+    expect(derivedLQPermissionUserFive!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedLQPermissionUserFive!.directPermissionId).toBe(
+      directGroupAdminPermission!.id
+    )
+    expect(derivedLQPermissionUserFive!.derived).toBe(false)
+
+    // verify that derived permissions on the live quiz were created for the admin users on the element
+    // user 1: activity OWNER -> element ADMIN
+    // user 2: activity WRITE -> element WRITE
+    // user 3: activity EXECUTE -> element READ
+    // user 4: activity ADMIN -> element ADMIN
+    // user 5: activity ADMIN -> element ADMIN
+    const derivedElementPermissionsUserOne =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userOne.id,
+          },
+        },
+      })
+    expect(derivedElementPermissionsUserOne).toBeTruthy()
+    expect(derivedElementPermissionsUserOne!.permissionLevel).toEqual(
+      PermissionLevel.OWNER
+    )
+    expect(derivedElementPermissionsUserOne!.directPermissionId).toBeNull()
+    expect(derivedElementPermissionsUserOne!.derived).toBe(false)
+
+    const derivedElementPermissionsUserTwo =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(derivedElementPermissionsUserTwo).toBeTruthy()
+    expect(derivedElementPermissionsUserTwo!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+    expect(derivedElementPermissionsUserTwo!.directPermissionId).toBe(
+      directGroupWritePermission!.id
+    )
+    expect(derivedElementPermissionsUserTwo!.derived).toBe(true)
+
+    const derivedElementPermissionsUserThree =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userThree.id,
+          },
+        },
+      })
+    expect(derivedElementPermissionsUserThree).toBeTruthy()
+    expect(derivedElementPermissionsUserThree!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(derivedElementPermissionsUserThree!.directPermissionId).toBe(
+      directGroupExecutePermission!.id
+    )
+    expect(derivedElementPermissionsUserThree!.derived).toBe(true)
+
+    const derivedElementPermissionsUserFour =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userFour.id,
+          },
+        },
+      })
+    expect(derivedElementPermissionsUserFour).toBeTruthy()
+    expect(derivedElementPermissionsUserFour!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedElementPermissionsUserFour!.directPermissionId).toBe(
+      directGroupAdminPermission!.id
+    )
+    expect(derivedElementPermissionsUserFour!.derived).toBe(true)
+
+    const derivedElementPermissionsUserFive =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userFive.id,
+          },
+        },
+      })
+    expect(derivedElementPermissionsUserFive).toBeTruthy()
+    expect(derivedElementPermissionsUserFive!.permissionLevel).toEqual(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedElementPermissionsUserFive!.directPermissionId).toBe(
+      directGroupAdminPermission!.id
+    )
+    expect(derivedElementPermissionsUserFive!.derived).toBe(true)
+
+    // verify that all users also received derived permissions on the answer collection
+    for (const user of [userTwo, userThree, userFour, userFive]) {
+      const derivedAnswerCollectionPermission =
+        await prisma.derivedPermission.findUnique({
+          where: {
+            answerCollectionId_userId: {
+              answerCollectionId: AC.id,
+              userId: user.id,
+            },
+          },
+        })
+      expect(derivedAnswerCollectionPermission).toBeTruthy()
+      expect(derivedAnswerCollectionPermission!.permissionLevel).toEqual(
+        PermissionLevel.READ
+      )
+      expect(derivedAnswerCollectionPermission!.derived).toBe(true)
+    }
 
     // verify that proper audit log entries were created
     const auditLogEntry1 = await prisma.auditLogEntry.findFirst({
@@ -1876,7 +2686,7 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       userOneCtx
     )
 
-    // grant READ permissions to user 2
+    // grant READ permissions to user 2 (without propagation)
     const directPermission = await prisma.permission.create({
       data: {
         userId: userTwo.id,
@@ -1913,8 +2723,143 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     })
     expect(readPermissionElement).toBeNull()
 
-    // change the permission level to EXECUTE
+    const readPermissionsAnswerCollection =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(readPermissionsAnswerCollection).toBeNull()
+
+    // enable propagation
     const res1 = await changeObjectPermissionLevel(
+      {
+        permissionId: directPermission!.id,
+        permissionLevel: PermissionLevel.READ,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res1).toBeTruthy()
+
+    const readPermissionActivityPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(readPermissionActivityPropagated).toBeTruthy()
+    expect(readPermissionActivityPropagated!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+
+    const readElementPermissionPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(readElementPermissionPropagated).toBeTruthy()
+    expect(readElementPermissionPropagated!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(readElementPermissionPropagated!.directPermissionId).toBe(
+      directPermission!.id
+    )
+    expect(readElementPermissionPropagated!.derived).toBe(true)
+
+    const readAnswerCollectionPermissionPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(readAnswerCollectionPermissionPropagated).toBeTruthy()
+    expect(readAnswerCollectionPermissionPropagated!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(readAnswerCollectionPermissionPropagated!.directPermissionId).toBe(
+      directPermission!.id
+    )
+    expect(readAnswerCollectionPermissionPropagated!.derived).toBe(true)
+
+    // change the permission level to EXECUTE (with propagation)
+    const res2 = await changeObjectPermissionLevel(
+      {
+        permissionId: directPermission!.id,
+        permissionLevel: PermissionLevel.EXECUTE,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res2).toBeTruthy()
+
+    const executePermissionActivityPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(executePermissionActivityPropagated).toBeTruthy()
+    expect(executePermissionActivityPropagated!.permissionLevel).toEqual(
+      PermissionLevel.EXECUTE
+    )
+
+    const executeElementPermissionPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(executeElementPermissionPropagated).toBeTruthy()
+    expect(executeElementPermissionPropagated!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(executeElementPermissionPropagated!.directPermissionId).toBe(
+      directPermission!.id
+    )
+    expect(executeElementPermissionPropagated!.derived).toBe(true)
+
+    const executeAnswerCollectionPermissionPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(executeAnswerCollectionPermissionPropagated).toBeTruthy()
+    expect(
+      executeAnswerCollectionPermissionPropagated!.permissionLevel
+    ).toEqual(PermissionLevel.READ)
+    expect(
+      executeAnswerCollectionPermissionPropagated!.directPermissionId
+    ).toBe(directPermission!.id)
+    expect(executeAnswerCollectionPermissionPropagated!.derived).toBe(true)
+
+    // disable propagation
+    const res3 = await changeObjectPermissionLevel(
       {
         permissionId: directPermission!.id,
         permissionLevel: PermissionLevel.EXECUTE,
@@ -1923,9 +2868,8 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       },
       userOneCtx
     )
-    expect(res1).toBeTruthy()
+    expect(res3).toBeTruthy()
 
-    // check that the derived permissions were updated correctly
     const executePermissionActivity = await prisma.derivedPermission.findUnique(
       {
         where: {
@@ -1951,8 +2895,19 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     })
     expect(executePermissionElement).toBeNull()
 
-    // change the permission level to WRITE
-    const res2 = await changeObjectPermissionLevel(
+    const executePermissionAnswerCollection =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(executePermissionAnswerCollection).toBeNull()
+
+    // change the permission level to WRITE (without propagation)
+    const res4 = await changeObjectPermissionLevel(
       {
         permissionId: directPermission!.id,
         permissionLevel: PermissionLevel.WRITE,
@@ -1961,9 +2916,8 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       },
       userOneCtx
     )
-    expect(res2).toBeTruthy()
+    expect(res4).toBeTruthy()
 
-    // check that the derived permissions were updated correctly
     const writePermissionActivity = await prisma.derivedPermission.findUnique({
       where: {
         liveQuizId_userId: {
@@ -1987,8 +2941,81 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
     })
     expect(writePermissionElement).toBeNull()
 
-    // change the permission level to ADMIN
-    const res3 = await changeObjectPermissionLevel(
+    const writePermissionAnswerCollection =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(writePermissionAnswerCollection).toBeNull()
+
+    // enable propagation
+    const res5 = await changeObjectPermissionLevel(
+      {
+        permissionId: directPermission!.id,
+        permissionLevel: PermissionLevel.WRITE,
+        liveQuizId: liveQuiz.id,
+        propagation: true,
+      },
+      userOneCtx
+    )
+    expect(res5).toBeTruthy()
+
+    const writePermissionActivityPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          liveQuizId_userId: {
+            liveQuizId: liveQuiz.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(writePermissionActivityPropagated).toBeTruthy()
+    expect(writePermissionActivityPropagated!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+
+    const writePermissionElementPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: SC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(writePermissionElementPropagated).toBeTruthy()
+    expect(writePermissionElementPropagated!.permissionLevel).toEqual(
+      PermissionLevel.WRITE
+    )
+    expect(writePermissionElementPropagated!.directPermissionId).toBe(
+      directPermission!.id
+    )
+    expect(writePermissionElementPropagated!.derived).toBe(true)
+
+    const writePermissionAnswerCollectionPropagated =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          answerCollectionId_userId: {
+            answerCollectionId: AC.id,
+            userId: userTwo.id,
+          },
+        },
+      })
+    expect(writePermissionAnswerCollectionPropagated).toBeTruthy()
+    expect(writePermissionAnswerCollectionPropagated!.permissionLevel).toEqual(
+      PermissionLevel.READ
+    )
+    expect(writePermissionAnswerCollectionPropagated!.directPermissionId).toBe(
+      directPermission!.id
+    )
+    expect(writePermissionAnswerCollectionPropagated!.derived).toBe(true)
+
+    // change the permission level to ADMIN (without propagation)
+    const res6 = await changeObjectPermissionLevel(
       {
         permissionId: directPermission!.id,
         permissionLevel: PermissionLevel.ADMIN,
@@ -1997,9 +3024,8 @@ describe('Unit tests for sharing functionalities of activities (e.g. live quiz)'
       },
       userOneCtx
     )
-    expect(res3).toBeTruthy()
+    expect(res6).toBeTruthy()
 
-    // check that the derived permissions were updated correctly (and new permissions created on the elements)
     const adminPermissionActivity = await prisma.derivedPermission.findUnique({
       where: {
         liveQuizId_userId: {

--- a/packages/graphql/test/elementPermissions.test.ts
+++ b/packages/graphql/test/elementPermissions.test.ts
@@ -703,9 +703,17 @@ describe('Unit tests covering the creation of derived permissions for elements',
         propagation: false,
       },
     })
-    const activityWRITEPermissions = await prisma.permission.create({
+    const activityEXECUTEPermissions = await prisma.permission.create({
       data: {
         userId: userThree.id,
+        liveQuizId: activity.id,
+        permissionLevel: PermissionLevel.EXECUTE,
+        propagation: false,
+      },
+    })
+    const activityWRITEPermissions = await prisma.permission.create({
+      data: {
+        userId: userFour.id,
         liveQuizId: activity.id,
         permissionLevel: PermissionLevel.WRITE,
         propagation: false,
@@ -713,7 +721,7 @@ describe('Unit tests covering the creation of derived permissions for elements',
     })
     const activityADMINPermissions = await prisma.permission.create({
       data: {
-        userId: userFour.id,
+        userId: userFive.id,
         liveQuizId: activity.id,
         permissionLevel: PermissionLevel.ADMIN,
         propagation: false,
@@ -724,7 +732,9 @@ describe('Unit tests covering the creation of derived permissions for elements',
     await recomputeDerivedPermissions({ liveQuizId: activity.id }, prisma)
 
     // verify that the correct derived permission entries on the element have been created
-    // user 1 (OWNER - ADMIN would be min. required = propagated), user 2 & user 3 (no access), user 4 (ADMIN - min. required = propagated)
+    // user 1 (OWNER - ADMIN would be min. required = propagated),
+    // user 2, 3, and 4 (no access),
+    // user 5 (ADMIN - min. required = propagated)
     const derivedPermissionUserOne = await prisma.derivedPermission.findUnique({
       where: {
         elementId_userId: {
@@ -771,18 +781,34 @@ describe('Unit tests covering the creation of derived permissions for elements',
         },
       }
     )
-    expect(derivedPermissionUserFour).toBeTruthy()
-    expect(derivedPermissionUserFour!.permissionLevel).toBe(
+    expect(derivedPermissionUserFour).toBeNull()
+
+    const derivedPermissionUserFive = await prisma.derivedPermission.findUnique(
+      {
+        where: {
+          elementId_userId: {
+            elementId: element.id,
+            userId: userFive.id,
+          },
+        },
+      }
+    )
+    expect(derivedPermissionUserFive).toBeTruthy()
+    expect(derivedPermissionUserFive!.permissionLevel).toBe(
       PermissionLevel.ADMIN
     )
-    expect(derivedPermissionUserFour!.directPermissionId).toBe(
+    expect(derivedPermissionUserFive!.directPermissionId).toBe(
       activityADMINPermissions.id
     )
-    expect(derivedPermissionUserFour!.derived).toBeTruthy()
+    expect(derivedPermissionUserFive!.derived).toBeTruthy()
 
     // update the permissions to have propagation enabled
     await prisma.permission.update({
       where: { id: activityREADPermissions.id },
+      data: { propagation: true },
+    })
+    await prisma.permission.update({
+      where: { id: activityEXECUTEPermissions.id },
       data: { propagation: true },
     })
     await prisma.permission.update({
@@ -798,7 +824,10 @@ describe('Unit tests covering the creation of derived permissions for elements',
     await recomputeDerivedPermissions({ liveQuizId: activity.id }, prisma)
 
     // verify that the correct derived permission entries on the element have been created
-    // user 1 (OWNER - ADMIN would be min. required = propagated), user 2 & user 3 (no access), user 4 (ADMIN - min. required = propagated)
+    // user 1 (OWNER - ADMIN will be propagated),
+    // user 2 & 3 (READ / EXECUTE - READ will be propagated)
+    // user 4 (WRITE - WRITE will be propagated)
+    // user 5 (ADMIN - ADMIN will be propagated)
     const derivedPermissionUserOne2 = await prisma.derivedPermission.findUnique(
       {
         where: {
@@ -826,7 +855,14 @@ describe('Unit tests covering the creation of derived permissions for elements',
         },
       }
     )
-    expect(derivedPermissionUserTwo2).toBeNull()
+    expect(derivedPermissionUserTwo2).toBeTruthy()
+    expect(derivedPermissionUserTwo2!.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(derivedPermissionUserTwo2!.directPermissionId).toBe(
+      activityREADPermissions.id
+    )
+    expect(derivedPermissionUserTwo2!.derived).toBeTruthy()
 
     const derivedPermissionUserThree2 =
       await prisma.derivedPermission.findUnique({
@@ -837,7 +873,14 @@ describe('Unit tests covering the creation of derived permissions for elements',
           },
         },
       })
-    expect(derivedPermissionUserThree2).toBeNull()
+    expect(derivedPermissionUserThree2).toBeTruthy()
+    expect(derivedPermissionUserThree2!.permissionLevel).toBe(
+      PermissionLevel.READ
+    )
+    expect(derivedPermissionUserThree2!.directPermissionId).toBe(
+      activityEXECUTEPermissions.id
+    )
+    expect(derivedPermissionUserThree2!.derived).toBeTruthy()
 
     const derivedPermissionUserFour2 =
       await prisma.derivedPermission.findUnique({
@@ -850,12 +893,30 @@ describe('Unit tests covering the creation of derived permissions for elements',
       })
     expect(derivedPermissionUserFour2).toBeTruthy()
     expect(derivedPermissionUserFour2!.permissionLevel).toBe(
-      PermissionLevel.ADMIN
+      PermissionLevel.WRITE
     )
     expect(derivedPermissionUserFour2!.directPermissionId).toBe(
-      activityADMINPermissions.id
+      activityWRITEPermissions.id
     )
     expect(derivedPermissionUserFour2!.derived).toBeTruthy()
+
+    const derivedPermissionUserFive2 =
+      await prisma.derivedPermission.findUnique({
+        where: {
+          elementId_userId: {
+            elementId: element.id,
+            userId: userFive.id,
+          },
+        },
+      })
+    expect(derivedPermissionUserFive2).toBeTruthy()
+    expect(derivedPermissionUserFive2!.permissionLevel).toBe(
+      PermissionLevel.ADMIN
+    )
+    expect(derivedPermissionUserFive2!.directPermissionId).toBe(
+      activityADMINPermissions.id
+    )
+    expect(derivedPermissionUserFive2!.derived).toBeTruthy()
   })
 
   it('Verify that minimum required permissions are correctly derived from activities for user groups (min. required = propagated for elements)', async () => {

--- a/packages/util/src/permissions/element.ts
+++ b/packages/util/src/permissions/element.ts
@@ -18,6 +18,36 @@ import {
   getMaxAccessLevelIndividual,
 } from './util.js'
 
+// WHERE clause component to filter relevant activities, which would result in permissions on the contained elements
+const ACTIVITY_PERMISSIONS_WHERE_CLAUSE = [
+  // ? ADMIN / OWNER permissions on activity
+  {
+    permissionLevel: {
+      in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
+    },
+  },
+  // ? propagation enabled & READ / WRITE / EXECUTE permissions on activity
+  // --> if this is modified, the logic in the function body below also needs to be adapted
+  {
+    permissionLevel: {
+      in: [
+        DB.PermissionLevel.READ,
+        DB.PermissionLevel.EXECUTE,
+        DB.PermissionLevel.WRITE,
+      ],
+    },
+    directPermission: {
+      propagation: true,
+      OR: [
+        { liveQuizId: { not: null } },
+        { practiceQuizId: { not: null } },
+        { microLearningId: { not: null } },
+        { groupActivityId: { not: null } },
+      ],
+    },
+  },
+]
+
 /**
  * Dispatch function for the recomputation of derived permissions for elements.
  *
@@ -141,12 +171,7 @@ export async function recomputeElementPermissionsUser(
                       permissions: {
                         some: {
                           userId,
-                          permissionLevel: {
-                            in: [
-                              DB.PermissionLevel.ADMIN,
-                              DB.PermissionLevel.OWNER,
-                            ],
-                          },
+                          OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                         },
                       },
                     },
@@ -156,12 +181,7 @@ export async function recomputeElementPermissionsUser(
                       permissions: {
                         some: {
                           userId,
-                          permissionLevel: {
-                            in: [
-                              DB.PermissionLevel.ADMIN,
-                              DB.PermissionLevel.OWNER,
-                            ],
-                          },
+                          OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                         },
                       },
                     },
@@ -171,12 +191,7 @@ export async function recomputeElementPermissionsUser(
                       permissions: {
                         some: {
                           userId,
-                          permissionLevel: {
-                            in: [
-                              DB.PermissionLevel.ADMIN,
-                              DB.PermissionLevel.OWNER,
-                            ],
-                          },
+                          OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                         },
                       },
                     },
@@ -190,12 +205,7 @@ export async function recomputeElementPermissionsUser(
                   permissions: {
                     some: {
                       userId,
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -211,12 +221,7 @@ export async function recomputeElementPermissionsUser(
                   permissions: {
                     where: {
                       userId,
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -230,12 +235,7 @@ export async function recomputeElementPermissionsUser(
                   permissions: {
                     where: {
                       userId,
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -245,12 +245,7 @@ export async function recomputeElementPermissionsUser(
                   permissions: {
                     where: {
                       userId,
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -260,12 +255,7 @@ export async function recomputeElementPermissionsUser(
                   permissions: {
                     where: {
                       userId,
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -302,8 +292,8 @@ export async function recomputeElementPermissionsUser(
       parentPermissionId = directPermissionId
     }
 
-    // if the element is included in an activity where the user has ADMIN / OWNER permissions
-    // --> owner requires derived admin permissions (at least) - skip if direct ADMIn permissions are already granted
+    // if the element is included in an activity where the user has ADMIN / OWNER permissions or propagation is enabled
+    // --> owner requires derived admin permissions (at least) - skip if direct ADMIN permissions are already granted
     if (
       element.elementInstances.length > 0 &&
       maxAccessLevel !== DB.PermissionLevel.ADMIN
@@ -315,10 +305,25 @@ export async function recomputeElementPermissionsUser(
         instance.elementStack?.microLearning?.permissions[0] ??
         instance.elementStack?.groupActivity?.permissions[0]
 
-      if (permission) {
+      // OWNER / ADMIN permissions on the activity -> ADMIN on element
+      if (
+        permission &&
+        (permission.permissionLevel === DB.PermissionLevel.OWNER ||
+          permission.permissionLevel === DB.PermissionLevel.ADMIN)
+      ) {
         maxAccessLevel = DB.PermissionLevel.ADMIN
         parentPermissionId = permission.directPermissionId ?? undefined
-        derived = true // permission was derived from another element
+        derived = true // permission was derived from an activity
+      }
+      // READ / EXECUTE / WRITE on the activity AND propagation enabled (only these are fetched above!)
+      // --> READ / WRITE on element
+      else if (permission) {
+        maxAccessLevel =
+          permission.permissionLevel === DB.PermissionLevel.WRITE
+            ? DB.PermissionLevel.WRITE
+            : DB.PermissionLevel.READ
+        parentPermissionId = permission.directPermissionId ?? undefined
+        derived = true // permission was derived from an activity
       }
     }
   }
@@ -448,12 +453,7 @@ export async function recomputeElementPermissionsObject(
                 include: {
                   permissions: {
                     where: {
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -466,12 +466,7 @@ export async function recomputeElementPermissionsObject(
                 include: {
                   permissions: {
                     where: {
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -480,12 +475,7 @@ export async function recomputeElementPermissionsObject(
                 include: {
                   permissions: {
                     where: {
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -494,12 +484,7 @@ export async function recomputeElementPermissionsObject(
                 include: {
                   permissions: {
                     where: {
-                      permissionLevel: {
-                        in: [
-                          DB.PermissionLevel.ADMIN,
-                          DB.PermissionLevel.OWNER,
-                        ],
-                      },
+                      OR: ACTIVITY_PERMISSIONS_WHERE_CLAUSE,
                     },
                   },
                 },
@@ -524,7 +509,7 @@ export async function recomputeElementPermissionsObject(
   })
 
   // get all activity permissions (ADMIN and OWNER level), which make a user qualify for ADMIN access on the element
-  const adminActivityPermissions: DB.DerivedPermission[] =
+  const activityPermissions: DB.DerivedPermission[] =
     element.elementInstances.flatMap((instance) => [
       ...(instance.elementBlock?.liveQuiz.permissions ?? []),
       ...(instance.elementStack?.practiceQuiz?.permissions ?? []),
@@ -534,29 +519,76 @@ export async function recomputeElementPermissionsObject(
 
   // extend the user access map based on the activity permissions resulting in derived ADMIN access
   const userAccess =
-    adminActivityPermissions.length > 0
-      ? adminActivityPermissions.reduce<UserAccessMap>(
+    activityPermissions.length > 0
+      ? activityPermissions.reduce<UserAccessMap>(
           (acc, permission) => {
-            // if the user already has a permission, check if it is already on ADMIN level
+            // if the user already has a ADMIN / OWNER permission, no derived access can be higher
             if (
               typeof acc[permission.userId] !== 'undefined' &&
-              acc[permission.userId]!.maxAccessLevel !==
-                DB.PermissionLevel.ADMIN &&
-              acc[permission.userId]!.maxAccessLevel !==
-                DB.PermissionLevel.OWNER
+              (acc[permission.userId]!.maxAccessLevel ===
+                DB.PermissionLevel.ADMIN ||
+                acc[permission.userId]!.maxAccessLevel ===
+                  DB.PermissionLevel.OWNER)
             ) {
-              acc[permission.userId]!.maxAccessLevel = DB.PermissionLevel.ADMIN
-              acc[permission.userId]!.parentPermissionId =
-                permission.directPermissionId ?? undefined
-              acc[permission.userId]!.derived = true // permission was derived from an activity with ADMIN permissions
+              return acc
             }
 
-            // if user does not have a permission yet, add it
-            if (typeof acc[permission.userId] === 'undefined') {
-              acc[permission.userId] = {
-                maxAccessLevel: DB.PermissionLevel.ADMIN,
-                parentPermissionId: permission.directPermissionId ?? undefined,
-                derived: true, // permission was derived from an activity with ADMIN permissions
+            // if the user has ADMIN / OWNER permissions on the activity, grant ADMIN access on the element
+            if (
+              permission.permissionLevel === DB.PermissionLevel.OWNER ||
+              permission.permissionLevel === DB.PermissionLevel.ADMIN
+            ) {
+              if (acc[permission.userId]) {
+                acc[permission.userId]!.maxAccessLevel =
+                  DB.PermissionLevel.ADMIN
+                acc[permission.userId]!.parentPermissionId =
+                  permission.directPermissionId ?? undefined
+                acc[permission.userId]!.derived = true // permission was derived from an activity with ADMIN permissions
+              } else {
+                acc[permission.userId] = {
+                  maxAccessLevel: DB.PermissionLevel.ADMIN,
+                  parentPermissionId:
+                    permission.directPermissionId ?? undefined,
+                  derived: true, // permission was derived from an activity with ADMIN permissions
+                }
+              }
+            }
+            // if the user has WRITE permissions on the activity and propagation is enabled, grant WRITE access on the element
+            // ? where clause already ensures that fetched WRITE permissions have propagation enabled on activity
+            else if (permission.permissionLevel === DB.PermissionLevel.WRITE) {
+              if (acc[permission.userId]) {
+                acc[permission.userId]!.maxAccessLevel =
+                  DB.PermissionLevel.WRITE
+                acc[permission.userId]!.parentPermissionId =
+                  permission.directPermissionId ?? undefined
+                acc[permission.userId]!.derived = true // permission was derived from an activity with WRITE permissions
+              } else {
+                acc[permission.userId] = {
+                  maxAccessLevel: DB.PermissionLevel.WRITE,
+                  parentPermissionId:
+                    permission.directPermissionId ?? undefined,
+                  derived: true, // permission was derived from an activity with WRITE permissions
+                }
+              }
+            }
+            // if the user has READ / EXECUTE permissions on the activity and propagation is enabled, grant READ access on the element
+            // ? where clause already ensures that fetched READ / EXECUTE permissions have propagation enabled on activity
+            else if (
+              permission.permissionLevel === DB.PermissionLevel.READ ||
+              permission.permissionLevel === DB.PermissionLevel.EXECUTE
+            ) {
+              if (acc[permission.userId]) {
+                acc[permission.userId]!.maxAccessLevel = DB.PermissionLevel.READ
+                acc[permission.userId]!.parentPermissionId =
+                  permission.directPermissionId ?? undefined
+                acc[permission.userId]!.derived = true // permission was derived from an activity with READ / EXECUTE permissions
+              } else {
+                acc[permission.userId] = {
+                  maxAccessLevel: DB.PermissionLevel.READ,
+                  parentPermissionId:
+                    permission.directPermissionId ?? undefined,
+                  derived: true, // permission was derived from an activity with READ / EXECUTE permissions
+                }
               }
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated permission propagation logic to ensure READ, EXECUTE, and WRITE permissions on activities with propagation enabled are correctly reflected as derived permissions on elements.
	- Adjusted test cases to accurately verify permission levels and propagation behavior for both users and user groups.

- **Refactor**
	- Streamlined and centralized the filtering of activity permissions to improve consistency and maintainability.

- **New Features**
	- Expanded propagation settings visibility to additional object types in the sharing interface.
	- Introduced more granular permission handling for quiz-related objects based on propagation status.

- **Tests**
	- Enhanced test coverage and updated assertions to align with revised permission propagation rules.
	- Added comprehensive tests for sharing live quizzes with individual users and groups, covering scenarios with and without permission propagation.
	- Verified audit log entries related to permission grants and changes with propagation toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->