### PR TITLE
chore(cypress): cover inline answer collection definition within templates in end-to-end testing

### DIFF
--- a/cypress/cypress/e2e/K-elements-selection-workflow.cy.ts
+++ b/cypress/cypress/e2e/K-elements-selection-workflow.cy.ts
@@ -547,6 +547,7 @@ describe('Test creation and editing functionalities, validation, etc. for select
   })
 
   it('Verify that a new answer collection was created when creating the selection question', function () {
+    cy.get('[data-cy="analytics"]').should('exist')
     cy.get('[data-cy="resources"]').click()
     cy.get('[data-cy="answer-collections"]').click()
     cy.get(

--- a/cypress/cypress/e2e/V-template-workflow.cy.ts
+++ b/cypress/cypress/e2e/V-template-workflow.cy.ts
@@ -13,8 +13,8 @@ describe('Test all functionalities related to the creation, management, sharing 
     cy.fixture('questions.json').then((questionData) => {
       this.data = questionData
     })
-    cy.fixture('V-template.json').then((liveQuizData) => {
-      this.data = { ...this.data, ...liveQuizData }
+    cy.fixture('V-template.json').then((questionData) => {
+      this.data = { ...this.data, ...questionData }
     })
   })
 
@@ -2454,6 +2454,139 @@ describe('Test all functionalities related to the creation, management, sharing 
   })
   // #endregion
 
+  // ! Part 3: Use the live quiz template with inline answer collection definitions
+  // #region
+  it('Open the live quiz template in the catalog and enter new selection and case study elements with inline answer collections', function () {
+    cy.loginInstitutionalCatalyst()
+    cy.get('[data-cy="analytics"]').should('exist')
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="catalog"]').click()
+
+    // open the template and complete the necessary parts of the settings step
+    cy.get(
+      `[data-cy="catalog-object-${this.data.liveQuiz.template1.name}"]`
+    ).realClick()
+    cy.get('[data-cy="live-quiz-template-settings"]').click()
+    cy.get('[data-cy="template-live-quiz-name"]')
+      .click()
+      .clear()
+      .type(this.data.activity3.name)
+    cy.get('[data-cy="template-live-quiz-display-name"]')
+      .click()
+      .clear()
+      .type(this.data.activity3.displayName)
+    cy.get('[data-cy="template-live-quiz-course"]').contains(
+      messages.manage.activityWizard.liveQuizNoCourse
+    )
+    cy.get('[data-cy="submit-template-settings"]').click()
+
+    // accept all elements up to the first selection / case study element
+    cy.wrap(['0-0', '0-1', '0-2', '0-3', '0-4']).each((identifier: string) => {
+      cy.get(`[data-cy="accept-template-element-${identifier}"]`).click()
+      cy.get(`[data-cy="next-template-element-${identifier}"]`).click()
+    })
+
+    // modify the selection element using an inline answer collection definition
+    cy.get(`[data-cy="create-new-element-template-0-5"]`).click()
+    cy.get('[data-cy="insert-question-title"]')
+      .click()
+      .clear()
+      .type(this.data.activity3.SETitle)
+    cy.get('[data-cy="create-inline-answer-collection"]').click()
+    cy.wrap(this.data.collection.options).each((option: string) => {
+      cy.get('#inline-answer-collection-options').type(`${option}{enter}`)
+    })
+    cy.get('[data-cy="configure-number-of-inputs"]').click().clear().type('2')
+    cy.get('[data-cy="save-new-question"]').click()
+    cy.get(`[data-cy="next-template-element-0-5"]`).click()
+
+    // modify the case study element, defining another inline answer collection
+    cy.get(`[data-cy="create-new-element-template-0-6"]`).click()
+    cy.get('[data-cy="insert-question-title"]')
+      .click()
+      .clear()
+      .type(this.data.activity3.CSTitle)
+    cy.get('[data-cy="create-inline-answer-collection"]').click()
+    cy.wrap(this.data.collection2.options).each((option: string) => {
+      cy.get('#inline-answer-collection-options').type(`${option}{enter}`)
+    })
+    cy.get('[data-cy="save-new-question"]').click()
+    cy.get(`[data-cy="next-template-element-0-6"]`).click()
+
+    // accept all remaining instances as contained in the template
+    cy.wrap([
+      '1-0',
+      '1-1',
+      '1-2',
+      '1-3',
+      '1-4',
+      '1-5',
+      '1-6',
+      '2-0',
+      '2-1',
+      '2-2',
+    ]).each((identifier: string) => {
+      cy.get(`[data-cy="accept-template-element-${identifier}"]`).click()
+      cy.get(`[data-cy="next-template-element-${identifier}"]`).click()
+    })
+
+    // confirm live quiz creation and verify successful redirect
+    cy.get(`[data-cy="live-quiz-template-submit"]`).click()
+    cy.get(`[data-cy="activity-LIVE_QUIZ-${this.data.activity3.name}"]`).should(
+      'exist'
+    )
+  })
+
+  it('Verify that the elements and the answer collection have been created correctly', function () {
+    cy.loginInstitutionalCatalyst()
+
+    // verify that the content of the selection element has been stored correctly
+    cy.get(`[data-cy="edit-element-${this.data.activity3.SETitle}"]`).click()
+    cy.get('[data-cy="create-inline-answer-collection"]').should('not.exist') // ensure that switching to manual item creation is not possible during editing
+    cy.get('[id="selection-0-field-0"]').click()
+    cy.wrap(this.data.collection.options).each((value: string) => {
+      cy.findByText(value).should('exist') // verify that correct options are available for selection
+    })
+    cy.get('[data-cy="close-element-modal"]').click()
+
+    // verify that the content of the case study element has been stored correctly
+    cy.get(`[data-cy="edit-element-${this.data.activity3.CSTitle}"]`).click()
+    cy.get('[data-cy="create-inline-answer-collection"]').should('not.exist') // ensure that switching to manual item creation is not possible during editing
+    cy.wrap(this.data.collection2.options).each((item: string) => {
+      cy.get('[data-cy="choose-case-study-items"]').contains(item) // verify that the correct items are available for assessment
+    })
+    cy.get('[data-cy="close-element-modal"]').click()
+
+    // verify that the answer collection based on the selection question has been created correctly
+    cy.get('[data-cy="resources"]').click()
+    cy.get('[data-cy="answer-collections"]').click()
+    const SECollection = `AC: ${this.data.activity3.SETitle}`
+    cy.get(`[data-cy="answer-collection-actions-${SECollection}"]`).click()
+    cy.get('[data-cy="edit-answer-collection"]').click()
+
+    cy.get('[data-cy="open-answer-collection-options"]').click()
+    cy.wrap(this.data.collection.options).each((item: string) => {
+      cy.get(`[data-cy="delete-answer-option-${item}"]`).should(
+        'not.be.disabled'
+      )
+      cy.get(`[data-cy="edit-answer-option-${item}"]`).should('not.be.disabled')
+    })
+    cy.get("[data-cy='close-answer-collection-edit-modal']").click()
+
+    // verify that the answer collection based on the case study question has been created correctly
+    const CSCollection = `AC: ${this.data.activity3.CSTitle}`
+    cy.get(`[data-cy="answer-collection-actions-${CSCollection}"]`).click()
+    cy.get('[data-cy="edit-answer-collection"]').click()
+
+    cy.get('[data-cy="open-answer-collection-options"]').click()
+    cy.wrap(this.data.collection2.options).each((item: string) => {
+      cy.get(`[data-cy="delete-answer-option-${item}"]`).should('be.disabled')
+      cy.get(`[data-cy="edit-answer-option-${item}"]`).should('not.be.disabled')
+    })
+    cy.get("[data-cy='close-answer-collection-edit-modal']").click()
+  })
+  // #endregion
+
   // ! Cleanup: Deletion of all created templates, activities and questions
   // #region
   it('Delete all created templates', function () {
@@ -2473,43 +2606,5 @@ describe('Test all functionalities related to the creation, management, sharing 
     ).click()
     cy.get('[data-cy="confirm-template-deletion"]').click()
   })
-
-  it('Delete all created activities', function () {
-    cy.loginLecturer()
-    cy.get(`[data-cy="activities"]`).click()
-
-    cy.get(`[data-cy="activity-LIVE_QUIZ-${this.data.activity1.name}"]`).should(
-      'exist'
-    )
-    cy.get(
-      `[data-cy="actions-LIVE_QUIZ-${this.data.activity1.name}"]`
-    ).realClick()
-    cy.get(`[data-cy="delete-live-quiz-${this.data.activity1.name}"]`).click()
-    cy.get(`[data-cy="confirm-deletion-responses"]`).should('not.exist') // ? azure functions do not work in cypress CI actions
-    cy.get(`[data-cy="confirm-deletion-qa-feedbacks"]`).should('not.exist')
-    cy.get(`[data-cy="confirm-deletion-confusion-feedbacks"]`).should(
-      'not.exist'
-    )
-    cy.get(`[data-cy="confirmation-modal-confirm"]`).click()
-    cy.findByText(this.data.activity1.name).should('not.exist')
-
-    cy.loginIndividualCatalyst()
-    cy.get(`[data-cy="activities"]`).click()
-    cy.get(`[data-cy="activity-LIVE_QUIZ-${this.data.activity2.name}"]`).should(
-      'exist'
-    )
-    cy.get(
-      `[data-cy="actions-LIVE_QUIZ-${this.data.activity2.name}"]`
-    ).realClick()
-    cy.get(`[data-cy="delete-live-quiz-${this.data.activity2.name}"]`).click()
-    cy.get(`[data-cy="confirm-deletion-responses"]`).should('not.exist') // ? azure functions do not work in cypress CI actions
-    cy.get(`[data-cy="confirm-deletion-qa-feedbacks"]`).should('not.exist')
-    cy.get(`[data-cy="confirm-deletion-confusion-feedbacks"]`).should(
-      'not.exist'
-    )
-    cy.get(`[data-cy="confirmation-modal-confirm"]`).click()
-    cy.findByText(this.data.activity2.name).should('not.exist')
-  })
-
   // #endregion
 })

