### PR TITLE
enhance(apps/frontend-pwa): make submit buttons float in PWA

### DIFF
--- a/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/ElementStack.tsx
@@ -358,75 +358,77 @@ function ElementStack({
         </div>
       </div>
 
-      {/* display continue button if question was already answered */}
-      {typeof stackStorage !== 'undefined' && !showMarkAsRead ? (
-        <Button
-          onClick={() => {
-            setStudentResponse({})
+      {/* Action Buttons Wrapper */}
+      <div className="sticky bottom-4 z-10 bg-white shadow-md p-2 float-right w-auto">
+        {/* display continue button if question was already answered */}
+        {typeof stackStorage !== 'undefined' && !showMarkAsRead ? (
+          <Button
+            onClick={() => {
+              setStudentResponse({})
 
-            if (currentStep === totalSteps) {
-              onAllStacksCompletion()
-            } else {
-              handleNextElement()
-            }
-          }}
-          className={{ root: 'float-right mt-4' }}
-          data={{ cy: 'student-stack-continue' }}
-        >
-          <Button.Label>
-            {currentStep === totalSteps
-              ? t('shared.generic.finish')
-              : t('shared.generic.continue')}
-          </Button.Label>
-        </Button>
-      ) : null}
+              if (currentStep === totalSteps) {
+                onAllStacksCompletion()
+              } else {
+                handleNextElement()
+              }
+            }}
+            className={{ root: '' }}
+            data={{ cy: 'student-stack-continue' }}
+          >
+            <Button.Label>
+              {currentStep === totalSteps
+                ? t('shared.generic.finish')
+                : t('shared.generic.continue')}
+            </Button.Label>
+          </Button>
+        ) : null}
 
-      {/* display mark all as read button, if only content elements have not been answered yet */}
-      {typeof stackStorage === 'undefined' && showMarkAsRead && (
-        <Button
-          className={{ root: 'float-right mt-4' }}
-          disabled={Object.values(studentResponse).some(
-            (response) => !response.valid
-          )}
-          onClick={() => {
-            // update the read status of all content elements in studentResponse to true
-            setStudentResponse((currentResponses) =>
-              Object.entries(currentResponses).reduce<StackStudentResponseType>(
-                (acc, [instanceId, value]) => {
-                  if (value.type === ElementType.Content) {
-                    return {
-                      ...acc,
-                      [instanceId]: {
-                        ...value,
-                        response: true,
-                      },
+        {/* display mark all as read button, if only content elements have not been answered yet */}
+        {typeof stackStorage === 'undefined' && showMarkAsRead && (
+          <Button
+            className={{ root: '' }}
+            disabled={Object.values(studentResponse).some(
+              (response) => !response.valid
+            )}
+            onClick={() => {
+              // update the read status of all content elements in studentResponse to true
+              setStudentResponse((currentResponses) =>
+                Object.entries(currentResponses).reduce<StackStudentResponseType>(
+                  (acc, [instanceId, value]) => {
+                    if (value.type === ElementType.Content) {
+                      return {
+                        ...acc,
+                        [instanceId]: {
+                          ...value,
+                          response: true,
+                        },
+                      }
+                    } else {
+                      return { ...acc, [instanceId]: value }
                     }
-                  } else {
-                    return { ...acc, [instanceId]: value }
-                  }
-                },
-                {}
+                  },
+                  {}
+                )
               )
-            )
-          }}
-          data={{ cy: 'practice-quiz-mark-all-as-read' }}
-        >
-          <Button.Label>{t('pwa.practiceQuiz.markAllAsRead')}</Button.Label>
-        </Button>
-      )}
+            }}
+            data={{ cy: 'practice-quiz-mark-all-as-read' }}
+          >
+            <Button.Label>{t('pwa.practiceQuiz.markAllAsRead')}</Button.Label>
+          </Button>
+        )}
 
-      {typeof stackStorage === 'undefined' && !showMarkAsRead && (
-        <Button
-          primary
-          loading={submittingResponse}
-          disabled={
-            (!previewOnly && activityExpired) ||
-            Object.values(studentResponse).some((response) => !response.valid)
-          }
-          className={{ root: 'float-right mt-4' }}
-          onClick={async () => {
-            const result = await respondToElementStack({
-              variables: {
+        {typeof stackStorage === 'undefined' && !showMarkAsRead && (
+          <Button
+            primary
+            loading={submittingResponse}
+            disabled={
+              (!previewOnly && activityExpired) ||
+              Object.values(studentResponse).some((response) => !response.valid)
+            }
+            className={{ root: '' }}
+            onClick={async () => {
+              const result = await respondToElementStack({
+                variables: {
                 isOwner: previewOnly,
                 stackId: stack.id,
                 courseId: courseId,

--- a/packages/shared-components/src/questions/LiveQuizProgress.tsx
+++ b/packages/shared-components/src/questions/LiveQuizProgress.tsx
@@ -56,7 +56,7 @@ export function LiveQuizProgress({
       />
 
       {!isSubmitHidden && (
-        <div className="my-auto">
+        <div className="my-auto sticky bottom-4 z-10 bg-white shadow-md p-2">
           <Button
             fluid
             primary


### PR DESCRIPTION
Makes the buttons in the PWA application sticky so they float at the bottom of the screen when you scroll while responding to questions.

This change affects:
- The button in Live Quizzes (`LiveQuizProgress.tsx`), making the button area sticky.
- The action buttons (like Continue and Mark as Read) in Practice Quizzes (`ElementStack.tsx`), by wrapping them in a sticky container.

The buttons will now remain visible and accessible even on long question pages, improving your experience by avoiding the need to scroll up to submit answers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout and appearance of action buttons in practice and live quiz components by grouping them in a sticky container with enhanced background, shadow, and padding.
  - Simplified button-level styling for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->