### PR TITLE
chore(cypress): extend e2e testing to cover participation in gamified live quiz without participant account

### DIFF
--- a/apps/frontend-manage/src/components/common/Header.tsx
+++ b/apps/frontend-manage/src/components/common/Header.tsx
@@ -218,12 +218,14 @@ function Header({ user }: { user?: User | null }): React.ReactElement {
           quizzes?.length !== 0 ? 'text-green-600' : 'text-slate-400'
         ),
       },
+      data: { cy: 'running-live-quiz-dropdown' },
       elements:
         quizzes?.map((quiz) => ({
           key: quiz.id,
           type: 'link',
           label: quiz.name,
           onClick: () => router.push(`/quizzes/${quiz.id}/cockpit`),
+          data: { cy: `running-live-quiz-${quiz.name}` },
         })) ?? [],
     },
     {

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
@@ -46,6 +46,7 @@ function LiveQuizQRModal({
               className={{ title: 'text-base', canvas: 'flex justify-center' }}
               path={accountRelativeLink}
               width={100}
+              data={{ cy: 'qr-link-shortname' }}
             />
             <Link passHref href={`/qr${accountRelativeLink}`} target="_blank">
               <Button
@@ -72,14 +73,10 @@ function LiveQuizQRModal({
               className={{ title: 'text-base', canvas: 'flex justify-center' }}
               path={quizRelativeLink}
               width={100}
+              data={{ cy: 'qr-link-direct' }}
             />
             <Link passHref href={`/qr${quizRelativeLink}`} target="_blank">
-              <Button
-                fluid
-                primary
-                className={{ root: 'mt-2' }}
-                data={{ cy: `qr-direct-link-${quizId}` }}
-              >
+              <Button fluid primary className={{ root: 'mt-2' }}>
                 <Button.Label>{t('manage.general.presentQrCode')}</Button.Label>
               </Button>
             </Link>

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizTimeline.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizTimeline.tsx
@@ -147,7 +147,7 @@ function LiveQuizTimeline({
             <Button
               className={{ root: 'h-8 sm:w-max' }}
               onClick={() => setQRModal(true)}
-              data={{ cy: `qr-modal-${quizId}` }}
+              data={{ cy: 'open-qr-modal' }}
             >
               <Button.Icon icon={faQrcode} />
               <Button.Label> {t('manage.general.qrCode')}</Button.Label>

--- a/apps/frontend-manage/src/pages/qr/[...args].tsx
+++ b/apps/frontend-manage/src/pages/qr/[...args].tsx
@@ -18,6 +18,7 @@ interface Props {
   showLink?: boolean
   showButton?: boolean
   showLogo?: boolean
+  data?: { cy?: string; test?: string }
 }
 
 export function QR({
@@ -27,6 +28,7 @@ export function QR({
   showLink = true,
   showButton = true,
   showLogo = true,
+  data,
 }: Props): React.ReactElement {
   const t = useTranslations()
 
@@ -55,6 +57,8 @@ export function QR({
             )}
             target="_blank"
             rel="noopener noreferrer"
+            data-cy={data?.cy}
+            data-test={data?.test}
           >
             {process.env.NEXT_PUBLIC_PWA_URL}
             {path}

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -162,6 +162,7 @@ function Header({
                       </div>
                     ),
                     className: { item: '!h-max py-0.5' },
+                    data: { cy: 'header-logged-in-as' },
                   },
                   {
                     id: 'separator',

--- a/apps/frontend-pwa/src/components/liveQuiz/AccountSelector.tsx
+++ b/apps/frontend-pwa/src/components/liveQuiz/AccountSelector.tsx
@@ -256,6 +256,7 @@ function AccountSelector({
                   label={t('shared.generic.pseudonym')}
                   placeholder="klicker123"
                   className={{ label: 'text-sm' }}
+                  data={{ cy: 'pseudonym-input' }}
                 />
                 <Button
                   type="button"
@@ -266,6 +267,7 @@ function AccountSelector({
                   }
                   onClick={() => setStep('avatar')}
                   className={{ root: 'mt-2 self-end' }}
+                  data={{ cy: 'pseudonym-next-step' }}
                 >
                   <Button.Icon icon={faArrowRight} />
                   <Button.Label>{t('shared.generic.next')}</Button.Label>
@@ -343,14 +345,23 @@ function AccountSelector({
                       </div>
                     ))}
                   </CarouselContent>
-                  <CarouselPrevious type="button" className="left-0" />
-                  <CarouselNext type="button" className="right-0" />
+                  <CarouselPrevious
+                    type="button"
+                    className="left-0"
+                    data-cy="avatar-carousel-prev"
+                  />
+                  <CarouselNext
+                    type="button"
+                    className="right-0"
+                    data-cy="avatar-carousel-next"
+                  />
                 </Carousel>
                 <Button
                   primary
                   type="submit"
                   loading={loggingIn}
                   className={{ root: 'mt-2 self-end' }}
+                  data={{ cy: 'submit-pseudonym-and-avatar' }}
                 >
                   {t('shared.generic.submit')}
                 </Button>

--- a/cypress/cypress/e2e/O-live-quiz-workflow.cy.ts
+++ b/cypress/cypress/e2e/O-live-quiz-workflow.cy.ts
@@ -1,4 +1,5 @@
 import messages from '../../../packages/i18n/messages/en'
+import { getDatetimeValidationString } from './helpers'
 
 describe('Different live-quiz workflows', function () {
   before(() => {
@@ -3124,6 +3125,295 @@ describe('Different live-quiz workflows', function () {
       ).should('not.exist')
       cy.get(`[data-cy="close-share-object"]`).click()
     })
+  })
+  // #endregion
+
+  // ! Part 6: Participation Modes Live Quiz
+  // #region
+  it('Create a gamified live quiz on which the different access modes can be tested and other activity types to validate limitations of live-quiz specific temporary accounts', function () {
+    cy.loginLecturer()
+    cy.createLiveQuiz({
+      name: this.data.modes.name,
+      displayName: this.data.modes.displayName,
+      courseName: this.data.modes.course,
+      blocks: [
+        { elements: [this.data.SCML.title] },
+        { elements: [this.data.MCML.title] },
+      ],
+    })
+    cy.get('[data-cy="create-new-activity"]').click()
+
+    cy.createPracticeQuiz({
+      name: this.data.modes.practiceQuizName,
+      displayName: this.data.modes.practiceQuizDisplayName,
+      courseName: this.data.modes.course,
+      stacks: [
+        { elements: [this.data.SCML.title] },
+        { elements: [this.data.MCML.title] },
+      ],
+    })
+    cy.get('[data-cy="create-new-activity"]').click()
+
+    cy.createMicroLearning({
+      name: this.data.modes.microLearningName,
+      displayName: this.data.modes.microLearningDisplayName,
+      courseName: this.data.modes.course,
+      startDate: {
+        monthDelta: -3,
+        day: 16,
+        hour: 2,
+        minute: 0,
+        validation: getDatetimeValidationString(-2, '16') + ', 02:00',
+      }, // 2 months in the past at 2:00
+      endDate: {
+        monthDelta: 3,
+        day: 14,
+        hour: 18,
+        minute: 0,
+        validation: getDatetimeValidationString(4, '14') + ', 18:00',
+      }, // 4 months in the future at 18:00
+      stacks: [
+        { elements: [this.data.SCML.title] },
+        { elements: [this.data.MCML.title] },
+      ],
+    })
+    cy.get('[data-cy="create-new-activity"]').click()
+
+    // start live quiz and open first block
+    cy.get('[data-cy="activities"]').click()
+    cy.get(`[data-cy="start-live-quiz-${this.data.modes.name}"]`).click()
+    cy.get('[data-cy="next-block-timeline"]').click()
+    cy.wait(500)
+  })
+
+  it('Choose anonymous participation in live quiz and verify the correct availability of account actions', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="running-live-quiz-dropdown"]').click()
+    cy.get(`[data-cy="running-live-quiz-${this.data.modes.name}"]`).click()
+    cy.get('[data-cy="open-qr-modal"]').click()
+
+    // store the direct link to the live quiz
+    cy.get('[data-cy="qr-link-direct"]').invoke('text').as('quizLink')
+
+    // get the direct link to the live quiz and visit it
+    cy.get('@quizLink').then((quizLink) => {
+      cy.clearAllCookies()
+      cy.clearAllLocalStorage()
+
+      // open the live quiz link and participate in the live quiz anonymously
+      cy.visit(String(quizLink))
+      cy.origin(
+        Cypress.env('URL_STUDENT'),
+        {
+          args: {
+            username: Cypress.env('STUDENT_USERNAME'),
+            password: Cypress.env('STUDENT_PASSWORD'),
+            messages,
+            data: this.data,
+          },
+        },
+        ({ username, password, messages, data }) => {
+          cy.get('[data-cy="participate-anonymously"]').click()
+          cy.get('[data-cy="participate-anonymously"]').should('not.exist') // wait for temporary account creation to finish
+
+          // verify that the correct options are shown in the participant dropdown
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]').should('not.exist')
+          cy.get('[data-cy="header-setup-profile"]').should('not.exist')
+          cy.get('[data-cy="participant-profile-login"]')
+            .should('exist')
+            .contains(messages.shared.generic.login)
+          cy.get('[data-cy="course-docs"]').should('exist')
+          cy.get('[data-cy="language-switch"]').should('exist')
+          cy.get('[data-cy="logout"]').should('not.exist')
+
+          // reload and verify that the anonymous participation choice persists
+          cy.reload()
+          cy.get('[data-cy="participate-anonymously"]').should('not.exist')
+
+          // log in with a valid account and verify that account mode selection is not shown
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="participant-profile-login"]').click()
+          cy.get('[data-cy="username-field"]').type(username)
+          cy.get('[data-cy="password-field"]').type(password)
+          cy.get('[data-cy="submit-login"]').click()
+          cy.get(`[data-cy="live-quiz-${data.modes.displayName}"]`).click()
+          cy.wait(1000)
+
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]')
+            .should('exist')
+            .contains(username)
+          cy.get('[data-cy="participant-profile-login"]')
+            .should('exist')
+            .contains(messages.shared.generic.profile)
+          cy.get('[data-cy="course-docs"]').should('exist')
+          cy.get('[data-cy="language-switch"]').should('exist')
+          cy.get('[data-cy="logout"]').should('exist')
+        }
+      )
+    })
+  })
+
+  it('Choose a temporary pseudonymm and verify the correct availability of account actions', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="running-live-quiz-dropdown"]').click()
+    cy.get(`[data-cy="running-live-quiz-${this.data.modes.name}"]`).click()
+    cy.get('[data-cy="open-qr-modal"]').click()
+
+    // store the direct link to the live quiz
+    cy.get('[data-cy="qr-link-direct"]').invoke('text').as('quizLink')
+
+    // get the direct link to the live quiz and visit it
+    cy.get('@quizLink').then((quizLink) => {
+      cy.clearAllCookies()
+      cy.clearAllLocalStorage()
+
+      // open the live quiz link and participate in the live quiz anonymously
+      cy.visit(String(quizLink))
+      cy.origin(
+        Cypress.env('URL_STUDENT'),
+        { args: { data: this.data } },
+        ({ data }) => {
+          // choose a temporary pseudonym
+          cy.get('[data-cy="create-temporary-pseudonym"]').click()
+          cy.get('[data-cy="cancel-define-pseudonym"]').click()
+          cy.get('[data-cy="create-temporary-pseudonym"]').click()
+          cy.get('[data-cy="pseudonym-input"]').type(data.modes.pseudonym)
+          cy.get('[data-cy="pseudonym-next-step"]').click()
+          cy.get('[data-cy="cancel-choose-avatar"]').click()
+          cy.get('[data-cy="pseudonym-input"]').should(
+            'have.value',
+            data.modes.pseudonym
+          )
+          cy.get('[data-cy="pseudonym-next-step"]').click()
+          cy.get('[data-cy="submit-pseudonym-and-avatar"]').should(
+            'not.be.disabled'
+          )
+          cy.get('[data-cy="avatar-carousel-next"]').click().click()
+          cy.get('[data-cy="avatar-carousel-prev"]').click()
+          cy.get('[data-cy="submit-pseudonym-and-avatar"]').click()
+
+          // verify that the correct options are shown in the participant dropdown
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]')
+            .should('exist')
+            .contains(data.modes.pseudonym)
+          cy.get('[data-cy="header-setup-profile"]').should('not.exist')
+          cy.get('[data-cy="participant-profile-login"]').should('not.exist')
+          cy.get('[data-cy="course-docs"]').should('exist')
+          cy.get('[data-cy="language-switch"]').should('exist')
+          cy.get('[data-cy="logout"]').should('exist')
+
+          // reload and verify that the temporary account is still logged in
+          cy.reload()
+          cy.get('[data-cy="create-temporary-pseudonym"]').should('not.exist')
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]')
+            .should('exist')
+            .contains(data.modes.pseudonym)
+
+          // log out of the current pseudonym and create a new one
+          cy.reload()
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="logout"]').click()
+          cy.get('[data-cy="create-temporary-pseudonym"]').click()
+          cy.get('[data-cy="pseudonym-input"]').type(data.modes.pseudonym2)
+          cy.get('[data-cy="pseudonym-next-step"]').click()
+          cy.get('[data-cy="submit-pseudonym-and-avatar"]').click()
+
+          // verify that the correct options are shown in the participant dropdown
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]')
+            .should('exist')
+            .contains(data.modes.pseudonym2)
+        }
+      )
+    })
+  })
+
+  it('Log in as a regular user and verify that all redirects work correctly', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="running-live-quiz-dropdown"]').click()
+    cy.get(`[data-cy="running-live-quiz-${this.data.modes.name}"]`).click()
+    cy.get('[data-cy="open-qr-modal"]').click()
+
+    // store the direct link to the live quiz
+    cy.get('[data-cy="qr-link-direct"]').invoke('text').as('quizLink')
+
+    // get the direct link to the live quiz and visit it
+    cy.get('@quizLink').then((quizLink) => {
+      cy.clearAllCookies()
+      cy.clearAllLocalStorage()
+
+      // open the live quiz link and participate in the live quiz anonymously
+      cy.visit(String(quizLink))
+      cy.origin(
+        Cypress.env('URL_STUDENT'),
+        {
+          args: {
+            username: Cypress.env('STUDENT_USERNAME'),
+            password: Cypress.env('STUDENT_PASSWORD'),
+            quizLink,
+            messages,
+          },
+        },
+        ({ username, password, quizLink, messages }) => {
+          // choose regular login
+          cy.get('[data-cy="login-with-account"]').click()
+          cy.get('[data-cy="username-field"]').type(username)
+          cy.get('[data-cy="password-field"]').type(password)
+          cy.get('[data-cy="submit-login"]').click()
+          cy.wait(1000) // wait for the live quiz to load
+
+          // verify that the participant has been automatically redirected to the live quiz
+          cy.location('href').then((href) => {
+            expect(href).to.include(quizLink)
+          })
+
+          // verify that the correct account actions are available
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]')
+            .should('exist')
+            .contains(username)
+          cy.get('[data-cy="participant-profile-login"]')
+            .should('exist')
+            .contains(messages.shared.generic.profile)
+          cy.get('[data-cy="course-docs"]').should('exist')
+          cy.get('[data-cy="language-switch"]').should('exist')
+          cy.get('[data-cy="logout"]').should('exist')
+
+          // verify that login persists on reload
+          cy.reload()
+          cy.get('[data-cy="header-avatar"]').click()
+          cy.get('[data-cy="header-logged-in-as"]')
+            .should('exist')
+            .contains(username)
+        }
+      )
+    })
+  })
+
+  it('Visit the live quiz leaderboard and check out that valid temporary participants are visible', function () {
+    cy.loginLecturer()
+    cy.get('[data-cy="activities"]').click()
+    cy.get(`[data-cy="live-quiz-cockpit-${this.data.modes.name}"]`).click()
+    cy.wait(1000)
+
+    // extract the quiz id from the URL and visit the evaluation view
+    cy.location('href').then((href) => {
+      const quizId = href.split('/')[4]
+      cy.visit(`${Cypress.env('URL_MANAGE')}/quizzes/${quizId}/evaluation`)
+    })
+    cy.get('[data-cy="evaluation-leaderboard"]').click()
+
+    // check that the user with "pseudonym" usename is not available, but the one with "pseudonym2" is
+    cy.get(`[data-cy="leaderboard-entry-${this.data.modes.pseudonym}"]`).should(
+      'not.exist'
+    )
+    cy.get(`[data-cy="leaderboard-entry-${this.data.modes.pseudonym2}"]`)
+      .should('exist')
+      .contains(this.data.modes.pseudonym2)
   })
   // #endregion
 })