--- a/cypress/cypress/fixtures/V-template.json
+++ b/cypress/cypress/fixtures/V-template.json
@@ -76,5 +76,11 @@
         "content": "CS Content NEW & MODIFIED"
       }
     }
+  },
+  "activity3": {
+    "name": "Live Quiz Activity 3",
+    "displayName": "Live Quiz Activity 3 (Display)",
+    "SETitle": "SE Title INLINE COLLECTION",
+    "CSTitle": "CS Title INLINE COLLECTION"
   }
 }

--- a/packages/graphql/src/services/resources.ts
+++ b/packages/graphql/src/services/resources.ts
@@ -45,6 +45,7 @@ export async function createAnswerCollection(
   },
   ctx: ContextWithUser
 ) {
+  let counter: number | null = null
   const oldCollection = await ctx.prisma.answerCollection.findUnique({
     where: {
       ownerId_name: {
@@ -54,15 +55,39 @@ export async function createAnswerCollection(
     },
   })
 
-  // if collection already exists for the user, notify him that a new name needs to be chosen
+  // if collection already exists try to increment the version number
   if (oldCollection) {
-    return null
+    // check if a suitable name has been identified
+    let success = false
+
+    // iterate until no collection with the selected name exists
+    for (let i = 0; i < 10; i++) {
+      counter = (counter ?? 0) + 1
+      const newName = `${name} (${counter})`
+      const existingCollection = await ctx.prisma.answerCollection.findUnique({
+        where: {
+          ownerId_name: {
+            ownerId: ctx.user.sub,
+            name: newName,
+          },
+        },
+      })
+
+      if (!existingCollection) {
+        success = true
+        break
+      }
+    }
+
+    if (!success) {
+      return null
+    }
   }
 
   const collection = await ctx.prisma.$transaction(async (prisma) => {
     const newCollection = await prisma.answerCollection.create({
       data: {
-        name,
+        name: counter ? `${name} (${counter})` : name,
         description,
         entries: {
           create: answers.map((answer) => ({

--- a/packages/graphql/test/resources.test.ts
+++ b/packages/graphql/test/resources.test.ts
@@ -143,7 +143,8 @@ describe('Unit tests for resource management (e.g. answer collections)', () => {
       },
       userOneCtx
     )
-    expect(res).toBeNull()
+    expect(res).toBeTruthy()
+    expect(res!.name).toBe(`${answerCollection1.name} (1)`)
   })
 
   it('Verify that all users with access to the answer collection can use the query to include it in elements', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced test coverage for selection workflows and template workflows, including scenarios with inline answer collections and live quiz templates.
  - Added a new activity entry in the template fixture data to support expanded testing.

- **Bug Fixes**
  - Improved the creation process for answer collections to automatically suggest a unique name if a duplicate exists, reducing naming conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->