### PR TITLE
enhance(apps/frontend-manage): add confidence intervals when hovering over case study scatter plot items

### DIFF
--- a/apps/frontend-manage/src/components/evaluation/elements/CSEvaluationScatter.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/CSEvaluationScatter.tsx
@@ -35,6 +35,8 @@ export type CaseStudyScatterPlotData = {
     yCriterionName: string
     x: number
     y: number | undefined
+    sigmaX?: number
+    sigmaY?: number
   }[]
 }
 

--- a/apps/frontend-manage/src/components/evaluation/elements/CSOneDimScatterPlot.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/CSOneDimScatterPlot.tsx
@@ -3,8 +3,10 @@ import {
   CaseStudyElementResultCriterionInfo,
 } from '@klicker-uzh/graphql/dist/ops'
 import { CHART_COLORS } from '@klicker-uzh/shared-components/src/constants'
+import { useState } from 'react'
 import {
   CartesianGrid,
+  ErrorBar,
   LabelList,
   Legend,
   ResponsiveContainer,
@@ -38,6 +40,14 @@ function CSOneDimScatterPlot({
   xLower: number
   xUpper: number
 }) {
+  // state for hover to show error bars
+  const [hoveredPoint, setHoveredPoint] = useState<{
+    caseId: string
+    itemLabel: string
+    x: number
+    caseIndex: number
+  } | null>(null)
+
   // get the criterion object for the X axis
   const xCriterionObj = criteria.find((c) => c.id === xCriterion)
 
@@ -54,7 +64,7 @@ function CSOneDimScatterPlot({
     : undefined
 
   return (
-    <ResponsiveContainer width="99%" height="50%">
+    <ResponsiveContainer width="99%" height="99%">
       <ScatterChart
         margin={{
           top: 20,
@@ -65,6 +75,7 @@ function CSOneDimScatterPlot({
       >
         <CartesianGrid />
         <XAxis
+          allowDataOverflow
           type="number"
           dataKey="x"
           domain={[xLower, xUpper]}
@@ -145,9 +156,14 @@ function CSOneDimScatterPlot({
           tickLine={true}
         />
         <YAxis
+          allowDataOverflow
           type="number"
           dataKey="caseId"
-          domain={[0, selectedCases.length - 1]}
+          domain={[
+            -(0.1 * selectedCases.length),
+            selectedCases.length - 1 + 0.1 * selectedCases.length,
+          ]}
+          ticks={selectedCases.map((_, index) => index)}
           tickFormatter={(tick) => cases[tick]?.name || ''}
           className={textSize.textLg}
         />
@@ -160,7 +176,7 @@ function CSOneDimScatterPlot({
             return (
               <div className="rounded-md border-2 border-black bg-white p-2">
                 <p className="font-bold">{data.itemLabel}</p>
-                <p>{`${data.xCriterionName}: ${getLabelForValue(data.x, xCriterionObj, xLower, xUpper)}`}</p>
+                <p>{`${data.xCriterionName}: ${getLabelForValue(data.x, xCriterionObj, xLower, xUpper)} ${typeof data.sigmaX !== 'undefined' ? `(± ${data.sigmaX.toFixed(2)})` : ''}`}</p>
               </div>
             )
           }}
@@ -168,30 +184,101 @@ function CSOneDimScatterPlot({
         {selectedCases.map((caseId, index) => {
           const caseIx = cases.findIndex((c) => c.id === caseId)
 
+          // do not show the currently hovered point in the scatter plot
+          const filteredData = hoveredPoint
+            ? scatterData[caseId]
+                .map((data) => ({ ...data, caseId: index }))
+                .filter(
+                  (point) =>
+                    !(
+                      hoveredPoint.caseId === caseId &&
+                      hoveredPoint.itemLabel === point.itemLabel
+                    )
+                )
+            : scatterData[caseId].map((data) => ({ ...data, caseId: index }))
+
           return (
             <Scatter
               key={caseId}
               name={cases[caseIx]?.name}
-              data={scatterData[caseId].map((data) => ({
-                ...data,
-                x: data.x,
-                caseId: index,
-              }))}
+              data={filteredData}
               fill={CHART_COLORS[caseIx % 12]}
               shape={(props: any) => (
-                <circle cx={props.cx} cy={props.cy} r={6} fill={props.fill} />
+                <circle
+                  cx={props.cx}
+                  cy={props.cy}
+                  r={6}
+                  fill={props.fill}
+                  onMouseEnter={() =>
+                    setHoveredPoint({
+                      caseId,
+                      itemLabel: props.payload.itemLabel,
+                      x: props.payload.x,
+                      caseIndex: index,
+                    })
+                  }
+                  onMouseLeave={() => setHoveredPoint(null)}
+                  style={{ cursor: 'pointer' }}
+                />
               )}
               isAnimationActive={false}
             >
               <LabelList
                 dataKey="itemLabel"
-                position="top"
+                position={index === 0 ? 'top' : 'bottom'}
                 offset={8}
                 className={textSize.textLg}
               />
             </Scatter>
           )
         })}
+
+        {/* render the hovered point with error bars */}
+        {hoveredPoint &&
+          selectedCases.map((caseId) => {
+            if (caseId !== hoveredPoint.caseId) return null
+            const caseIx = cases.findIndex((c) => c.id === caseId)
+            const hoveredPointData = scatterData[caseId]
+              .filter((point) => point.itemLabel === hoveredPoint.itemLabel)
+              .map((data) => ({
+                ...data,
+                caseId: hoveredPoint.caseIndex,
+              }))
+
+            if (hoveredPointData.length === 0) return null
+
+            return (
+              <Scatter
+                legendType="none"
+                key={`${caseId}-hovered`}
+                data={hoveredPointData}
+                fill={CHART_COLORS[caseIx % 12]}
+                shape={(props: any) => (
+                  <circle
+                    cx={props.cx}
+                    cy={props.cy}
+                    r={8}
+                    fill={props.fill}
+                    opacity={1}
+                    stroke="#000"
+                    strokeWidth={1}
+                    onMouseLeave={() => setHoveredPoint(null)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                )}
+                isAnimationActive={false}
+              >
+                <ErrorBar
+                  dataKey="sigmaX"
+                  width={4}
+                  strokeWidth={2}
+                  opacity={0.8}
+                  stroke={CHART_COLORS[caseIx % 12]}
+                  direction="x"
+                />
+              </Scatter>
+            )
+          })}
         <Legend
           align="right"
           verticalAlign="top"

--- a/apps/frontend-manage/src/components/evaluation/elements/CSOneDimScatterPlot.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/CSOneDimScatterPlot.tsx
@@ -73,7 +73,7 @@ function CSOneDimScatterPlot({
           left: 30,
         }}
       >
-        <CartesianGrid />
+        <CartesianGrid vertical={true} horizontal={false} />
         <XAxis
           allowDataOverflow
           type="number"

--- a/apps/frontend-manage/src/components/evaluation/elements/CSTwoDimScatterPlot.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/CSTwoDimScatterPlot.tsx
@@ -3,8 +3,10 @@ import {
   CaseStudyElementResultCriterionInfo,
 } from '@klicker-uzh/graphql/dist/ops'
 import { CHART_COLORS } from '@klicker-uzh/shared-components/src/constants'
+import { useState } from 'react'
 import {
   CartesianGrid,
+  ErrorBar,
   LabelList,
   Legend,
   ResponsiveContainer,
@@ -47,6 +49,14 @@ function CSTwoDimScatterPlot({
   const xCriterionObj = criteria.find((c) => c.id === xCriterion)
   const yCriterionObj = criteria.find((c) => c.id === yCriterion)
 
+  // state for hover to show error bars
+  const [hoveredPoint, setHoveredPoint] = useState<{
+    caseId: string
+    itemLabel: string
+    x: number
+    y: number
+  } | null>(null)
+
   // check if labels exist for the criteria
   const xHasLabels = !!(
     xCriterionObj?.labels?.min && xCriterionObj?.labels?.max
@@ -80,6 +90,7 @@ function CSTwoDimScatterPlot({
       >
         <CartesianGrid />
         <XAxis
+          allowDataOverflow
           type="number"
           dataKey="x"
           domain={[xLower, xUpper]}
@@ -160,6 +171,7 @@ function CSTwoDimScatterPlot({
           tickLine={true}
         />
         <YAxis
+          allowDataOverflow
           type="number"
           dataKey="y"
           domain={[yLower, yUpper]}
@@ -167,7 +179,7 @@ function CSTwoDimScatterPlot({
             value: yCriterionObj?.name,
             angle: -90,
             position: 'left',
-            offset: -10,
+            offset: -7,
             className: textSize.textXl,
           }}
           tick={(props) => {
@@ -251,33 +263,119 @@ function CSTwoDimScatterPlot({
                 <p className="font-bold">{data.itemLabel}</p>
                 <p>{`${data.xCriterionName}: ${getLabelForValue(data.x, xCriterionObj, xLower, xUpper)}`}</p>
                 <p>{`${data.yCriterionName}: ${getLabelForValue(data.y, yCriterionObj, yLower, yUpper)}`}</p>
+                {data.sigmaX &&
+                  data.sigmaY &&
+                  data.aggregationType === 'mean' && (
+                    <p className="text-xs italic">{`Standard Deviation: X: ±${data.sigmaX.toFixed(2)}, Y: ±${data.sigmaY.toFixed(2)}`}</p>
+                  )}
               </div>
             )
           }}
         />
+
+        {/* render the base scatter points for all cases & values */}
         {selectedCases.map((caseId) => {
           const caseIx = cases.findIndex((c) => c.id === caseId)
+
+          // do not show the currently hovered point in the scatter plot
+          const filteredData = hoveredPoint
+            ? scatterData[caseId].filter(
+                (point) =>
+                  !(
+                    hoveredPoint.caseId === caseId &&
+                    hoveredPoint.itemLabel === point.itemLabel
+                  )
+              )
+            : scatterData[caseId]
 
           return (
             <Scatter
               key={caseId}
               name={cases[caseIx]?.name}
-              data={scatterData[caseId]}
+              data={filteredData}
               fill={CHART_COLORS[caseIx % 12]}
               shape={(props: any) => (
-                <circle cx={props.cx} cy={props.cy} r={6} fill={props.fill} />
+                <circle
+                  cx={props.cx}
+                  cy={props.cy}
+                  r={6}
+                  fill={props.fill}
+                  opacity={0.8}
+                  onMouseEnter={() =>
+                    setHoveredPoint({
+                      caseId,
+                      itemLabel: props.payload.itemLabel,
+                      x: props.payload.x,
+                      y: props.payload.y,
+                    })
+                  }
+                  onMouseLeave={() => setHoveredPoint(null)}
+                  style={{ cursor: 'pointer' }}
+                />
               )}
               isAnimationActive={false}
             >
               <LabelList
                 dataKey="itemLabel"
-                position="top"
+                position="bottom"
                 offset={8}
                 className={textSize.textLg}
               />
             </Scatter>
           )
         })}
+
+        {/* render the hovered point with error bars */}
+        {hoveredPoint &&
+          selectedCases.map((caseId) => {
+            if (caseId !== hoveredPoint.caseId) return null
+
+            const caseIx = cases.findIndex((c) => c.id === caseId)
+            const hoveredPointData = scatterData[caseId].filter(
+              (point) => point.itemLabel === hoveredPoint.itemLabel
+            )
+            if (hoveredPointData.length === 0) return null
+
+            return (
+              <Scatter
+                legendType="none"
+                key={`${caseId}-hovered`}
+                data={hoveredPointData}
+                fill={CHART_COLORS[caseIx % 12]}
+                shape={(props: any) => (
+                  <circle
+                    cx={props.cx}
+                    cy={props.cy}
+                    r={8}
+                    fill={props.fill}
+                    opacity={1}
+                    stroke="#000"
+                    strokeWidth={1}
+                    onMouseLeave={() => setHoveredPoint(null)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                )}
+                isAnimationActive={false}
+              >
+                <ErrorBar
+                  dataKey="sigmaX"
+                  width={4}
+                  strokeWidth={2}
+                  opacity={0.8}
+                  stroke={CHART_COLORS[caseIx % 12]}
+                  direction="x"
+                />
+                <ErrorBar
+                  dataKey="sigmaY"
+                  width={4}
+                  strokeWidth={2}
+                  opacity={0.8}
+                  stroke={CHART_COLORS[caseIx % 12]}
+                  direction="y"
+                />
+              </Scatter>
+            )
+          })}
         <Legend
           align="right"
           verticalAlign="top"

--- a/apps/frontend-manage/src/components/evaluation/elements/CSTwoDimScatterPlot.tsx
+++ b/apps/frontend-manage/src/components/evaluation/elements/CSTwoDimScatterPlot.tsx
@@ -263,13 +263,8 @@ function CSTwoDimScatterPlot({
             return (
               <div className="rounded-md border-2 border-black bg-white p-2">
                 <p className="font-bold">{data.itemLabel}</p>
-                <p>{`${data.xCriterionName}: ${getLabelForValue(data.x, xCriterionObj, xLower, xUpper)}`}</p>
-                <p>{`${data.yCriterionName}: ${getLabelForValue(data.y, yCriterionObj, yLower, yUpper)}`}</p>
-                {data.sigmaX &&
-                  data.sigmaY &&
-                  data.aggregationType === 'mean' && (
-                    <p className="text-xs italic">{`Standard Deviation: X: ±${data.sigmaX.toFixed(2)}, Y: ±${data.sigmaY.toFixed(2)}`}</p>
-                  )}
+                <p>{`${data.xCriterionName}: ${getLabelForValue(data.x, xCriterionObj, xLower, xUpper)} ${typeof data.sigmaX !== 'undefined' ? `(± ${data.sigmaX.toFixed(2)})` : ''}`}</p>
+                <p>{`${data.yCriterionName}: ${getLabelForValue(data.y, yCriterionObj, yLower, yUpper)} ${typeof data.sigmaY !== 'undefined' ? `(± ${data.sigmaY.toFixed(2)})` : ''}`}</p>
               </div>
             )
           }}

--- a/apps/frontend-manage/src/components/evaluation/hooks/useCaseStudyScatterData.tsx
+++ b/apps/frontend-manage/src/components/evaluation/hooks/useCaseStudyScatterData.tsx
@@ -74,6 +74,14 @@ function useCaseStudyScatterData({
             yCriterionName: yCriterionObject?.name ?? '',
             x: xValue,
             y: yValue,
+            sigmaX:
+              aggregationType === 'mean'
+                ? xCriterionObject?.statistics?.sd
+                : undefined, // standard deviation in x direction (only set around mean)
+            sigmaY:
+              aggregationType === 'mean'
+                ? yCriterionObject?.statistics?.sd
+                : undefined, // standard deviation in y direction (only set around mean)
           }
         })
 
@@ -103,6 +111,7 @@ function useCaseStudyScatterData({
     xCriterion,
     yCriterion,
     aggregationType,
+    setInitialLoading,
   ])
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scatter plots now display error bars for standard deviations in X and Y when available and aggregation type is "mean".
  - Enhanced scatter plot interactivity: hovering over a point highlights it with increased size, stroke, and opacity, and shows detailed statistical information, including standard deviations.
  - Tooltips now include standard deviation values for X and Y when applicable.

- **Style**
  - Improved visual feedback and label positioning for scatter plot points.
  - Adjusted axis settings to allow data overflow and refined label offsets for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->