--- a/cypress/cypress/fixtures/O-live-quiz.json
+++ b/cypress/cypress/fixtures/O-live-quiz.json
@@ -49,5 +49,16 @@
     "group2": "Group 2",
     "group3": "Group 3",
     "group4": "Group 4"
+  },
+  "modes": {
+    "course": "Testkurs",
+    "name": "Live Quiz 4",
+    "displayName": "Live Quiz 4 (Display)",
+    "practiceQuizName": "Practice Quiz",
+    "practiceQuizDisplayName": "Practice Quiz (Display)",
+    "microLearningName": "Micro Learning Quiz",
+    "microLearningDisplayName": "Micro Learning Quiz (Display)",
+    "pseudonym": "klickerMaster",
+    "pseudonym2": "klickerAmateur"
   }
 }

--- a/packages/shared-components/src/Participant.tsx
+++ b/packages/shared-components/src/Participant.tsx
@@ -42,6 +42,7 @@ function Participant({
         className
       )}
       onClick={onClick}
+      data-cy={`leaderboard-entry-${pseudonym}`}
     >
       <div className="flex flex-1 flex-row items-center gap-2">
         {rank && <div className="ml-1 w-3 text-lg font-bold">{rank}</div>}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unique data attributes to various interactive elements (such as dropdowns, buttons, and leaderboard entries) to enhance testability and facilitate end-to-end testing.
  - Introduced new end-to-end tests covering multiple participation modes in live quizzes, including anonymous, pseudonym, and regular user scenarios.
  - Expanded test fixtures with quiz mode data for comprehensive test coverage.

- **Tests**
  - Added extensive Cypress tests for live quiz participation workflows and leaderboard validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->