### PR TITLE
refactor(apps/frontend-*): improve rendering efficiency by ensuring that modals are only rendered when required

### DIFF
--- a/apps/frontend-control/src/components/layout/MobileMenuBar.tsx
+++ b/apps/frontend-control/src/components/layout/MobileMenuBar.tsx
@@ -45,13 +45,12 @@ function MobileMenuBar({ quizId }: MobileMenuBarProps) {
         </MenuButton>
       </div>
 
-      {quizId && (
+      {quizId && embedModalOpen ? (
         <EmbeddingModal
-          open={embedModalOpen}
-          setOpen={setEmbedModalOpen}
+          onClose={() => setEmbedModalOpen(false)}
           quizId={quizId}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/apps/frontend-control/src/components/liveQuizzes/EmbeddingModal.tsx
+++ b/apps/frontend-control/src/components/liveQuizzes/EmbeddingModal.tsx
@@ -10,12 +10,6 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useMemo } from 'react'
 
-interface EmbeddingModalProps {
-  open: boolean
-  setOpen: (newValue: boolean) => void
-  quizId: string
-}
-
 function HMACLink({
   quizId,
   hmac,
@@ -53,7 +47,13 @@ function HMACLink({
   )
 }
 
-function EmbeddingModal({ open, setOpen, quizId }: EmbeddingModalProps) {
+function EmbeddingModal({
+  onClose,
+  quizId,
+}: {
+  onClose: () => void
+  quizId: string
+}) {
   const t = useTranslations()
   const { data: dataLiveQuiz } = useQuery(GetSingleLiveQuizDocument, {
     variables: { quizId: quizId || '' },
@@ -73,10 +73,10 @@ function EmbeddingModal({ open, setOpen, quizId }: EmbeddingModalProps) {
 
   return (
     <Modal
+      open
       hideCloseButton
-      open={open}
-      onClose={() => setOpen(false)}
-      onSecondaryAction={() => setOpen(false)}
+      onClose={onClose}
+      onSecondaryAction={onClose}
       secondaryLabel={t('shared.generic.close')}
       dataSecondaryAction={{ cy: 'close-embedding-modal' }}
     >

--- a/apps/frontend-control/src/components/liveQuizzes/LiveQuizLists.tsx
+++ b/apps/frontend-control/src/components/liveQuizzes/LiveQuizLists.tsx
@@ -106,7 +106,7 @@ function LiveQuizLists({
         <StartModal
           quizId={startId}
           quizName={startName}
-          setStartModalOpen={setStartModalOpen}
+          onClose={() => setStartModalOpen(false)}
         />
       )}
     </>

--- a/apps/frontend-control/src/components/liveQuizzes/LiveQuizLists.tsx
+++ b/apps/frontend-control/src/components/liveQuizzes/LiveQuizLists.tsx
@@ -99,17 +99,16 @@ function LiveQuizLists({
         <div>{t('control.course.noPlannedLiveQuizzes')}</div>
       )}
 
-      <EmbeddingModal
-        open={embedOpen}
-        setOpen={(newValue: boolean) => setEmbedOpen(newValue)}
-        quizId={quizId}
-      />
-      <StartModal
-        quizId={startId}
-        quizName={startName}
-        startModalOpen={startModalOpen}
-        setStartModalOpen={setStartModalOpen}
-      />
+      {embedOpen && (
+        <EmbeddingModal onClose={() => setEmbedOpen(false)} quizId={quizId} />
+      )}
+      {startModalOpen && (
+        <StartModal
+          quizId={startId}
+          quizName={startName}
+          setStartModalOpen={setStartModalOpen}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-control/src/components/liveQuizzes/StartModal.tsx
+++ b/apps/frontend-control/src/components/liveQuizzes/StartModal.tsx
@@ -8,19 +8,15 @@ import { H3, Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
 
-interface StartModalProps {
-  quizId: string
-  quizName: string
-  startModalOpen: boolean
-  setStartModalOpen: (open: boolean) => void
-}
-
 function StartModal({
   quizId,
   quizName,
-  startModalOpen,
   setStartModalOpen,
-}: StartModalProps) {
+}: {
+  quizId: string
+  quizName: string
+  setStartModalOpen: (open: boolean) => void
+}) {
   const t = useTranslations()
   const router = useRouter()
   const [startLiveQuiz, { loading: startingLiveQuiz }] = useMutation(
@@ -59,7 +55,7 @@ function StartModal({
 
   return (
     <Modal
-      open={startModalOpen}
+      open
       onClose={() => setStartModalOpen(false)}
       primaryLabel={t('shared.generic.start')}
       onPrimaryAction={async () => {

--- a/apps/frontend-control/src/components/liveQuizzes/StartModal.tsx
+++ b/apps/frontend-control/src/components/liveQuizzes/StartModal.tsx
@@ -11,11 +11,11 @@ import { useRouter } from 'next/router'
 function StartModal({
   quizId,
   quizName,
-  setStartModalOpen,
+  onClose,
 }: {
   quizId: string
   quizName: string
-  setStartModalOpen: (open: boolean) => void
+  onClose: () => void
 }) {
   const t = useTranslations()
   const router = useRouter()
@@ -56,7 +56,7 @@ function StartModal({
   return (
     <Modal
       open
-      onClose={() => setStartModalOpen(false)}
+      onClose={onClose}
       primaryLabel={t('shared.generic.start')}
       onPrimaryAction={async () => {
         try {
@@ -65,7 +65,7 @@ function StartModal({
           })
           router.push(`/session/${quizId}`)
         } catch (error) {
-          setStartModalOpen(false)
+          onClose()
           toast({
             type: 'error',
             message: t('control.course.liveQuizStartFailed'),
@@ -76,7 +76,7 @@ function StartModal({
       primaryLoading={startingLiveQuiz}
       dataPrimaryAction={{ cy: 'confirm-start-live-quiz' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => setStartModalOpen(false)}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'cancel-start-live-quiz-modal' }}
       className={{ content: 'mx-auto my-auto h-max w-max md:min-w-[30rem]' }}
       hideCloseButton

--- a/apps/frontend-manage/src/components/activities/creation/StackBlockCreation.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/StackBlockCreation.tsx
@@ -260,11 +260,12 @@ function StackBlockCreation({
         isOver={isOver}
         index={stackIx}
       />
-      <StackDescriptionModal
-        stackIx={stackIx}
-        modalOpen={stackDescriptionModal}
-        setModalOpen={setStackDescriptionModal}
-      />
+      {stackDescriptionModal && (
+        <StackDescriptionModal
+          stackIx={stackIx}
+          setModalOpen={setStackDescriptionModal}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/activities/creation/StackDescriptionModal.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/StackDescriptionModal.tsx
@@ -2,22 +2,18 @@ import { FormikTextField, Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import EditorField from './EditorField'
 
-interface StackDescriptionModalProps {
-  stackIx: number
-  modalOpen: boolean
-  setModalOpen: (open: boolean) => void
-}
-
 function StackDescriptionModal({
   stackIx,
-  modalOpen,
   setModalOpen,
-}: StackDescriptionModalProps) {
+}: {
+  stackIx: number
+  setModalOpen: (open: boolean) => void
+}) {
   const t = useTranslations()
 
   return (
     <Modal
-      open={modalOpen}
+      open
       onClose={() => setModalOpen(false)}
       title={t('manage.activityWizard.stackDescriptionTitle', {
         stackIx: stackIx + 1,

--- a/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivityStackClues.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivityStackClues.tsx
@@ -117,7 +117,7 @@ function GroupActivityStackClues({
                             delay={0}
                             className={{
                               tooltip: 'z-30 text-sm',
-                              trigger: 'mt-[0.05rem]',
+                              trigger: 'mt-[0.2rem]',
                             }}
                           >
                             <FontAwesomeIcon

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizBlockSettingsModal.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizBlockSettingsModal.tsx
@@ -3,14 +3,12 @@ import { useTranslations } from 'next-intl'
 import { ElementBlockFormValues } from '../WizardLayout'
 
 function LiveQuizBlockSettingsModal({
-  openSettings,
-  setOpenSettings,
+  onClose,
   block,
   index,
   replace,
 }: {
-  openSettings: boolean
-  setOpenSettings: (open: boolean) => void
+  onClose: () => void
   block: ElementBlockFormValues
   index: number
   replace: (index: number, block: ElementBlockFormValues) => void
@@ -19,13 +17,13 @@ function LiveQuizBlockSettingsModal({
 
   return (
     <Modal
-      open={openSettings}
-      onClose={() => setOpenSettings(false)}
+      open
+      onClose={onClose}
       title={t('manage.activityWizard.blockSettingsTitle', {
         blockIx: index + 1,
       })}
       primaryLabel={t('shared.generic.ok')}
-      onPrimaryAction={() => setOpenSettings(false)}
+      onPrimaryAction={onClose}
       dataPrimaryAction={{ cy: 'close-block-settings' }}
       className={{
         content: 'sm:w-3/4 md:w-1/2',

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizCreationBlock.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizCreationBlock.tsx
@@ -195,13 +195,14 @@ function LiveQuizCreationBlock({
         isOver={isOver}
         index={blockIx}
       />
-      <LiveQuizBlockSettingsModal
-        openSettings={openSettings}
-        setOpenSettings={setOpenSettings}
-        block={block}
-        index={blockIx}
-        replace={replace}
-      />
+      {openSettings && (
+        <LiveQuizBlockSettingsModal
+          onClose={() => setOpenSettings(false)}
+          block={block}
+          index={blockIx}
+          replace={replace}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/activities/overview/ActivityDetailsModal.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityDetailsModal.tsx
@@ -10,19 +10,17 @@ import Link from 'next/link'
 
 function ActivityDetailsModal({
   activity,
-  open,
   onClose,
 }: {
   activity: ActivityInfo
-  open: boolean
   onClose: () => void
 }) {
   const t = useTranslations()
 
   return (
     <Modal
+      open
       title={t('manage.activities.activityDetails')}
-      open={open}
       onClose={onClose}
       className={{ content: 'w-96 min-w-96 max-w-96' }}
       data={{ cy: 'activity-details-modal' }}

--- a/apps/frontend-manage/src/components/activities/overview/ActivityList.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityList.tsx
@@ -49,7 +49,7 @@ function ActivityList({
   }
 
   return (
-    <div className="flex flex-col gap-[0.15rem]">
+    <div className="flex flex-col gap-2">
       {activities.map((activity) => (
         <ActivityListEntry
           key={`activity-list-entry-${activity.id}`}

--- a/apps/frontend-manage/src/components/activities/overview/ActivityListEntry.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityListEntry.tsx
@@ -204,34 +204,38 @@ function ActivityListEntry({
           ) : null}
         </div>
       </div>
-      <ActivityDetailsModal
-        activity={activity}
-        open={showDetails}
-        onClose={() => setShowDetails(false)}
-      />
-      <ActivityNameChangeModal
-        id={activity.id}
-        name={activity.name}
-        type={activity.type}
-        displayName={activity.displayName}
-        open={changeName}
-        setOpen={setChangeName}
-      />
+      {showDetails && (
+        <ActivityDetailsModal
+          activity={activity}
+          onClose={() => setShowDetails(false)}
+        />
+      )}
+      {changeName && (
+        <ActivityNameChangeModal
+          id={activity.id}
+          name={activity.name}
+          type={activity.type}
+          displayName={activity.displayName}
+          onClose={() => setChangeName(false)}
+        />
+      )}
 
-      <ActivityLogDialog
-        objectId={String(activity.id)}
-        objectType={
-          activity.type === ActivityType.LiveQuiz
-            ? ObjectType.LiveQuiz
-            : activity.type === ActivityType.PracticeQuiz
-              ? ObjectType.PracticeQuiz
-              : activity.type === ActivityType.MicroLearning
-                ? ObjectType.MicroLearning
-                : ObjectType.GroupActivity
-        }
-        open={isActivityLogOpen}
-        onOpenChange={setActivityLogOpen}
-      />
+      {isActivityLogOpen && (
+        <ActivityLogDialog
+          objectId={String(activity.id)}
+          objectType={
+            activity.type === ActivityType.LiveQuiz
+              ? ObjectType.LiveQuiz
+              : activity.type === ActivityType.PracticeQuiz
+                ? ObjectType.PracticeQuiz
+                : activity.type === ActivityType.MicroLearning
+                  ? ObjectType.MicroLearning
+                  : ObjectType.GroupActivity
+          }
+          open={isActivityLogOpen}
+          onClose={() => setActivityLogOpen(false)}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/activities/overview/ActivityRemovalModal.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityRemovalModal.tsx
@@ -46,8 +46,7 @@ function ActivityRemovalModal({
 
   return (
     <ActivityConfirmationModal
-      open={isModalOpen}
-      setOpen={setModalOpen}
+      onClose={() => setModalOpen(false)}
       title={t('manage.activities.removeActivity')}
       message={t.rich('manage.activities.confirmActivityRemoval', {
         name: title,

--- a/apps/frontend-manage/src/components/activities/overview/GroupActivityActions.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/GroupActivityActions.tsx
@@ -141,21 +141,19 @@ function GroupActivityActions({
         activityType={groupActivity.type}
       />
       <div>
-        {sharingModal && groupActivity.isManager && (
+        {sharingModal && groupActivity.isManager ? (
           <ObjectSharingModalWrapper
             objectUuid={groupActivity.id}
             objectName={groupActivity.name}
             objectType={ObjectType.GroupActivity}
             isTemplate={isTemplate}
             isOwner={groupActivity.isOwner ?? false}
-            open={sharingModal}
             onClose={() => setSharingModal(false)}
           />
-        )}
+        ) : null}
         {publishingModal && (
           <PublishConfirmationModal
-            open={publishingModal}
-            setOpen={setPublishingModal}
+            onClose={() => setPublishingModal(false)}
             elementType={ElementInstanceType.GroupActivity}
             elementId={groupActivity.id}
             title={groupActivity.name}
@@ -163,16 +161,17 @@ function GroupActivityActions({
             publicationHint={t('manage.course.groupActivityPublishingHint')}
           />
         )}
-        <ExtensionModal
-          open={extensionModal}
-          setOpen={setExtensionModal}
-          type="groupActivity"
-          id={groupActivity.id}
-          currentEndDate={groupActivity.scheduledEndAt}
-          courseId={groupActivity.courseId!}
-          title={t('manage.course.extendGroupActivity')}
-          description={t('manage.course.extendGroupActivityDescription')}
-        />
+        {extensionModal && (
+          <ExtensionModal
+            onClose={() => setExtensionModal(false)}
+            type="groupActivity"
+            id={groupActivity.id}
+            currentEndDate={groupActivity.scheduledEndAt}
+            courseId={groupActivity.courseId!}
+            title={t('manage.course.extendGroupActivity')}
+            description={t('manage.course.extendGroupActivityDescription')}
+          />
+        )}
 
         {removalModal && groupActivity.isRemovable && (
           <ActivityRemovalModal
@@ -185,8 +184,7 @@ function GroupActivityActions({
         )}
         {deletionModal && (
           <GroupActivityDeletionModal
-            open={deletionModal}
-            setOpen={setDeletionModal}
+            onClose={() => setDeletionModal(false)}
             activityId={groupActivity.id}
             courseId={groupActivity.courseId!}
           />
@@ -194,16 +192,14 @@ function GroupActivityActions({
 
         {endingModal && (
           <GroupActivityEndingModal
-            open={endingModal}
-            setOpen={setEndingModal}
+            onClose={() => setEndingModal(false)}
             activityId={groupActivity.id}
             courseId={groupActivity.courseId!}
           />
         )}
         {startingModal && (
           <GroupActivityStartingModal
-            open={startingModal}
-            setOpen={setStartingModal}
+            onClose={() => setStartingModal(false)}
             activityId={groupActivity.id}
             activityEndDate={groupActivity.scheduledEndAt}
             groupDeadlineDate={groupActivity.groupDeadlineDate}
@@ -212,14 +208,14 @@ function GroupActivityActions({
           />
         )}
 
-        {groupActivity && (
+        {groupActivity && activityLogOpen ? (
           <ActivityLogDialog
             objectId={groupActivity.id}
             objectType={ObjectType.GroupActivity}
             open={activityLogOpen}
-            onOpenChange={setActivityLogOpen}
+            onClose={() => setActivityLogOpen(false)}
           />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/apps/frontend-manage/src/components/activities/overview/LiveQuizActions.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/LiveQuizActions.tsx
@@ -175,8 +175,7 @@ function LiveQuizActions({
         {deletionModal && (
           <LiveQuizDeletionModal
             quizId={liveQuiz.id}
-            open={deletionModal}
-            setOpen={setDeletionModal}
+            onClose={() => setDeletionModal(false)}
             onDelete={onDelete}
             deleting={deleting}
           />
@@ -186,8 +185,7 @@ function LiveQuizActions({
           <TemplateDeletionModal
             activityId={liveQuiz.id}
             activityType={ActivityType.LiveQuiz}
-            open={templateDeletionModal}
-            setOpen={setTemplateDeletionModal}
+            onClose={() => setTemplateDeletionModal(false)}
             onSuccess={() =>
               toast({
                 type: 'success',
@@ -208,8 +206,7 @@ function LiveQuizActions({
           <TemplateEditModal
             activityId={liveQuiz.id}
             activityType={ActivityType.LiveQuiz}
-            open={templateEditingModal}
-            setOpen={setTemplateEditingModal}
+            onClose={() => setTemplateEditingModal(false)}
             onSuccess={() =>
               toast({
                 type: 'success',
@@ -230,15 +227,13 @@ function LiveQuizActions({
         {qrModal && (
           <LiveQuizQRModal
             quizId={liveQuiz.id}
-            open={qrModal}
-            setOpen={setQRModal}
+            onClose={() => setQRModal(false)}
           />
         )}
 
         {embeddingModal && (
           <EmbeddingModal
             key={liveQuiz.id}
-            open={embeddingModal}
             onClose={() => setEmbeddingModal(false)}
             quizId={liveQuiz.id}
             elements={liveQuiz.stacks.flatMap((stack) =>
@@ -250,17 +245,16 @@ function LiveQuizActions({
           />
         )}
 
-        {sharingModal && liveQuiz.isManager && (
+        {sharingModal && liveQuiz.isManager ? (
           <ObjectSharingModalWrapper
             objectUuid={liveQuiz.id}
             objectName={liveQuiz.name}
             objectType={ObjectType.LiveQuiz}
             isTemplate={isTemplate}
             isOwner={liveQuiz.isOwner ?? false}
-            open={sharingModal}
             onClose={() => setSharingModal(false)}
           />
-        )}
+        ) : null}
 
         {removalModal && liveQuiz.isRemovable && (
           <ActivityRemovalModal
@@ -272,34 +266,37 @@ function LiveQuizActions({
           />
         )}
 
-        <TemplateConversionModal
-          open={conversionModal.open}
-          setOpen={(open) => setConversionModal({ ...conversionModal, open })}
-          activityId={conversionModal.activityId}
-          activityType={conversionModal.activityType}
-          onSuccess={() =>
-            toast({
-              type: 'success',
-              message: t('manage.template.templateCreationSuccess'),
-              options: { duration: 3500 },
-            })
-          }
-          onError={() =>
-            toast({
-              type: 'error',
-              message: t('manage.template.templateCreationError'),
-            })
-          }
-        />
+        {conversionModal.open && (
+          <TemplateConversionModal
+            onClose={() =>
+              setConversionModal((prev) => ({ ...prev, open: false }))
+            }
+            activityId={conversionModal.activityId}
+            activityType={conversionModal.activityType}
+            onSuccess={() =>
+              toast({
+                type: 'success',
+                message: t('manage.template.templateCreationSuccess'),
+                options: { duration: 3500 },
+              })
+            }
+            onError={() =>
+              toast({
+                type: 'error',
+                message: t('manage.template.templateCreationError'),
+              })
+            }
+          />
+        )}
 
-        {liveQuiz && (
+        {liveQuiz && activityLogOpen ? (
           <ActivityLogDialog
             objectId={liveQuiz.id}
             objectType={ObjectType.LiveQuiz}
             open={activityLogOpen}
-            onOpenChange={setActivityLogOpen}
+            onClose={() => setActivityLogOpen(false)}
           />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/apps/frontend-manage/src/components/activities/overview/MicrolearningActions.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/MicrolearningActions.tsx
@@ -160,21 +160,19 @@ function MicrolearningActions({
         activityType={microLearning.type}
       />
       <div>
-        {sharingModal && microLearning.isManager && (
+        {sharingModal && microLearning.isManager ? (
           <ObjectSharingModalWrapper
             objectUuid={microLearning.id}
             objectName={microLearning.name}
             objectType={ObjectType.MicroLearning}
             isTemplate={isTemplate}
             isOwner={microLearning.isOwner ?? false}
-            open={sharingModal}
             onClose={() => setSharingModal(false)}
           />
-        )}
+        ) : null}
         {publishModal && (
           <PublishConfirmationModal
-            open={publishModal}
-            setOpen={setPublishModal}
+            onClose={() => setPublishModal(false)}
             elementType={ElementInstanceType.Microlearning}
             elementId={microLearning.id}
             title={microLearning.name}
@@ -194,8 +192,7 @@ function MicrolearningActions({
         )}
         {deletionModal && (
           <MicroLearningDeletionModal
-            open={deletionModal}
-            setOpen={setDeletionModal}
+            onClose={() => setDeletionModal(false)}
             activityId={microLearning.id}
             courseId={microLearning.courseId!}
           />
@@ -203,8 +200,7 @@ function MicrolearningActions({
 
         {endingModal && (
           <MicroLearningEndingModal
-            open={endingModal}
-            setOpen={setEndingModal}
+            onClose={() => setEndingModal(false)}
             activityId={microLearning.id}
             courseId={microLearning.courseId!}
           />
@@ -217,19 +213,18 @@ function MicrolearningActions({
             courseId={microLearning.courseId!}
             title={t('manage.course.extendMicroLearning')}
             description={t('manage.course.extendMicroLearningDescription')}
-            open={extensionModal}
-            setOpen={setExtensionModal}
+            onClose={() => setExtensionModal(false)}
           />
         )}
 
-        {microLearning && (
+        {microLearning && activityLogOpen ? (
           <ActivityLogDialog
             objectId={microLearning.id}
             objectType={ObjectType.MicroLearning}
             open={activityLogOpen}
-            onOpenChange={setActivityLogOpen}
+            onClose={() => setActivityLogOpen(false)}
           />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/apps/frontend-manage/src/components/activities/overview/PracticeQuizActions.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/PracticeQuizActions.tsx
@@ -137,31 +137,28 @@ function PracticeQuizActions({
           <PracticeQuizPublishingModal
             elementId={practiceQuiz.id}
             title={practiceQuiz.name}
-            open={publishModal}
-            setOpen={setPublishModal}
+            onClose={() => setPublishModal(false)}
             courseId={practiceQuiz.courseId!}
             courseStartDate={practiceQuiz.courseStartDate}
           />
         )}
         {deletionModal && (
           <PracticeQuizDeletionModal
-            open={deletionModal}
-            setOpen={setDeletionModal}
+            onClose={() => setDeletionModal(false)}
             activityId={practiceQuiz.id}
             courseId={practiceQuiz.courseId!}
           />
         )}
-        {sharingModal && practiceQuiz.isManager && (
+        {sharingModal && practiceQuiz.isManager ? (
           <ObjectSharingModalWrapper
             objectUuid={practiceQuiz.id}
             objectName={practiceQuiz.name}
             objectType={ObjectType.PracticeQuiz}
             isTemplate={isTemplate}
             isOwner={practiceQuiz.isOwner ?? false}
-            open={sharingModal}
             onClose={() => setSharingModal(false)}
           />
-        )}
+        ) : null}
         {removalModal && practiceQuiz.isRemovable && (
           <ActivityRemovalModal
             activityId={practiceQuiz.id}
@@ -172,14 +169,14 @@ function PracticeQuizActions({
           />
         )}
 
-        {practiceQuiz && (
+        {practiceQuiz && activityLogOpen ? (
           <ActivityLogDialog
             objectId={practiceQuiz.id}
             objectType={ObjectType.PracticeQuiz}
             open={activityLogOpen}
-            onOpenChange={setActivityLogOpen}
+            onClose={() => setActivityLogOpen(false)}
           />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/apps/frontend-manage/src/components/activities/templates/ExistingElementSelectionModal.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/ExistingElementSelectionModal.tsx
@@ -11,14 +11,12 @@ import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 function ExistingElementSelectionModal({
-  open,
   onClose,
   replaceWithExistingElement,
   requiredElementType,
   hasSampleSolution,
   hasAnswerFeedbacks,
 }: {
-  open: boolean
   onClose: () => void
   replaceWithExistingElement: (elementId: number, elementName: string) => void
   requiredElementType: ElementType
@@ -60,10 +58,10 @@ function ExistingElementSelectionModal({
 
   return (
     <Modal
+      open
       escapeDisabled
       hideCloseButton
       title={t('manage.template.selectExistingElement')}
-      open={open}
       onClose={() => {
         setSelectedElement(null)
         onClose()

--- a/apps/frontend-manage/src/components/activities/templates/LiveQuizTemplate.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/LiveQuizTemplate.tsx
@@ -369,30 +369,31 @@ function LiveQuizTemplate({ template }: { template: ActivityTemplate }) {
               </SectionCollapsible>
             ))}
 
-            <LiveQuizTemplateTimeLimitModal
-              open={timeLimitModal.open && timeLimitModal.blockIx === blockIx}
-              onClose={() => setTimeLimitModal({ open: false, blockIx: 0 })}
-              blockIx={blockIx}
-              timeLimit={quizData.blocks[blockIx]?.timeLimit}
-              setTimeLimit={(newValue) => {
-                setQuizData((prev) => {
-                  if (!prev) {
-                    return prev
-                  }
+            {timeLimitModal.open && timeLimitModal.blockIx === blockIx ? (
+              <LiveQuizTemplateTimeLimitModal
+                onClose={() => setTimeLimitModal({ open: false, blockIx: 0 })}
+                blockIx={blockIx}
+                timeLimit={quizData.blocks[blockIx]?.timeLimit}
+                setTimeLimit={(newValue) => {
+                  setQuizData((prev) => {
+                    if (!prev) {
+                      return prev
+                    }
 
-                  const blocks = [...prev.blocks]
-                  blocks[blockIx] = {
-                    ...blocks[blockIx],
-                    timeLimit: newValue,
-                  }
+                    const blocks = [...prev.blocks]
+                    blocks[blockIx] = {
+                      ...blocks[blockIx],
+                      timeLimit: newValue,
+                    }
 
-                  return {
-                    ...prev,
-                    blocks,
-                  }
-                })
-              }}
-            />
+                    return {
+                      ...prev,
+                      blocks,
+                    }
+                  })
+                }}
+              />
+            ) : null}
           </div>
         ))}
 
@@ -556,28 +557,30 @@ function LiveQuizTemplate({ template }: { template: ActivityTemplate }) {
           </div>
         </div>
       </div>
-      <TemplateResetConfirmationPrompt
-        open={resetTemplatePrompt}
-        onClose={() => setResetTemplatePrompt(false)}
-        onConfirm={() => {
-          if (initialTemplateFormData) {
-            // reset the form inputs
-            setQuizData(initialTemplateFormData)
 
-            // reset the progress parameters
-            const progress = loadProgressFromLiveQuizData({
-              quizData: initialTemplateFormData,
-            })
-            setCollapsibles(progress)
+      {resetTemplatePrompt && (
+        <TemplateResetConfirmationPrompt
+          onClose={() => setResetTemplatePrompt(false)}
+          onConfirm={() => {
+            if (initialTemplateFormData) {
+              // reset the form inputs
+              setQuizData(initialTemplateFormData)
 
-            // unset touched state for settings collapsible
-            setClosingSettingsDisabled(false)
+              // reset the progress parameters
+              const progress = loadProgressFromLiveQuizData({
+                quizData: initialTemplateFormData,
+              })
+              setCollapsibles(progress)
 
-            // close the modal
-            setResetTemplatePrompt(false)
-          }
-        }}
-      />
+              // unset touched state for settings collapsible
+              setClosingSettingsDisabled(false)
+
+              // close the modal
+              setResetTemplatePrompt(false)
+            }
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/activities/templates/NewElementDataDiscardingModal.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/NewElementDataDiscardingModal.tsx
@@ -5,11 +5,9 @@ import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function NewElementDataDiscardingModal({
-  open,
   onClose,
   onConfirm,
 }: {
-  open: boolean
   onClose: () => void
   onConfirm: () => void
 }) {
@@ -17,7 +15,7 @@ function NewElementDataDiscardingModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.template.discardEnteredElementContent')}
       secondaryLabel={
@@ -37,6 +35,7 @@ function NewElementDataDiscardingModal({
       onPrimaryAction={onConfirm}
       dataPrimaryAction={{ cy: 'confirm-discard-new-edits' }}
       data={{ cy: 'discard-new-edits-modal' }}
+      className={{ content: 'max-w-2xl' }}
     >
       <div className="mb-4">
         {t('manage.template.confirmDiscardEnteredElementContent')}

--- a/apps/frontend-manage/src/components/activities/templates/TemplateElementContent.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/TemplateElementContent.tsx
@@ -223,23 +223,24 @@ function TemplateElementContent({
         </Button>
       </div>
 
-      <ExistingElementSelectionModal
-        open={existingElementModal}
-        onClose={() => setExistingElementModal(false)}
-        replaceWithExistingElement={replaceWithExistingElement}
-        requiredElementType={templateElement.instance.elementType}
-        hasSampleSolution={
-          'options' in templateElement.instance.elementData
-            ? templateElement.instance.elementData.options.hasSampleSolution
-            : null
-        }
-        hasAnswerFeedbacks={
-          'options' in templateElement.instance.elementData &&
-          'hasAnswerFeedbacks' in templateElement.instance.elementData.options
-            ? templateElement.instance.elementData.options.hasAnswerFeedbacks
-            : null
-        }
-      />
+      {existingElementModal && (
+        <ExistingElementSelectionModal
+          onClose={() => setExistingElementModal(false)}
+          replaceWithExistingElement={replaceWithExistingElement}
+          requiredElementType={templateElement.instance.elementType}
+          hasSampleSolution={
+            'options' in templateElement.instance.elementData
+              ? templateElement.instance.elementData.options.hasSampleSolution
+              : null
+          }
+          hasAnswerFeedbacks={
+            'options' in templateElement.instance.elementData &&
+            'hasAnswerFeedbacks' in templateElement.instance.elementData.options
+              ? templateElement.instance.elementData.options.hasAnswerFeedbacks
+              : null
+          }
+        />
+      )}
 
       <TemplateNewElementModal
         templateId={templateId}
@@ -249,16 +250,17 @@ function TemplateElementContent({
         onSaveNewElement={saveNewElement}
       />
 
-      <NewElementDataDiscardingModal
-        open={comfirmDiscardCustom.open}
-        onClose={() =>
-          setConfirmDiscardCustom({ open: false, onConfirm: () => {} })
-        }
-        onConfirm={() => {
-          comfirmDiscardCustom.onConfirm()
-          setConfirmDiscardCustom({ open: false, onConfirm: () => {} })
-        }}
-      />
+      {comfirmDiscardCustom.open && (
+        <NewElementDataDiscardingModal
+          onClose={() =>
+            setConfirmDiscardCustom({ open: false, onConfirm: () => {} })
+          }
+          onConfirm={() => {
+            comfirmDiscardCustom.onConfirm()
+            setConfirmDiscardCustom({ open: false, onConfirm: () => {} })
+          }}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/activities/templates/TemplateElementContent.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/TemplateElementContent.tsx
@@ -242,13 +242,14 @@ function TemplateElementContent({
         />
       )}
 
-      <TemplateNewElementModal
-        templateId={templateId}
-        open={newElementModal}
-        onClose={() => setNewElementModal(false)}
-        templateElement={templateElement}
-        onSaveNewElement={saveNewElement}
-      />
+      {newElementModal && (
+        <TemplateNewElementModal
+          templateId={templateId}
+          onClose={() => setNewElementModal(false)}
+          templateElement={templateElement}
+          onSaveNewElement={saveNewElement}
+        />
+      )}
 
       {comfirmDiscardCustom.open && (
         <NewElementDataDiscardingModal

--- a/apps/frontend-manage/src/components/activities/templates/TemplateNewElementModal.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/TemplateNewElementModal.tsx
@@ -6,13 +6,11 @@ import { ActivityTemplateElementFormValues } from './types'
 import useFormValuesFromElementInstance from './useFormValuesFromElementInstance'
 
 function TemplateNewElementModal({
-  open,
   onClose,
   templateId,
   templateElement,
   onSaveNewElement,
 }: {
-  open: boolean
   onClose: () => void
   templateId: string
   templateElement: ActivityTemplateElementFormValues

--- a/apps/frontend-manage/src/components/activities/templates/TemplateNewElementModal.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/TemplateNewElementModal.tsx
@@ -30,7 +30,6 @@ function TemplateNewElementModal({
     <ElementEditForm
       isTemplate
       templateId={templateId}
-      open={open}
       onClose={onClose}
       onSuccess={onClose} // success toast is not required -> success immediately visible
       mode={ElementEditMode.CREATE}

--- a/apps/frontend-manage/src/components/activities/templates/TemplateResetConfirmationPrompt.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/TemplateResetConfirmationPrompt.tsx
@@ -3,11 +3,9 @@ import { Button, Modal, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function TemplateResetConfirmationPrompt({
-  open,
   onClose,
   onConfirm,
 }: {
-  open: boolean
   onClose: () => void
   onConfirm: () => void
 }) {
@@ -15,24 +13,24 @@ function TemplateResetConfirmationPrompt({
 
   return (
     <Modal
+      open
       hideCloseButton
       escapeDisabled
-      open={open}
       onClose={() => null}
       title={t('manage.template.resetConfirmation')}
       secondaryLabel={t('shared.generic.cancel')}
       onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'cancel-template-reset' }}
       primaryLabel={
-        <div className="flex flex-row items-center gap-2.5">
+        <div className="flex flex-row items-center">
           <Button.Icon icon={faArrowsRotate} />
-          <span>{t('manage.template.confirmReset')}</span>
+          <Button.Label>{t('manage.template.confirmReset')}</Button.Label>
         </div>
       }
       primaryButtonStyle="destructive"
       onPrimaryAction={onConfirm}
       dataPrimaryAction={{ cy: 'confirm-template-reset' }}
-      // className={{ content: 'max-w-2xl gap-1' }}
+      className={{ content: 'max-w-2xl' }}
     >
       <UserNotification
         type="warning"

--- a/apps/frontend-manage/src/components/activities/templates/liveQuiz/LiveQuizTemplateTimeLimitModal.tsx
+++ b/apps/frontend-manage/src/components/activities/templates/liveQuiz/LiveQuizTemplateTimeLimitModal.tsx
@@ -4,13 +4,11 @@ import { Modal, NumberField } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function LiveQuizTemplateTimeLimitModal({
-  open,
   onClose,
   blockIx,
   timeLimit,
   setTimeLimit,
 }: {
-  open: boolean
   onClose: () => void
   blockIx: number
   timeLimit: string | undefined
@@ -20,7 +18,7 @@ function LiveQuizTemplateTimeLimitModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.activityWizard.blockSettingsTitle', {
         blockIx: blockIx + 1,

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogChangeAccessModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogChangeAccessModal.tsx
@@ -11,7 +11,6 @@ import { Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function CatalogChangeAccessModal({
-  open,
   onClose,
   objectType,
   objectName,
@@ -19,7 +18,6 @@ function CatalogChangeAccessModal({
   newAccess,
   catalogCollectionId,
 }: {
-  open: boolean
   onClose: () => void
   objectType: ObjectType
   objectName: string
@@ -37,7 +35,7 @@ function CatalogChangeAccessModal({
 
   return (
     <Modal
-      open={open}
+      open
       title={t('manage.catalog.changeAccessTitle')}
       onClose={onClose}
       primaryLabel={t('manage.catalog.changeAccessConfirm')}

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogCopyModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogCopyModal.tsx
@@ -10,7 +10,6 @@ import CatalogAdditionalObjectInfo from './info/CatalogAdditionalObjectInfo'
 import useCopyCatalogObject from './useCopyCatalogObject'
 
 function CatalogCopyModal({
-  open,
   onSuccess,
   onClose,
   objectType,
@@ -19,7 +18,6 @@ function CatalogCopyModal({
   objectOwner,
   catalogCollectionId,
 }: {
-  open: boolean
   onSuccess: () => void
   onClose: () => void
   objectType: ObjectType
@@ -45,7 +43,7 @@ function CatalogCopyModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={(e) => {
         e?.stopPropagation()
         onClose()

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogImportModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogImportModal.tsx
@@ -9,7 +9,6 @@ import CatalogAdditionalObjectInfo from './info/CatalogAdditionalObjectInfo'
 import useImportCatalogObject from './useImportCatalogObject'
 
 function CatalogImportModal({
-  open,
   onSuccess,
   onClose,
   objectType,
@@ -18,7 +17,6 @@ function CatalogImportModal({
   objectOwner,
   catalogCollectionId,
 }: {
-  open: boolean
   onSuccess: () => void
   onClose: () => void
   objectType: ObjectType
@@ -44,7 +42,7 @@ function CatalogImportModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={(e) => {
         e?.stopPropagation()
         onClose()

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogObjectItem.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogObjectItem.tsx
@@ -212,9 +212,8 @@ function CatalogObjectItem({
       </div>
 
       {/* functionality for users without access to request it for restricted catalog collections */}
-      {!actionsDisabled && !object.isRequested ? (
+      {!actionsDisabled && !object.isRequested && requestModal ? (
         <CatalogRequestModal
-          open={requestModal}
           onSuccess={() => {
             toast({
               type: 'success',
@@ -234,9 +233,10 @@ function CatalogObjectItem({
       ) : null}
 
       {/* functionality for users to copy a publicly available object */}
-      {!actionsDisabled && object.access === ObjectAccess.Public ? (
+      {!actionsDisabled &&
+      object.access === ObjectAccess.Public &&
+      copyModal ? (
         <CatalogCopyModal
-          open={copyModal}
           onSuccess={() => {
             toast({
               type: 'success',
@@ -255,9 +255,10 @@ function CatalogObjectItem({
       ) : null}
 
       {/* functionality for users to import a publicly available object */}
-      {!actionsDisabled && object.access === ObjectAccess.Public ? (
+      {!actionsDisabled &&
+      object.access === ObjectAccess.Public &&
+      importModal ? (
         <CatalogImportModal
-          open={importModal}
           onSuccess={() => {
             toast({
               type: 'success',
@@ -276,9 +277,8 @@ function CatalogObjectItem({
       ) : null}
 
       {/* functionality to cancel request for requested catalog object */}
-      {object.isRequested ? (
+      {object.isRequested && requestCancellationModal ? (
         <CatalogRequestCancellationModal
-          open={requestCancellationModal}
           onSuccess={() => {
             toast({
               type: 'success',
@@ -298,24 +298,26 @@ function CatalogObjectItem({
 
       {managedAccess ? (
         <>
-          <CatalogChangeAccessModal
-            open={changeAccessModal}
-            onClose={() => setChangeAccessModal(false)}
-            objectType={object.objectType}
-            objectName={object.name}
-            assignmentId={object.id}
-            newAccess={newAccess}
-            catalogCollectionId={catalogCollectionId}
-          />
-          <CatalogObjectRemovalModal
-            object={object}
-            open={removalModal}
-            catalogCollectionId={catalogCollectionId}
-            onClose={() => setRemovalModal(false)}
-          />
+          {changeAccessModal && (
+            <CatalogChangeAccessModal
+              onClose={() => setChangeAccessModal(false)}
+              objectType={object.objectType}
+              objectName={object.name}
+              assignmentId={object.id}
+              newAccess={newAccess}
+              catalogCollectionId={catalogCollectionId}
+            />
+          )}
+          {removalModal && (
+            <CatalogObjectRemovalModal
+              object={object}
+              catalogCollectionId={catalogCollectionId}
+              onClose={() => setRemovalModal(false)}
+            />
+          )}
         </>
       ) : null}
-      {object.isManager ? (
+      {object.isManager && sharingModal ? (
         object.objectUuid ? (
           <ObjectSharingModalWrapper
             objectUuid={object.objectUuid}
@@ -323,7 +325,6 @@ function CatalogObjectItem({
             objectType={object.objectType}
             catalogCollectionId={catalogCollectionId}
             isOwner={object.isOwner}
-            open={sharingModal}
             onClose={() => setSharingModal(false)}
           />
         ) : (
@@ -333,7 +334,6 @@ function CatalogObjectItem({
             objectType={object.objectType}
             catalogCollectionId={catalogCollectionId}
             isOwner={object.isOwner}
-            open={sharingModal}
             onClose={() => setSharingModal(false)}
           />
         )

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogObjectRemovalModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogObjectRemovalModal.tsx
@@ -10,12 +10,10 @@ import { useTranslations } from 'next-intl'
 
 function CatalogObjectRemovalModal({
   object,
-  open,
   catalogCollectionId,
   onClose,
 }: {
   object: CatalogObject
-  open: boolean
   catalogCollectionId?: string
   onClose: () => void
 }) {
@@ -26,7 +24,7 @@ function CatalogObjectRemovalModal({
 
   return (
     <Modal
-      open={open}
+      open
       title={
         (object.objectType === ObjectType.LiveQuiz ||
           object.objectType === ObjectType.PracticeQuiz ||

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogRequestCancellationModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogRequestCancellationModal.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from 'next-intl'
 import useRequestCancellationCatalogObject from './useRequestCancellationCatalogObject'
 
 function CatalogRequestCancellationModal({
-  open,
   onSuccess,
   onClose,
   objectType,
@@ -15,7 +14,6 @@ function CatalogRequestCancellationModal({
   objectOwner,
   catalogCollectionId,
 }: {
-  open: boolean
   onSuccess: () => void
   onClose: () => void
   objectType: ObjectType
@@ -41,7 +39,7 @@ function CatalogRequestCancellationModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={(e) => {
         e?.stopPropagation()
         onClose()

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogRequestModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogRequestModal.tsx
@@ -10,7 +10,6 @@ import CatalogAdditionalObjectInfo from './info/CatalogAdditionalObjectInfo'
 import useRequestCatalogObject from './useRequestCatalogObject'
 
 function CatalogRequestModal({
-  open,
   onSuccess,
   onClose,
   objectType,
@@ -20,7 +19,6 @@ function CatalogRequestModal({
   objectAccess,
   catalogCollectionId,
 }: {
-  open: boolean
   onSuccess: () => void
   onClose: () => void
   objectType: ObjectType
@@ -47,7 +45,7 @@ function CatalogRequestModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={(e) => {
         e?.stopPropagation()
         onClose()

--- a/apps/frontend-manage/src/components/catalog/actions/CatalogSharingRequest.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/CatalogSharingRequest.tsx
@@ -122,18 +122,19 @@ function CatalogSharingRequest({ request }: { request: ObjectSharingRequest }) {
           <Button.Label>{t('shared.generic.decline')}</Button.Label>
         </Button>
       </div>
-      <SharingRequestApprovalModal
-        request={request}
-        open={approvalModal}
-        onClose={() => setApprovalModal(false)}
-        onSuccess={() =>
-          toast({
-            type: 'success',
-            message: t('manage.catalog.approvalSuccessful'),
-            options: { duration: 3000 },
-          })
-        }
-      />
+      {approvalModal && (
+        <SharingRequestApprovalModal
+          request={request}
+          onClose={() => setApprovalModal(false)}
+          onSuccess={() =>
+            toast({
+              type: 'success',
+              message: t('manage.catalog.approvalSuccessful'),
+              options: { duration: 3000 },
+            })
+          }
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/catalog/actions/ObjectImport.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/ObjectImport.tsx
@@ -173,9 +173,8 @@ function ObjectImport({
           />
         ) : null}
       </div>
-      {collectionEditor ? (
+      {collectionEditor && objectAdditionModalOpen ? (
         <AddObjectToCatalogModal
-          open={objectAdditionModalOpen}
           onClose={() => setObjectAdditionModalOpen(false)}
           catalogCollectionId={catalogCollectionId as string | undefined}
           onSuccess={() => {
@@ -196,9 +195,8 @@ function ObjectImport({
         />
       ) : null}
 
-      {typeof catalogCollectionId === 'undefined' ? (
+      {typeof catalogCollectionId === 'undefined' && collectionModalOpen ? (
         <CreateCatalogCollectionModal
-          open={collectionModalOpen}
           onClose={() => setCollectionModalOpen(false)}
           onSuccess={() => {
             toast({

--- a/apps/frontend-manage/src/components/catalog/actions/SharingRequestApprovalModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/actions/SharingRequestApprovalModal.tsx
@@ -17,12 +17,10 @@ import PropagatedPermissionsTable from '../../sharing/PropagatedPermissionsTable
 
 function SharingRequestApprovalModal({
   request,
-  open,
   onClose,
   onSuccess,
 }: {
   request: ObjectSharingRequest
-  open: boolean
   onClose: () => void
   onSuccess: () => void
 }) {
@@ -37,7 +35,7 @@ function SharingRequestApprovalModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={(e) => {
         e?.stopPropagation()
         onClose()

--- a/apps/frontend-manage/src/components/catalog/administration/AddObjectToCatalogModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/administration/AddObjectToCatalogModal.tsx
@@ -13,7 +13,6 @@ import ObjectTypeSelection from './ObjectTypeSelection'
 import SelectObjectForCatalog from './SelectObjectForCatalog'
 
 interface AddObjectToCatalogModalProps {
-  open: boolean
   onClose: () => void
   catalogCollectionId?: string
   onSuccess: () => void
@@ -28,7 +27,6 @@ export interface CatalogObjectAdditionFormValues {
 }
 
 function AddObjectToCatalogModal({
-  open,
   onClose,
   catalogCollectionId,
   onSuccess,
@@ -39,8 +37,8 @@ function AddObjectToCatalogModal({
 
   return (
     <Modal
+      open
       title={t('manage.catalog.addObjectToCatalogTitle')}
-      open={open}
       onClose={onClose}
       className={{ content: 'max-w-2xl pb-2' }}
       dataCloseButton={{ cy: 'close-add-object-modal' }}

--- a/apps/frontend-manage/src/components/catalog/administration/CatalogCollectionListItem.tsx
+++ b/apps/frontend-manage/src/components/catalog/administration/CatalogCollectionListItem.tsx
@@ -153,51 +153,52 @@ function CatalogCollectionListItem({
 
       {collection.isManager ? (
         <>
-          <ObjectSharingModalWrapper
-            open={sharingModal}
-            onClose={() => setSharingModal(false)}
-            objectUuid={collection.id}
-            objectName={collection.name}
-            objectType={ObjectType.CatalogCollection}
-            isOwner={collection.isOwner ?? false}
-          />
-          <CatalogCollectionDeletionModal
-            catalogCollectionId={collection.id}
-            catalogCollectionName={collection.name}
-            open={deletionModal}
-            onClose={() => setDeletionModal(false)}
-            onSuccess={() =>
-              toast({
-                type: 'success',
-                message: t('manage.catalog.deletionSuccessful'),
-                options: { duration: 3500 },
-              })
-            }
-          />
-          <CatalogChangeAccessModal
-            open={changeAccessModal}
-            onClose={() => setChangeAccessModal(false)}
-            objectType={ObjectType.CatalogCollection}
-            objectName={collection.name}
-            newAccess={newAccess}
-            catalogCollectionId={collection.id}
-          />
+          {sharingModal && (
+            <ObjectSharingModalWrapper
+              onClose={() => setSharingModal(false)}
+              objectUuid={collection.id}
+              objectName={collection.name}
+              objectType={ObjectType.CatalogCollection}
+              isOwner={collection.isOwner ?? false}
+            />
+          )}
+          {deletionModal && (
+            <CatalogCollectionDeletionModal
+              catalogCollectionId={collection.id}
+              catalogCollectionName={collection.name}
+              onClose={() => setDeletionModal(false)}
+              onSuccess={() =>
+                toast({
+                  type: 'success',
+                  message: t('manage.catalog.deletionSuccessful'),
+                  options: { duration: 3500 },
+                })
+              }
+            />
+          )}
+          {changeAccessModal && (
+            <CatalogChangeAccessModal
+              onClose={() => setChangeAccessModal(false)}
+              objectType={ObjectType.CatalogCollection}
+              objectName={collection.name}
+              newAccess={newAccess}
+              catalogCollectionId={collection.id}
+            />
+          )}
         </>
       ) : null}
 
-      {collection.isEditor ? (
+      {collection.isEditor && nameChangeModal ? (
         <CatalogCollectionNameChangeModal
           catalogCollectionId={collection.id}
           name={collection.name}
-          open={nameChangeModal}
           onClose={() => setNameChangeModal(false)}
         />
       ) : null}
 
       {/* functionality for users without access to request it for restricted catalog collections */}
-      {isRequestable ? (
+      {isRequestable && requestModal ? (
         <CatalogRequestModal
-          open={requestModal}
           onSuccess={() => {
             toast({
               type: 'success',

--- a/apps/frontend-manage/src/components/catalog/collections/CatalogCollectionDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/collections/CatalogCollectionDeletionModal.tsx
@@ -9,7 +9,6 @@ import { useTranslations } from 'next-intl'
 interface CatalogCollectionDeletionModalProps {
   catalogCollectionId: string
   catalogCollectionName: string
-  open: boolean
   onClose: () => void
   onSuccess: () => void
 }
@@ -17,7 +16,6 @@ interface CatalogCollectionDeletionModalProps {
 function CatalogCollectionDeletionModal({
   catalogCollectionId,
   catalogCollectionName,
-  open,
   onClose,
   onSuccess,
 }: CatalogCollectionDeletionModalProps) {
@@ -28,7 +26,7 @@ function CatalogCollectionDeletionModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.catalog.deleteCatalogCollectionTitle')}
       secondaryLabel={t('shared.generic.cancel')}

--- a/apps/frontend-manage/src/components/catalog/collections/CatalogCollectionNameChangeModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/collections/CatalogCollectionNameChangeModal.tsx
@@ -8,19 +8,15 @@ import { Formik } from 'formik'
 import { useTranslations } from 'next-intl'
 import * as Yup from 'yup'
 
-interface CatalogCollectionNameChangeModalProps {
-  catalogCollectionId: string
-  name: string
-  open: boolean
-  onClose: () => void
-}
-
 function CatalogCollectionNameChangeModal({
   catalogCollectionId,
   name,
-  open,
   onClose,
-}: CatalogCollectionNameChangeModalProps) {
+}: {
+  catalogCollectionId: string
+  name: string
+  onClose: () => void
+}) {
   const t = useTranslations()
   const [changeCatalogCollectionName] = useMutation(
     ChangeCatalogCollectionNameDocument
@@ -39,9 +35,9 @@ function CatalogCollectionNameChangeModal({
 
   return (
     <Modal
+      open
       hideCloseButton
       escapeDisabled
-      open={open}
       onClose={onClose}
       title={t('manage.catalog.changeCatalogCollectionName')}
       className={{ content: 'max-w-xl pb-1' }}

--- a/apps/frontend-manage/src/components/catalog/collections/CreateCatalogCollectionModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/collections/CreateCatalogCollectionModal.tsx
@@ -28,116 +28,114 @@ function CreateCatalogCollectionModal({
   const [createCatalogCollection] = useMutation(CreateCatalogCollectionDocument)
 
   return (
-    <>
-      <Modal
-        open
-        onClose={onClose}
-        title={t('manage.catalog.createCatalogCollectionTitle')}
-        data={{ cy: 'create-catalog-collection-modal' }}
-        className={{ content: 'pb-1' }}
-      >
-        <div className="mb-4 text-sm">
-          {t('manage.catalog.createCatalogCollectionDescription')}
-        </div>
+    <Modal
+      open
+      onClose={onClose}
+      title={t('manage.catalog.createCatalogCollectionTitle')}
+      data={{ cy: 'create-catalog-collection-modal' }}
+      className={{ content: 'pb-1' }}
+    >
+      <div className="mb-4 text-sm">
+        {t('manage.catalog.createCatalogCollectionDescription')}
+      </div>
 
-        <Formik
-          initialValues={{
-            name: '',
-            access: ObjectAccess.Public,
-          }}
-          validationSchema={yup.object().shape({
-            name: yup.string().required(t('manage.catalog.nameRequired')),
-            access: yup.string().required(t('manage.catalog.accessRequired')),
-          })}
-          onSubmit={async (values, { resetForm }) => {
-            try {
-              const res = await createCatalogCollection({
-                variables: {
-                  name: values.name,
-                  access: values.access as ObjectAccess,
-                },
-                update: (cache, { data }) => {
-                  if (!data?.createCatalogCollection) return
+      <Formik
+        initialValues={{
+          name: '',
+          access: ObjectAccess.Public,
+        }}
+        validationSchema={yup.object().shape({
+          name: yup.string().required(t('manage.catalog.nameRequired')),
+          access: yup.string().required(t('manage.catalog.accessRequired')),
+        })}
+        onSubmit={async (values, { resetForm }) => {
+          try {
+            const res = await createCatalogCollection({
+              variables: {
+                name: values.name,
+                access: values.access as ObjectAccess,
+              },
+              update: (cache, { data }) => {
+                if (!data?.createCatalogCollection) return
 
-                  const prevCollections = cache.readQuery({
-                    query: GetCatalogCollectionsListDocument,
-                  })
+                const prevCollections = cache.readQuery({
+                  query: GetCatalogCollectionsListDocument,
+                })
 
-                  if (!prevCollections?.getCatalogCollectionsList) {
-                    return
-                  }
+                if (!prevCollections?.getCatalogCollectionsList) {
+                  return
+                }
 
-                  cache.writeQuery({
-                    query: GetCatalogCollectionsListDocument,
-                    data: {
-                      getCatalogCollectionsList: [
-                        ...(prevCollections.getCatalogCollectionsList ?? []),
-                        data.createCatalogCollection,
-                      ],
-                    },
-                  })
-                },
-              })
+                cache.writeQuery({
+                  query: GetCatalogCollectionsListDocument,
+                  data: {
+                    getCatalogCollectionsList: [
+                      ...(prevCollections.getCatalogCollectionsList ?? []),
+                      data.createCatalogCollection,
+                    ],
+                  },
+                })
+              },
+            })
 
-              if (res.data?.createCatalogCollection) {
-                resetForm()
-                onSuccess()
-              } else {
-                onError()
-              }
-            } catch (error) {
-              console.error('Error creating catalog collection:', error)
+            if (res.data?.createCatalogCollection) {
+              resetForm()
+              onSuccess()
+            } else {
               onError()
             }
-          }}
-        >
-          {({ values, setFieldValue, isValid, isSubmitting }) => (
-            <Form className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2 md:flex-row">
-                <FormikTextField
-                  name="name"
-                  label={t('manage.catalog.collectionName')}
-                  tooltip={t('manage.catalog.collectionNameTooltip')}
-                  placeholder={t('manage.catalog.collectionNamePlaceholder')}
-                  required
-                  data={{ cy: 'catalog-collection-name-input' }}
-                />
-
-                <ObjectAccessSelection
-                  hideTooltip
-                  value={values.access}
-                  onChange={(value) => setFieldValue('access', value)}
-                  cyPrefix="modal"
-                />
-              </div>
-              <UserNotification
-                message={t(
-                  `manage.catalog.accessDescription${values.access as ObjectAccess}`
-                )}
+          } catch (error) {
+            console.error('Error creating catalog collection:', error)
+            onError()
+          }
+        }}
+      >
+        {({ values, setFieldValue, isValid, isSubmitting }) => (
+          <Form className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2 md:flex-row">
+              <FormikTextField
+                name="name"
+                label={t('manage.catalog.collectionName')}
+                tooltip={t('manage.catalog.collectionNameTooltip')}
+                placeholder={t('manage.catalog.collectionNamePlaceholder')}
+                required
+                data={{ cy: 'catalog-collection-name-input' }}
               />
 
-              <div className="flex justify-between gap-2">
-                <Button
-                  onClick={onClose}
-                  data={{ cy: 'cancel-catalog-collection-creation' }}
-                >
-                  <Button.Label>{t('shared.generic.cancel')}</Button.Label>
-                </Button>
-                <Button
-                  type="submit"
-                  primary
-                  disabled={!isValid || isSubmitting}
-                  loading={isSubmitting}
-                  data={{ cy: 'create-catalog-collection-submit' }}
-                >
-                  <Button.Label>{t('shared.generic.create')}</Button.Label>
-                </Button>
-              </div>
-            </Form>
-          )}
-        </Formik>
-      </Modal>
-    </>
+              <ObjectAccessSelection
+                hideTooltip
+                value={values.access}
+                onChange={(value) => setFieldValue('access', value)}
+                cyPrefix="modal"
+              />
+            </div>
+            <UserNotification
+              message={t(
+                `manage.catalog.accessDescription${values.access as ObjectAccess}`
+              )}
+            />
+
+            <div className="flex justify-between gap-2">
+              <Button
+                onClick={onClose}
+                data={{ cy: 'cancel-catalog-collection-creation' }}
+              >
+                <Button.Label>{t('shared.generic.cancel')}</Button.Label>
+              </Button>
+              <Button
+                type="submit"
+                primary
+                disabled={!isValid || isSubmitting}
+                loading={isSubmitting}
+                data={{ cy: 'create-catalog-collection-submit' }}
+              >
+                <Button.Label>{t('shared.generic.create')}</Button.Label>
+              </Button>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </Modal>
   )
 }
 

--- a/apps/frontend-manage/src/components/catalog/collections/CreateCatalogCollectionModal.tsx
+++ b/apps/frontend-manage/src/components/catalog/collections/CreateCatalogCollectionModal.tsx
@@ -15,26 +15,22 @@ import { useTranslations } from 'next-intl'
 import * as yup from 'yup'
 import ObjectAccessSelection from '../administration/ObjectAccessSelection'
 
-interface CreateCatalogCollectionModalProps {
-  open: boolean
-  onClose: () => void
-  onSuccess: () => void
-  onError: () => void
-}
-
 function CreateCatalogCollectionModal({
-  open,
   onClose,
   onSuccess,
   onError,
-}: CreateCatalogCollectionModalProps) {
+}: {
+  onClose: () => void
+  onSuccess: () => void
+  onError: () => void
+}) {
   const t = useTranslations()
   const [createCatalogCollection] = useMutation(CreateCatalogCollectionDocument)
 
   return (
     <>
       <Modal
-        open={open}
+        open
         onClose={onClose}
         title={t('manage.catalog.createCatalogCollectionTitle')}
         data={{ cy: 'create-catalog-collection-modal' }}

--- a/apps/frontend-manage/src/components/common/Header.tsx
+++ b/apps/frontend-manage/src/components/common/Header.tsx
@@ -302,11 +302,9 @@ function Header({ user }: { user?: User | null }): React.ReactElement {
           className={{ root: '-gap-1 flex flex-row' }}
         />
       </div>
-      <SupportModal
-        open={showSupportModal}
-        setOpen={setShowSupportModal}
-        user={user}
-      />
+      {showSupportModal && (
+        <SupportModal onClose={() => setShowSupportModal(false)} user={user} />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/common/SupportModal.tsx
+++ b/apps/frontend-manage/src/components/common/SupportModal.tsx
@@ -19,21 +19,21 @@ import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import SupportEntry from './SupportEntry'
 
-interface SupportModalProps {
-  open: boolean
-  setOpen: (newOpen: boolean) => void
+function SupportModal({
+  onClose,
+  user,
+}: {
+  onClose: () => void
   user?: User | null
-}
-
-function SupportModal({ open, setOpen, user }: SupportModalProps) {
+}) {
   const t = useTranslations()
 
   return (
     <Modal
+      open
       fullScreen
       title={t('manage.support.modalTitle')}
-      open={open}
-      onClose={() => setOpen(false)}
+      onClose={onClose}
       className={{
         overlay: 'my-auto text-black',
         title: 'text-left text-xl md:text-2xl',

--- a/apps/frontend-manage/src/components/courses/CourseListButton.tsx
+++ b/apps/frontend-manage/src/components/courses/CourseListButton.tsx
@@ -212,14 +212,14 @@ function CourseListButton({
         ) : null}
       </Button>
 
-      {course && dataUser?.userProfile?.privatePreview && (
+      {course && dataUser?.userProfile?.privatePreview && activityLogOpen ? (
         <ActivityLogDialog
           objectId={course.id}
           objectType={ObjectType.Course}
           open={activityLogOpen}
-          onOpenChange={setActivityLogOpen}
+          onClose={() => setActivityLogOpen(false)}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/courses/CourseOverviewHeader.tsx
+++ b/apps/frontend-manage/src/components/courses/CourseOverviewHeader.tsx
@@ -208,7 +208,6 @@ function CourseOverviewHeader({
       {courseSettingsModal && (
         <CourseManipulationModal
           initialValues={course}
-          modalOpen={courseSettingsModal}
           earliestGroupDeadline={earliestGroupDeadline}
           earliestStartDate={earliestStartDate}
           latestEndDate={latestEndDate}
@@ -264,23 +263,24 @@ function CourseOverviewHeader({
         />
       )}
 
-      {sharingModal && course.isManager && (
+      {sharingModal && course.isManager ? (
         <ObjectSharingModalWrapper
           objectUuid={course.id}
           objectName={course.name}
           objectType={ObjectType.Course}
           isOwner={course.isOwner ?? false}
-          open={sharingModal}
           onClose={() => setSharingModal(false)}
         />
-      )}
+      ) : null}
 
-      <ActivityLogDialog
-        objectId={course.id}
-        objectType={ObjectType.Course}
-        open={isActivityLogOpen}
-        onOpenChange={setIsActivityLogOpen}
-      />
+      {isActivityLogOpen && (
+        <ActivityLogDialog
+          objectId={course.id}
+          objectType={ObjectType.Course}
+          open={isActivityLogOpen}
+          onClose={() => setIsActivityLogOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/courses/GroupActivityElement.tsx
+++ b/apps/frontend-manage/src/components/courses/GroupActivityElement.tsx
@@ -319,27 +319,30 @@ function GroupActivityElement({
 
         <div>{statusMap[groupActivity.status ?? PublicationStatus.Draft]}</div>
       </div>
-      <GroupActivityDeletionModal
-        open={deletionModal}
-        setOpen={setDeletionModal}
-        activityId={groupActivity.id}
-        courseId={courseId}
-      />
-      <GroupActivityEndingModal
-        open={endingModal}
-        setOpen={setEndingModal}
-        activityId={groupActivity.id}
-        courseId={courseId}
-      />
-      <GroupActivityStartingModal
-        open={startingModal}
-        setOpen={setStartingModal}
-        activityId={groupActivity.id}
-        activityEndDate={groupActivity.scheduledEndAt}
-        groupDeadlineDate={groupDeadlineDate}
-        numOfParticipantGroups={numOfParticipantGroups}
-        courseId={courseId}
-      />
+      {deletionModal && (
+        <GroupActivityDeletionModal
+          onClose={() => setDeletionModal(false)}
+          activityId={groupActivity.id}
+          courseId={courseId}
+        />
+      )}
+      {endingModal && (
+        <GroupActivityEndingModal
+          onClose={() => setEndingModal(false)}
+          activityId={groupActivity.id}
+          courseId={courseId}
+        />
+      )}
+      {startingModal && (
+        <GroupActivityStartingModal
+          onClose={() => setStartingModal(false)}
+          activityId={groupActivity.id}
+          activityEndDate={groupActivity.scheduledEndAt}
+          groupDeadlineDate={groupDeadlineDate}
+          numOfParticipantGroups={numOfParticipantGroups}
+          courseId={courseId}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/courses/GroupsList.tsx
+++ b/apps/frontend-manage/src/components/courses/GroupsList.tsx
@@ -102,11 +102,12 @@ function GroupsList({
           ))}
         </div>
       </TabContent>
-      <AssignmentConfirmationModal
-        courseId={courseId}
-        open={open}
-        setOpen={setOpen}
-      />
+      {open && (
+        <AssignmentConfirmationModal
+          courseId={courseId}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/courses/LiveQuizElement.tsx
+++ b/apps/frontend-manage/src/components/courses/LiveQuizElement.tsx
@@ -288,13 +288,14 @@ function LiveQuizElement({ quiz }: { quiz: LiveQuizListElementType }) {
           </div>
         </div>
 
-        <LiveQuizDeletionModal
-          quizId={quiz.id}
-          open={deletionModal}
-          setOpen={setDeletionModal}
-          onDelete={deleteLiveQuiz}
-          deleting={deletingLiveQuiz}
-        />
+        {deletionModal && (
+          <LiveQuizDeletionModal
+            quizId={quiz.id}
+            onClose={() => setDeletionModal(false)}
+            onDelete={deleteLiveQuiz}
+            deleting={deletingLiveQuiz}
+          />
+        )}
       </div>
 
       <div className="flex w-full flex-row justify-between">

--- a/apps/frontend-manage/src/components/courses/MicroLearningElement.tsx
+++ b/apps/frontend-manage/src/components/courses/MicroLearningElement.tsx
@@ -461,28 +461,31 @@ function MicroLearningElement({
         </div>
       </div>
 
-      <MicroLearningDeletionModal
-        open={deletionModal}
-        setOpen={setDeletionModal}
-        activityId={microLearning.id}
-        courseId={courseId}
-      />
-      <MicroLearningEndingModal
-        open={endingModal}
-        setOpen={setEndingModal}
-        activityId={microLearning.id}
-        courseId={courseId}
-      />
-      <ExtensionModal
-        type="microLearning"
-        id={microLearning.id}
-        currentEndDate={microLearning.scheduledEndAt}
-        courseId={courseId}
-        title={t('manage.course.extendMicroLearning')}
-        description={t('manage.course.extendMicroLearningDescription')}
-        open={extensionModal}
-        setOpen={setExtensionModal}
-      />
+      {deletionModal && (
+        <MicroLearningDeletionModal
+          onClose={() => setDeletionModal(false)}
+          activityId={microLearning.id}
+          courseId={courseId}
+        />
+      )}
+      {endingModal && (
+        <MicroLearningEndingModal
+          onClose={() => setEndingModal(false)}
+          activityId={microLearning.id}
+          courseId={courseId}
+        />
+      )}
+      {extensionModal && (
+        <ExtensionModal
+          type="microLearning"
+          id={microLearning.id}
+          currentEndDate={microLearning.scheduledEndAt}
+          courseId={courseId}
+          title={t('manage.course.extendMicroLearning')}
+          description={t('manage.course.extendMicroLearningDescription')}
+          onClose={() => setExtensionModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/courses/PracticeQuizElement.tsx
+++ b/apps/frontend-manage/src/components/courses/PracticeQuizElement.tsx
@@ -412,8 +412,7 @@ function PracticeQuizElement({
         </div>
       </div>
       <PracticeQuizDeletionModal
-        open={deletionModal}
-        setOpen={setDeletionModal}
+        onClose={() => setDeletionModal(false)}
         activityId={practiceQuiz.id}
         courseId={courseId}
       />

--- a/apps/frontend-manage/src/components/courses/PracticeQuizElement.tsx
+++ b/apps/frontend-manage/src/components/courses/PracticeQuizElement.tsx
@@ -411,11 +411,13 @@ function PracticeQuizElement({
           {statusMap[practiceQuiz.status]}
         </div>
       </div>
-      <PracticeQuizDeletionModal
-        onClose={() => setDeletionModal(false)}
-        activityId={practiceQuiz.id}
-        courseId={courseId}
-      />
+      {deletionModal && (
+        <PracticeQuizDeletionModal
+          onClose={() => setDeletionModal(false)}
+          activityId={practiceQuiz.id}
+          courseId={courseId}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/courses/actions/ActivityNameChangeModal.tsx
+++ b/apps/frontend-manage/src/components/courses/actions/ActivityNameChangeModal.tsx
@@ -16,8 +16,7 @@ interface ActivityNameChangeModalProps {
   name: string
   displayName: string
   courseId?: string | null
-  open: boolean
-  setOpen: (value: boolean) => void
+  onClose: () => void
 }
 
 function ActivityNameChangeModal({
@@ -26,8 +25,7 @@ function ActivityNameChangeModal({
   name,
   displayName,
   courseId,
-  open,
-  setOpen,
+  onClose,
 }: ActivityNameChangeModalProps) {
   const t = useTranslations()
   const [changeActivityName] = useMutation(ChangeActivityNameDocument)
@@ -41,10 +39,10 @@ function ActivityNameChangeModal({
 
   return (
     <Modal
+      open
       hideCloseButton
       escapeDisabled
-      open={open}
-      onClose={(): void => setOpen(false)}
+      onClose={onClose}
       title={t('manage.activities.changeActivityName')}
       className={{
         content: 'max-w-lg pb-1',
@@ -85,7 +83,7 @@ function ActivityNameChangeModal({
               options: { duration: 4000 },
             })
             setSubmitting(false)
-            setOpen(false)
+            onClose()
           } else {
             toast({
               type: 'error',
@@ -130,7 +128,7 @@ function ActivityNameChangeModal({
             <div className="mt-3 flex flex-row justify-between">
               <Button
                 type="button"
-                onClick={(): void => setOpen(false)}
+                onClick={onClose}
                 data={{ cy: 'activity-name-change-cancel' }}
               >
                 <Button.Label>{t('shared.generic.cancel')}</Button.Label>

--- a/apps/frontend-manage/src/components/courses/actions/PublishGroupActivityButton.tsx
+++ b/apps/frontend-manage/src/components/courses/actions/PublishGroupActivityButton.tsx
@@ -31,15 +31,16 @@ function PublishGroupActivityButton({
         <Button.Icon icon={faUserGroup} />
         <Button.Label>{t('manage.course.publishGroupActivity')}</Button.Label>
       </Button>
-      <PublishConfirmationModal
-        open={publishModal}
-        setOpen={setPublishModal}
-        elementType={ElementInstanceType.GroupActivity}
-        elementId={groupActivity.id}
-        title={groupActivity.name}
-        courseId={courseId}
-        publicationHint={t('manage.course.groupActivityPublishingHint')}
-      />
+      {publishModal && (
+        <PublishConfirmationModal
+          onClose={() => setPublishModal(false)}
+          elementType={ElementInstanceType.GroupActivity}
+          elementId={groupActivity.id}
+          title={groupActivity.name}
+          courseId={courseId}
+          publicationHint={t('manage.course.groupActivityPublishingHint')}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/courses/actions/PublishMicroLearningButton.tsx
+++ b/apps/frontend-manage/src/components/courses/actions/PublishMicroLearningButton.tsx
@@ -31,15 +31,16 @@ function PublishMicroLearningButton({
         <Button.Icon icon={faUserGroup} />
         <Button.Label>{t('manage.course.publishMicrolearning')}</Button.Label>
       </Button>
-      <PublishConfirmationModal
-        open={publishModal}
-        setOpen={setPublishModal}
-        elementType={ElementInstanceType.Microlearning}
-        elementId={microLearning.id}
-        title={microLearning.name}
-        courseId={courseId}
-        publicationHint={t('manage.course.microPublishingHint')}
-      />
+      {publishModal && (
+        <PublishConfirmationModal
+          onClose={() => setPublishModal(false)}
+          elementType={ElementInstanceType.Microlearning}
+          elementId={microLearning.id}
+          title={microLearning.name}
+          courseId={courseId}
+          publicationHint={t('manage.course.microPublishingHint')}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/courses/actions/PublishPracticeQuizButton.tsx
+++ b/apps/frontend-manage/src/components/courses/actions/PublishPracticeQuizButton.tsx
@@ -30,14 +30,15 @@ function PublishPracticeQuizButton({
         <Button.Icon icon={faUserGroup} />
         <Button.Label>{t('manage.course.publishPracticeQuiz')}</Button.Label>
       </Button>
-      <PracticeQuizPublishingModal
-        elementId={practiceQuiz.id}
-        title={practiceQuiz.name}
-        open={publishModal}
-        setOpen={setPublishModal}
-        courseId={courseId}
-        courseStartDate={courseStartDate}
-      />
+      {publishModal && (
+        <PracticeQuizPublishingModal
+          elementId={practiceQuiz.id}
+          title={practiceQuiz.name}
+          onClose={() => setPublishModal(false)}
+          courseId={courseId}
+          courseStartDate={courseStartDate}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/courses/groupActivity/FinalizeGradingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/groupActivity/FinalizeGradingModal.tsx
@@ -5,68 +5,62 @@ import { FinalizeGroupActivityGradingDocument } from '@klicker-uzh/graphql/dist/
 import { Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
-interface FinalizeGradingModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  activityId: string
-}
-
 function FinalizeGradingModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
-}: FinalizeGradingModalProps) {
+}: {
+  onClose: () => void
+  activityId: string
+}) {
   const t = useTranslations()
   const [finalizeGroupActivityGrading, { loading: finalizingGrading }] =
     useMutation(FinalizeGroupActivityGradingDocument)
 
   return (
-    <>
-      <Modal
-        title={t('manage.groupActivity.finalizeGrading')}
-        primaryLabel={t('shared.generic.confirm')}
-        primaryLoading={finalizingGrading}
-        onPrimaryAction={async () => {
-          const { data } = await finalizeGroupActivityGrading({
-            variables: { id: activityId },
-          })
+    <Modal
+      open
+      title={t('manage.groupActivity.finalizeGrading')}
+      primaryLabel={t('shared.generic.confirm')}
+      primaryLoading={finalizingGrading}
+      onPrimaryAction={async () => {
+        const { data } = await finalizeGroupActivityGrading({
+          variables: { id: activityId },
+        })
 
-          if (data?.finalizeGroupActivityGrading?.id) {
-            toast({
-              type: 'success',
-              message: t('manage.groupActivity.finalizeGradingSuccess'),
-              options: { duration: 4000 },
-            })
-          } else {
-            toast({
-              type: 'error',
-              message: t('manage.groupActivity.finalizeGradingError'),
-              options: { duration: 6000 },
-            })
-          }
-          setOpen(false)
-        }}
-        dataPrimaryAction={{ cy: 'confirm-finalize-grading' }}
-        secondaryLabel={t('shared.generic.cancel')}
-        onSecondaryAction={() => setOpen(false)}
-        dataSecondaryAction={{ cy: 'cancel-finalize-grading' }}
-        onClose={() => setOpen(false)}
-        open={open}
-        hideCloseButton={true}
-        className={{ content: 'max-w-xl' }}
-      >
-        <div className="flex flex-row items-center gap-4">
-          <FontAwesomeIcon
-            icon={faTriangleExclamation}
-            size="xl"
-            className="text-orange-600"
-          />
-          <div className="text-base">
-            {t('manage.groupActivity.confirmFinalizeGrading')}
-          </div>
+        if (data?.finalizeGroupActivityGrading?.id) {
+          toast({
+            type: 'success',
+            message: t('manage.groupActivity.finalizeGradingSuccess'),
+            options: { duration: 4000 },
+          })
+        } else {
+          toast({
+            type: 'error',
+            message: t('manage.groupActivity.finalizeGradingError'),
+            options: { duration: 6000 },
+          })
+        }
+        onClose()
+      }}
+      dataPrimaryAction={{ cy: 'confirm-finalize-grading' }}
+      secondaryLabel={t('shared.generic.cancel')}
+      onSecondaryAction={onClose}
+      dataSecondaryAction={{ cy: 'cancel-finalize-grading' }}
+      onClose={onClose}
+      hideCloseButton={true}
+      className={{ content: 'max-w-xl' }}
+    >
+      <div className="flex flex-row items-center gap-4">
+        <FontAwesomeIcon
+          icon={faTriangleExclamation}
+          size="xl"
+          className="text-orange-600"
+        />
+        <div className="text-base">
+          {t('manage.groupActivity.confirmFinalizeGrading')}
         </div>
-      </Modal>
-    </>
+      </div>
+    </Modal>
   )
 }
 

--- a/apps/frontend-manage/src/components/courses/groupActivity/GroupActivityExtensionButton.tsx
+++ b/apps/frontend-manage/src/components/courses/groupActivity/GroupActivityExtensionButton.tsx
@@ -35,16 +35,17 @@ function GroupActivityExtensionButton({
         <Button.Icon icon={faCalendar} />
         <Button.Label>{t('manage.course.extendGroupActivity')}</Button.Label>
       </Button>
-      <ExtensionModal
-        type="groupActivity"
-        id={activityId}
-        currentEndDate={scheduledEndAt}
-        courseId={courseId}
-        title={t('manage.course.extendGroupActivity')}
-        description={t('manage.course.extendGroupActivityDescription')}
-        open={extensionModal}
-        setOpen={setExtensionModal}
-      />
+      {extensionModal && (
+        <ExtensionModal
+          type="groupActivity"
+          id={activityId}
+          currentEndDate={scheduledEndAt}
+          courseId={courseId}
+          title={t('manage.course.extendGroupActivity')}
+          description={t('manage.course.extendGroupActivityDescription')}
+          onClose={() => setExtensionModal(false)}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/courses/groupActivity/SubmissionSwitchModal.tsx
+++ b/apps/frontend-manage/src/components/courses/groupActivity/SubmissionSwitchModal.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from 'next-intl'
 
 interface SubmissionSwitchModalProps {
   nextSubmission: number
-  switchingModal: boolean
   setSelectedSubmission: (submissionId: number) => void
   setCurrentEditing: (editing: boolean) => void
   setSwitchingModal: (switching: boolean) => void
@@ -11,7 +10,6 @@ interface SubmissionSwitchModalProps {
 
 function SubmissionSwitchModal({
   nextSubmission,
-  switchingModal,
   setSelectedSubmission,
   setCurrentEditing,
   setSwitchingModal,
@@ -20,6 +18,7 @@ function SubmissionSwitchModal({
 
   return (
     <Modal
+      open
       title={t('manage.groupActivity.switchSubmission')}
       primaryLabel={t('shared.generic.confirm')}
       onPrimaryAction={() => {
@@ -32,7 +31,6 @@ function SubmissionSwitchModal({
       onSecondaryAction={() => setSwitchingModal(false)}
       dataSecondaryAction={{ cy: 'cancel-submission-switch' }}
       onClose={(): void => setSwitchingModal(false)}
-      open={switchingModal}
       hideCloseButton={true}
       className={{ content: 'max-w-xl' }}
     >

--- a/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/groups/AssignmentConfirmationModal.tsx
@@ -8,12 +8,10 @@ import { useTranslations } from 'next-intl'
 
 function AssignmentConfirmationModal({
   courseId,
-  open,
-  setOpen,
+  onClose,
 }: {
   courseId: string
-  open: boolean
-  setOpen: (value: boolean) => void
+  onClose: () => void
 }) {
   const t = useTranslations()
   const [
@@ -50,8 +48,8 @@ function AssignmentConfirmationModal({
 
   return (
     <Modal
-      open={open}
-      onClose={(): void => setOpen(false)}
+      open
+      onClose={onClose}
       title={t('manage.course.finalizeRandomGroupAssignment')}
       primaryLabel={t('shared.generic.confirm')}
       primaryLoading={randomGroupCreationLoading}
@@ -65,7 +63,7 @@ function AssignmentConfirmationModal({
             message: t('manage.course.groupAssignmentSuccessful'),
             options: { duration: 5000 },
           })
-          setOpen(false)
+          onClose()
         } else {
           console.error('Error while creating random groups')
           toast({
@@ -77,7 +75,7 @@ function AssignmentConfirmationModal({
       }}
       dataPrimaryAction={{ cy: 'confirm-random-group-assignment' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => setOpen(false)}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'cancel-random-group-assignment' }}
     >
       <div className="mb-2 font-bold">{t('shared.generic.pleaseReview')}</div>

--- a/apps/frontend-manage/src/components/courses/modals/ActivityConfirmationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/ActivityConfirmationModal.tsx
@@ -3,8 +3,7 @@ import { useTranslations } from 'next-intl'
 import React from 'react'
 
 interface ActivityConfirmationModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
+  onClose: () => void
   title: string
   message: string | React.ReactNode
   onSubmit: () => Promise<any>
@@ -16,8 +15,7 @@ interface ActivityConfirmationModalProps {
 }
 
 function ActivityConfirmationModal({
-  open,
-  setOpen,
+  onClose,
   title,
   message,
   onSubmit,
@@ -34,10 +32,8 @@ function ActivityConfirmationModal({
 
   return (
     <Modal
-      open={open}
-      onClose={() => {
-        setOpen(false)
-      }}
+      open
+      onClose={onClose}
       className={{ content: '!w-full max-w-[50rem]' }}
       title={title}
       primaryLabel={t('shared.generic.confirm')}
@@ -52,13 +48,11 @@ function ActivityConfirmationModal({
       }
       onPrimaryAction={async () => {
         await onSubmit()
-        setOpen(false)
+        onClose()
       }}
       dataPrimaryAction={{ cy: 'confirmation-modal-confirm' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => {
-        setOpen(false)
-      }}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'confirmation-modal-cancel' }}
       dataCloseButton={{ cy: 'confirmation-modal-close' }}
     >

--- a/apps/frontend-manage/src/components/courses/modals/CourseArchiveModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/CourseArchiveModal.tsx
@@ -6,19 +6,15 @@ import {
 import { Modal, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
-interface CourseArchiveModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  courseId: string | null
-  isArchived: boolean
-}
-
 function CourseArchiveModal({
-  open,
-  setOpen,
+  onClose,
   courseId,
   isArchived,
-}: CourseArchiveModalProps) {
+}: {
+  onClose: () => void
+  courseId: string | null
+  isArchived: boolean
+}) {
   const t = useTranslations()
   const [toggleArchiveCourse, { loading }] = useMutation(
     ToggleArchiveCourseDocument,
@@ -31,10 +27,8 @@ function CourseArchiveModal({
 
   return (
     <Modal
-      open={open}
-      onClose={() => {
-        setOpen(false)
-      }}
+      open
+      onClose={onClose}
       title={
         isArchived
           ? t('manage.courseList.unarchiveCourse')
@@ -54,13 +48,11 @@ function CourseArchiveModal({
             },
           },
         })
-        setOpen(false)
+        onClose()
       }}
       dataPrimaryAction={{ cy: 'course-archive-modal-confirm' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => {
-        setOpen(false)
-      }}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'course-archive-modal-cancel' }}
       className={{ content: 'max-w-[30rem]' }}
     >

--- a/apps/frontend-manage/src/components/courses/modals/CourseDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/CourseDeletionModal.tsx
@@ -4,6 +4,7 @@ import {
   GetCourseSummaryDocument,
   GetUserCoursesDocument,
 } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
@@ -87,11 +88,10 @@ function CourseDeletionModal({
     })
   }, [courseId, data?.getCourseSummary])
 
-  if (!courseId || !data?.getCourseSummary) {
+  const summary = data?.getCourseSummary
+  if (!courseId) {
     return null
   }
-
-  const summary = data.getCourseSummary
 
   return (
     <Modal
@@ -132,11 +132,15 @@ function CourseDeletionModal({
       }}
       dataSecondaryAction={{ cy: 'course-deletion-modal-cancel' }}
     >
-      <CourseDeletionConfirmations
-        summary={summary}
-        confirmations={confirmations}
-        setConfirmations={setConfirmations}
-      />
+      {queryLoading || !summary ? (
+        <Loader />
+      ) : (
+        <CourseDeletionConfirmations
+          summary={summary}
+          confirmations={confirmations}
+          setConfirmations={setConfirmations}
+        />
+      )}
     </Modal>
   )
 }

--- a/apps/frontend-manage/src/components/courses/modals/CourseDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/CourseDeletionModal.tsx
@@ -19,17 +19,13 @@ export interface CourseDeletionConfirmationType {
   deleteLeaderboardEntries: boolean
 }
 
-interface CourseDeletionModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  courseId: string | null
-}
-
 function CourseDeletionModal({
-  open,
-  setOpen,
+  onClose,
   courseId,
-}: CourseDeletionModalProps) {
+}: {
+  onClose: () => void
+  courseId: string | null
+}) {
   const initialConfirmations: CourseDeletionConfirmationType = {
     deleteParticipations: false,
     disconnectLiveQuizzes: false,
@@ -99,9 +95,9 @@ function CourseDeletionModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={() => {
-        setOpen(false)
+        onClose()
         setConfirmations({ ...initialConfirmations })
       }}
       className={{ content: '!w-full max-w-[60rem]' }}
@@ -125,13 +121,13 @@ function CourseDeletionModal({
             },
           },
         })
-        setOpen(false)
+        onClose()
         setConfirmations({ ...initialConfirmations })
       }}
       dataPrimaryAction={{ cy: 'course-deletion-modal-confirm' }}
       secondaryLabel={t('shared.generic.close')}
       onSecondaryAction={() => {
-        setOpen(false)
+        onClose()
         setConfirmations({ ...initialConfirmations })
       }}
       dataSecondaryAction={{ cy: 'course-deletion-modal-cancel' }}

--- a/apps/frontend-manage/src/components/courses/modals/CourseManipulationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/CourseManipulationModal.tsx
@@ -22,7 +22,6 @@ import GamificationSettingMonitor from './GamificationSettingMonitor'
 
 interface CourseManipulationModalProps {
   initialValues?: Course
-  modalOpen: boolean
   earliestGroupDeadline?: string
   earliestStartDate?: string
   latestEndDate?: string
@@ -50,7 +49,6 @@ export interface CourseManipulationFormData {
 
 function CourseManipulationModal({
   initialValues,
-  modalOpen,
   earliestGroupDeadline,
   earliestStartDate,
   latestEndDate,
@@ -183,13 +181,13 @@ function CourseManipulationModal({
 
   return (
     <Modal
+      open
       escapeDisabled
       title={
         initialValues
           ? t('manage.course.modifyCourse')
           : t('manage.courseList.createNewCourse')
       }
-      open={modalOpen}
       onClose={onModalClose}
       className={{ content: '!w-full' }}
     >

--- a/apps/frontend-manage/src/components/courses/modals/CourseRemovalModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/CourseRemovalModal.tsx
@@ -41,8 +41,7 @@ function CourseRemovalModal({
 
   return (
     <ActivityConfirmationModal
-      open={isModalOpen}
-      setOpen={setModalOpen}
+      onClose={() => setModalOpen(false)}
       title={t('manage.course.removeCourse')}
       message={t.rich('manage.course.confirmCourseRemoval', {
         name: title,

--- a/apps/frontend-manage/src/components/courses/modals/ExtensionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/ExtensionModal.tsx
@@ -18,8 +18,7 @@ interface ExtensionModalProps {
   courseId: string
   title: string
   description: string
-  open: boolean
-  setOpen: (value: boolean) => void
+  onClose: () => void
 }
 
 function ExtensionModal({
@@ -29,8 +28,7 @@ function ExtensionModal({
   courseId,
   title,
   description,
-  open,
-  setOpen,
+  onClose,
 }: ExtensionModalProps) {
   const t = useTranslations()
   const [extendMicroLearning] = useMutation(ExtendMicroLearningDocument)
@@ -38,8 +36,8 @@ function ExtensionModal({
 
   return (
     <Modal
-      onClose={(): void => setOpen(false)}
-      open={open}
+      open
+      onClose={onClose}
       hideCloseButton={true}
       title={title}
       className={{
@@ -109,7 +107,7 @@ function ExtensionModal({
             }
 
             setSubmitting(false)
-            setOpen(false)
+            onClose()
           }}
         >
           {({ isValid, isSubmitting }) => (
@@ -132,7 +130,7 @@ function ExtensionModal({
               />
               <div className="mt-3 flex flex-row justify-between">
                 <Button
-                  onClick={(): void => setOpen(false)}
+                  onClick={onClose}
                   data={{ cy: 'extend-activity-cancel' }}
                 >
                   <Button.Label>{t('shared.generic.cancel')}</Button.Label>

--- a/apps/frontend-manage/src/components/courses/modals/GroupActivityDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/GroupActivityDeletionModal.tsx
@@ -9,19 +9,15 @@ import { useEffect, useState } from 'react'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
-interface GroupActivityConfirmationModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  activityId: string
-  courseId: string
-}
-
-function GroupActivityConfirmationModal({
-  open,
-  setOpen,
+function GroupActivityDeletionModal({
+  onClose,
   activityId,
   courseId,
-}: GroupActivityConfirmationModalProps) {
+}: {
+  onClose: () => void
+  activityId: string
+  courseId: string
+}) {
   const t = useTranslations()
   const { data: summaryData, loading: summaryLoading } = useQuery(
     GetGroupActivitySummaryDocument,
@@ -72,8 +68,7 @@ function GroupActivityConfirmationModal({
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.course.deleteGroupActivity')}
       message={t('manage.course.deleteGroupActivityMessage')}
       onSubmit={async () => await deleteGroupActivity()}
@@ -126,4 +121,4 @@ function GroupActivityConfirmationModal({
   )
 }
 
-export default GroupActivityConfirmationModal
+export default GroupActivityDeletionModal

--- a/apps/frontend-manage/src/components/courses/modals/GroupActivityEndingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/GroupActivityEndingModal.tsx
@@ -10,19 +10,15 @@ import { useEffect, useState } from 'react'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
-interface GroupActivityEndingModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  activityId: string
-  courseId: string
-}
-
 function GroupActivityEndingModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
   courseId,
-}: GroupActivityEndingModalProps) {
+}: {
+  onClose: () => void
+  activityId: string
+  courseId: string
+}) {
   const t = useTranslations()
   const { data: summaryData, loading: summaryLoading } = useQuery(
     GetGroupActivitySummaryDocument,
@@ -72,8 +68,7 @@ function GroupActivityEndingModal({
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.course.endGroupActivity')}
       message={t('manage.course.endGroupActivityMessage')}
       onSubmit={async () => await endGroupActivity()}

--- a/apps/frontend-manage/src/components/courses/modals/GroupActivityStartingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/GroupActivityStartingModal.tsx
@@ -12,8 +12,7 @@ import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
 interface GroupActivityStartingModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
+  onClose: () => void
   activityId: string
   activityEndDate: string
   courseId: string
@@ -22,8 +21,7 @@ interface GroupActivityStartingModalProps {
 }
 
 function GroupActivityStartingModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
   activityEndDate,
   courseId,
@@ -58,18 +56,15 @@ function GroupActivityStartingModal({
 
   // on open, reset confirmations
   useEffect(() => {
-    if (open) {
-      setConfirmations({
-        participantGroups: false,
-        availableUntil: false,
-      })
-    }
-  }, [open])
+    setConfirmations({
+      participantGroups: false,
+      availableUntil: false,
+    })
+  }, [])
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.course.startGroupActivityNow')}
       message={t('manage.course.startGroupActivityNowMessage')}
       onSubmit={async () => await openGroupActivity()}

--- a/apps/frontend-manage/src/components/courses/modals/LiveQuizDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/LiveQuizDeletionModal.tsx
@@ -5,21 +5,17 @@ import { useEffect, useState } from 'react'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
-interface LiveQuizDeletionModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  quizId: string
-  onDelete: () => Promise<any>
-  deleting: boolean
-}
-
 function LiveQuizDeletionModal({
-  open,
-  setOpen,
+  onClose,
   quizId,
   onDelete,
   deleting,
-}: LiveQuizDeletionModalProps) {
+}: {
+  onClose: () => void
+  quizId: string
+  onDelete: () => Promise<any>
+  deleting: boolean
+}) {
   const t = useTranslations()
   const { data: summaryData, loading: summaryLoading } = useQuery(
     GetLiveQuizSummaryDocument,
@@ -55,8 +51,7 @@ function LiveQuizDeletionModal({
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.liveQuizzes.deleteLiveQuiz')}
       message={t('manage.liveQuizzes.deleteLiveQuizMessage')}
       onSubmit={async () => await onDelete()}

--- a/apps/frontend-manage/src/components/courses/modals/MicroLearningDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/MicroLearningDeletionModal.tsx
@@ -10,19 +10,15 @@ import { useEffect, useState } from 'react'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
-interface MicroLearningDeletionModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  activityId: string
-  courseId: string
-}
-
 function MicroLearningDeletionModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
   courseId,
-}: MicroLearningDeletionModalProps) {
+}: {
+  onClose: () => void
+  activityId: string
+  courseId: string
+}) {
   const t = useTranslations()
   const { data: summaryData, loading: summaryLoading } = useQuery(
     GetMicroLearningSummaryDocument,
@@ -73,8 +69,7 @@ function MicroLearningDeletionModal({
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.course.deleteMicroLearning')}
       message={t('manage.course.deleteMicroLearningMessage')}
       onSubmit={async () => await deleteMicroLearning()}

--- a/apps/frontend-manage/src/components/courses/modals/MicroLearningEndingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/MicroLearningEndingModal.tsx
@@ -9,19 +9,15 @@ import { useTranslations } from 'next-intl'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
-interface MicroLearningEndingModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  activityId: string
-  courseId: string
-}
-
 function MicroLearningEndingModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
   courseId,
-}: MicroLearningEndingModalProps) {
+}: {
+  onClose: () => void
+  activityId: string
+  courseId: string
+}) {
   const t = useTranslations()
   const { data: summaryData, loading: summaryLoading } = useQuery(
     GetMicroLearningSummaryDocument,
@@ -90,8 +86,7 @@ function MicroLearningEndingModal({
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.course.endMicroLearning')}
       message={t('manage.course.endMicroLearningMessage')}
       onSubmit={async () => await endMicroLearning()}

--- a/apps/frontend-manage/src/components/courses/modals/PracticeQuizDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/PracticeQuizDeletionModal.tsx
@@ -10,19 +10,15 @@ import { useEffect, useState } from 'react'
 import ConfirmationItem from '../../common/ConfirmationItem'
 import ActivityConfirmationModal from './ActivityConfirmationModal'
 
-interface PracticeQuizDeletionModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  activityId: string
-  courseId: string
-}
-
 function PracticeQuizDeletionModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
   courseId,
-}: PracticeQuizDeletionModalProps) {
+}: {
+  onClose: () => void
+  activityId: string
+  courseId: string
+}) {
   const t = useTranslations()
   const { data: summaryData, loading: summaryLoading } = useQuery(
     GetPracticeQuizSummaryDocument,
@@ -73,8 +69,7 @@ function PracticeQuizDeletionModal({
 
   return (
     <ActivityConfirmationModal
-      open={open}
-      setOpen={setOpen}
+      onClose={onClose}
       title={t('manage.course.deletePracticeQuiz')}
       message={t('manage.course.deletePracticeQuizMessage')}
       onSubmit={async () => await deletePracticeQuiz()}

--- a/apps/frontend-manage/src/components/courses/modals/PracticeQuizPublishingModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/PracticeQuizPublishingModal.tsx
@@ -18,8 +18,7 @@ interface PracticeQuizPublishingModalProps {
   title: string
   courseId: string
   courseStartDate: string
-  open: boolean
-  setOpen: (value: boolean) => void
+  onClose: () => void
 }
 
 function PracticeQuizPublishingModal({
@@ -27,8 +26,7 @@ function PracticeQuizPublishingModal({
   title,
   courseId,
   courseStartDate,
-  open,
-  setOpen,
+  onClose,
 }: PracticeQuizPublishingModalProps) {
   const t = useTranslations()
   const [publishPracticeQuiz, { loading: practiceQuizPublishing }] =
@@ -36,9 +34,9 @@ function PracticeQuizPublishingModal({
 
   return (
     <Modal
+      open
       title={`${t('shared.generic.practiceQuiz')}: ${title}`}
-      onClose={(): void => setOpen(false)}
-      open={open}
+      onClose={onClose}
       className={{ content: 'pb-2 text-base' }}
       dataCloseButton={{ cy: 'cancel-practice-quiz-publication' }}
     >
@@ -70,7 +68,7 @@ function PracticeQuizPublishingModal({
                   { query: GetUserActivitiesDocument },
                 ],
               })
-              setOpen(false)
+              onClose()
             }}
             loading={practiceQuizPublishing}
             data={{ cy: 'publish-practice-quiz-immediately' }}
@@ -109,7 +107,7 @@ function PracticeQuizPublishingModal({
                   { query: GetUserActivitiesDocument },
                 ],
               })
-              setOpen(false)
+              onClose()
             }}
             validationSchema={yup.object().shape({
               availableFrom: yup

--- a/apps/frontend-manage/src/components/courses/modals/PublishConfirmationModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/PublishConfirmationModal.tsx
@@ -10,8 +10,7 @@ import { H3, Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 interface PublishConfirmationModalProps {
-  open: boolean
-  setOpen: (value: boolean) => void
+  onClose: () => void
   elementType:
     | ElementInstanceType.Microlearning
     | ElementInstanceType.GroupActivity
@@ -22,8 +21,7 @@ interface PublishConfirmationModalProps {
 }
 
 function PublishConfirmationModal({
-  open,
-  setOpen,
+  onClose,
   elementType,
   elementId,
   title,
@@ -57,6 +55,7 @@ function PublishConfirmationModal({
 
   return (
     <Modal
+      open
       title={t(`manage.course.publishItem${elementType}`)}
       primaryLabel={t('shared.generic.confirm')}
       primaryLoading={mlPublishLoading || gaPublishLoading}
@@ -66,16 +65,15 @@ function PublishConfirmationModal({
         } else if (elementType === ElementInstanceType.GroupActivity) {
           await publishGroupActivity()
         }
-        setOpen(false)
+        onClose()
       }}
       dataPrimaryAction={{ cy: 'confirm-publish-action' }}
       secondaryLabel={t('shared.generic.cancel')}
       onSecondaryAction={() => {
-        setOpen(false)
+        onClose()
       }}
       dataSecondaryAction={{ cy: 'cancel-publish-action' }}
-      onClose={(): void => setOpen(false)}
-      open={open}
+      onClose={onClose}
       hideCloseButton={true}
       className={{
         content: 'w-[40rem]',

--- a/apps/frontend-manage/src/components/courses/modals/TagDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/TagDeletionModal.tsx
@@ -7,14 +7,15 @@ import {
 import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
-interface TagDeletionModalProps {
+function TagDeletionModal({
+  id,
+  name,
+  onClose,
+}: {
   id: number
   name: string
-  open: boolean
-  setOpen: (value: boolean) => void
-}
-
-function TagDeletionModal({ id, name, open, setOpen }: TagDeletionModalProps) {
+  onClose: () => void
+}) {
   const t = useTranslations()
   const [deleteTag, { loading: deleting }] = useMutation(DeleteTagDocument, {
     variables: {
@@ -49,19 +50,19 @@ function TagDeletionModal({ id, name, open, setOpen }: TagDeletionModalProps) {
 
   return (
     <Modal
-      onClose={(): void => setOpen(false)}
-      open={open}
+      open
+      onClose={onClose}
       title={t('manage.tags.deleteTag')}
       primaryLabel={t('shared.generic.confirm')}
       primaryLoading={deleting}
       primaryButtonStyle="destructive"
       onPrimaryAction={async () => {
         await deleteTag()
-        setOpen(false)
+        onClose()
       }}
       dataPrimaryAction={{ cy: 'confirm-delete-tag' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => setOpen(false)}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'cancel-delete-tag' }}
       className={{ content: 'max-w-xl' }}
     >

--- a/apps/frontend-manage/src/components/courses/modals/TemplateConversionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/TemplateConversionModal.tsx
@@ -29,8 +29,7 @@ import ConversionTypeMonitor from './ConversionTypeMonitor'
 import TemplateFormFields from './TemplateFormFields'
 
 interface TemplateConversionModalProps {
-  open: boolean
-  setOpen: (open: boolean) => void
+  onClose: () => void
   activityId: string
   activityType: ActivityType
   onSuccess: () => void
@@ -38,8 +37,7 @@ interface TemplateConversionModalProps {
 }
 
 function TemplateConversionModal({
-  open,
-  setOpen,
+  onClose,
   activityId,
   activityType,
   onSuccess,
@@ -80,7 +78,7 @@ function TemplateConversionModal({
   }, [templateInfo])
 
   const handleModalClose = () => {
-    setOpen(false)
+    onClose()
     setCurrentStep(0)
     setConfirmations({
       activityConversion: false,
@@ -92,11 +90,11 @@ function TemplateConversionModal({
 
   return (
     <Modal
+      open
       escapeDisabled
       title={t('manage.template.convertToTemplate', {
         activityType: t(`shared.types.${activityType}`),
       })}
-      open={open}
       onClose={handleModalClose}
       className={{ content: 'gap-2 pb-2 lg:w-[55rem]' }}
       dataCloseButton={{ cy: 'close-template-conversion-modal' }}

--- a/apps/frontend-manage/src/components/courses/modals/TemplateDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/TemplateDeletionModal.tsx
@@ -13,8 +13,7 @@ import { useTranslations } from 'next-intl'
 interface TemplateDeletionModalProps {
   activityId: string
   activityType: ActivityType
-  open: boolean
-  setOpen: (open: boolean) => void
+  onClose: () => void
   onSuccess: () => void
   onError: () => void
 }
@@ -22,8 +21,7 @@ interface TemplateDeletionModalProps {
 function TemplateDeletionModal({
   activityId,
   activityType,
-  open,
-  setOpen,
+  onClose,
   onSuccess,
   onError,
 }: TemplateDeletionModalProps) {
@@ -45,9 +43,9 @@ function TemplateDeletionModal({
 
   return (
     <Modal
+      open
       title={t('manage.template.deleteTemplate')}
-      open={open}
-      onClose={() => setOpen(false)}
+      onClose={onClose}
       data={{ cy: 'delete-template-modal' }}
       primaryLabel={
         <div className="flex flex-row items-center gap-2.5">
@@ -63,7 +61,7 @@ function TemplateDeletionModal({
 
           if (data?.deleteActivityTemplate) {
             onSuccess()
-            setOpen(false)
+            onClose()
           } else {
             onError()
           }
@@ -74,8 +72,9 @@ function TemplateDeletionModal({
       }}
       dataPrimaryAction={{ cy: 'confirm-template-deletion' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => setOpen(false)}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'cancel-deletion' }}
+      className={{ content: 'max-w-xl' }}
     >
       {t('manage.template.deleteTemplateExplanation')}
     </Modal>

--- a/apps/frontend-manage/src/components/courses/modals/TemplateEditModal.tsx
+++ b/apps/frontend-manage/src/components/courses/modals/TemplateEditModal.tsx
@@ -17,8 +17,7 @@ import TemplateFormFields from './TemplateFormFields'
 interface TemplateEditModalProps {
   activityId: string
   activityType: ActivityType
-  open: boolean
-  setOpen: (open: boolean) => void
+  onClose: () => void
   onSuccess: () => void
   onError: () => void
 }
@@ -26,8 +25,7 @@ interface TemplateEditModalProps {
 function TemplateEditModal({
   activityId,
   activityType,
-  open,
-  setOpen,
+  onClose,
   onSuccess,
   onError,
 }: TemplateEditModalProps) {
@@ -46,9 +44,9 @@ function TemplateEditModal({
 
   return (
     <Modal
+      open
       title={t('manage.template.editTemplate')}
-      open={open}
-      onClose={() => setOpen(false)}
+      onClose={onClose}
       className={{ content: 'gap-2 pb-2' }}
       data={{ cy: 'edit-template-modal' }}
       dataCloseButton={{ cy: 'close-edit-template-modal' }}
@@ -100,7 +98,7 @@ function TemplateEditModal({
 
               if (result.data?.editActivityTemplate) {
                 onSuccess()
-                setOpen(false)
+                onClose()
               } else {
                 onError()
               }

--- a/apps/frontend-manage/src/components/groups/DeleteUserGroupModal.tsx
+++ b/apps/frontend-manage/src/components/groups/DeleteUserGroupModal.tsx
@@ -11,13 +11,11 @@ import { useEffect, useState } from 'react'
 import ConfirmationItem from '../common/ConfirmationItem'
 
 function DeleteUserGroupModal({
-  open,
   onClose,
   onSuccess,
   groupId,
   groupName,
 }: {
-  open: boolean
   onClose: () => void
   onSuccess: () => void
   groupId: number
@@ -41,18 +39,16 @@ function DeleteUserGroupModal({
 
   // on open, reset confirmations
   useEffect(() => {
-    if (open) {
-      setConfirmations({
-        resolveGroup: false,
-        revokeDirectPermissions: false,
-        irreversibleAction: false,
-      })
-    }
-  }, [open])
+    setConfirmations({
+      resolveGroup: false,
+      revokeDirectPermissions: false,
+      irreversibleAction: false,
+    })
+  }, [])
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.userGroups.deleteGroup')}
       primaryLabel={

--- a/apps/frontend-manage/src/components/groups/LeaveUserGroupModal.tsx
+++ b/apps/frontend-manage/src/components/groups/LeaveUserGroupModal.tsx
@@ -12,13 +12,11 @@ import { Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function LeaveUserGroupModal({
-  open,
   onClose,
   onSuccess,
   groupId,
   groupName,
 }: {
-  open: boolean
   onClose: () => void
   onSuccess: () => void
   groupId: number
@@ -36,7 +34,7 @@ function LeaveUserGroupModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.userGroups.leaveGroup')}
       primaryLabel={

--- a/apps/frontend-manage/src/components/groups/UserGroupEditModal.tsx
+++ b/apps/frontend-manage/src/components/groups/UserGroupEditModal.tsx
@@ -27,11 +27,9 @@ import useRemoveUserFromGroup from './useRemoveUserFromGroup'
 import useTransferGroupOwnership from './useTransferGroupOwnership'
 
 function UserGroupEditModal({
-  open,
   onClose,
   group,
 }: {
-  open: boolean
   onClose: () => void
   group: UserGroup
 }) {
@@ -51,69 +49,158 @@ function UserGroupEditModal({
   const [titleState, setTitleState] = useState(group.name)
 
   return (
-    <>
-      <Modal
-        open={open}
-        onClose={onClose}
-        title={
-          titleEditMode ? (
-            <div className="flex max-w-[90%] flex-row items-center md:max-w-[80%]">
-              <div className="mr-2.5 whitespace-nowrap">{`${t('shared.generic.userGroup')}: `}</div>
-              <TextField
-                value={titleState}
-                onChange={(newValue) => setTitleState(newValue)}
-                className={{ input: 'h-8 font-normal' }}
-                data={{ cy: 'edit-group-name-input' }}
-              />
+    <Modal
+      open
+      onClose={onClose}
+      title={
+        titleEditMode ? (
+          <div className="flex max-w-[90%] flex-row items-center md:max-w-[80%]">
+            <div className="mr-2.5 whitespace-nowrap">{`${t('shared.generic.userGroup')}: `}</div>
+            <TextField
+              value={titleState}
+              onChange={(newValue) => setTitleState(newValue)}
+              className={{ input: 'h-8 font-normal' }}
+              data={{ cy: 'edit-group-name-input' }}
+            />
+            <Button
+              basic
+              primary
+              className={{ root: 'ml-1.5 px-2 py-2 hover:text-white' }}
+              onClick={async () => {
+                await onNameChange({
+                  groupId: group.id,
+                  newName: titleState,
+                  setTitleEditMode,
+                })
+              }}
+              data={{ cy: 'save-new-group-name' }}
+            >
+              <Button.Icon withoutLabel icon={faSave} />
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-row items-center gap-1.5">
+            <div>{`${t('shared.generic.userGroup')}: ${group.name}`}</div>
+            {isGroupEditor ? (
               <Button
                 basic
-                primary
-                className={{ root: 'ml-1.5 px-2 py-2 hover:text-white' }}
-                onClick={async () => {
-                  await onNameChange({
-                    groupId: group.id,
-                    newName: titleState,
-                    setTitleEditMode,
-                  })
-                }}
-                data={{ cy: 'save-new-group-name' }}
+                onClick={() => setTitleEditMode(true)}
+                className={{ root: 'px-1.5 py-1.5' }}
+                data={{ cy: 'edit-group-name' }}
               >
-                <Button.Icon withoutLabel icon={faSave} />
+                <Button.Icon withoutLabel icon={faPencil} />
               </Button>
-            </div>
-          ) : (
-            <div className="flex flex-row items-center gap-1.5">
-              <div>{`${t('shared.generic.userGroup')}: ${group.name}`}</div>
-              {isGroupEditor ? (
-                <Button
-                  basic
-                  onClick={() => setTitleEditMode(true)}
-                  className={{ root: 'px-1.5 py-1.5' }}
-                  data={{ cy: 'edit-group-name' }}
-                >
-                  <Button.Icon withoutLabel icon={faPencil} />
-                </Button>
-              ) : null}
-            </div>
-          )
-        }
-        className={{
-          content: twMerge(
-            'flex !max-w-xl flex-col pb-0',
-            isGroupEditor && '!max-w-3xl'
-          ),
-        }}
-        dataCloseButton={{ cy: 'close-user-group-edit-modal' }}
-      >
-        <div className="mb-2.5 flex flex-row items-center gap-2">
-          <FontAwesomeIcon icon={faUserTie} />
-          <H4 className={{ root: 'my-0 py-0' }}>{t('shared.generic.owner')}</H4>
-          <div data-cy="group-owner-shortname-email">{`${group.owner!.shortname} (${group.owner!.email})`}</div>
-        </div>
+            ) : null}
+          </div>
+        )
+      }
+      className={{
+        content: twMerge(
+          'flex !max-w-xl flex-col pb-0',
+          isGroupEditor && '!max-w-3xl'
+        ),
+      }}
+      dataCloseButton={{ cy: 'close-user-group-edit-modal' }}
+    >
+      <div className="mb-2.5 flex flex-row items-center gap-2">
+        <FontAwesomeIcon icon={faUserTie} />
+        <H4 className={{ root: 'my-0 py-0' }}>{t('shared.generic.owner')}</H4>
+        <div data-cy="group-owner-shortname-email">{`${group.owner!.shortname} (${group.owner!.email})`}</div>
+      </div>
 
-        <H4>{t('manage.userGroups.admins')}</H4>
-        {!group.admins || group.admins.length === 0 ? (
-          <>
+      <H4>{t('manage.userGroups.admins')}</H4>
+      {!group.admins || group.admins.length === 0 ? (
+        <>
+          {isGroupEditor ? (
+            <AddUserGroupMember
+              adminMode
+              groupId={group.id}
+              loading={loading}
+            />
+          ) : null}
+          <UserNotification
+            type="info"
+            message={t('manage.userGroups.noAdmins')}
+            className={{ root: 'mb-4 mt-2' }}
+          />
+        </>
+      ) : (
+        <>
+          <div className="mb-2">
+            {group.admins.map((admin) => (
+              <div
+                key={`group-admin-${admin.id}`}
+                data-cy={`group-admin-${admin.shortname}`}
+                className="flex flex-row justify-between border-b py-1 text-sm first:border-t"
+              >
+                <div className="flex flex-row items-center gap-2">
+                  <FontAwesomeIcon icon={faUser} />
+                  <div>
+                    {isGroupEditor
+                      ? `${admin.shortname} (${admin.email})`
+                      : admin.shortname}
+                  </div>
+                </div>
+                {isGroupEditor && !admin.isSelf ? (
+                  <div className="flex flex-row gap-0">
+                    {group.isOwner ? (
+                      <Button
+                        basic
+                        disabled={loading}
+                        className={{ root: 'px-1.5 py-[0.35rem]' }}
+                        onClick={async () => {
+                          await onOwnershipTransfer({
+                            group,
+                            newOwnerId: admin.id!,
+                          })
+                        }}
+                        data={{
+                          cy: `transfer-group-ownership-${admin.shortname}`,
+                        }}
+                      >
+                        <Button.Icon
+                          withoutLabel
+                          icon={faUserTie}
+                          className={{ root: 'h-3.5 w-3.5' }}
+                        />
+                      </Button>
+                    ) : null}
+                    <Button
+                      basic
+                      disabled={loading}
+                      className={{ root: 'px-1.5 py-1' }}
+                      onClick={async () => {
+                        await onDemotion({
+                          groupId: group.id,
+                          adminId: admin.id!,
+                          adminShortname: admin.shortname,
+                          adminEmail: admin.email,
+                        })
+                      }}
+                      data={{ cy: `demote-group-admin-${admin.shortname}` }}
+                    >
+                      <Button.Icon withoutLabel icon={faUserMinus} />
+                    </Button>
+                    <Button
+                      basic
+                      disabled={loading}
+                      className={{
+                        root: 'px-1.5 py-1 text-red-600 hover:text-red-600',
+                      }}
+                      onClick={async () => {
+                        await onRemove({
+                          groupId: group.id,
+                          userId: admin.id!,
+                        })
+                      }}
+                      data={{ cy: `remove-group-admin-${admin.shortname}` }}
+                    >
+                      <Button.Icon withoutLabel icon={faUserXmark} />
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            ))}
             {isGroupEditor ? (
               <AddUserGroupMember
                 adminMode
@@ -121,207 +208,116 @@ function UserGroupEditModal({
                 loading={loading}
               />
             ) : null}
-            <UserNotification
-              type="info"
-              message={t('manage.userGroups.noAdmins')}
-              className={{ root: 'mb-4 mt-2' }}
-            />
-          </>
-        ) : (
-          <>
-            <div className="mb-2">
-              {group.admins.map((admin) => (
-                <div
-                  key={`group-admin-${admin.id}`}
-                  data-cy={`group-admin-${admin.shortname}`}
-                  className="flex flex-row justify-between border-b py-1 text-sm first:border-t"
-                >
-                  <div className="flex flex-row items-center gap-2">
-                    <FontAwesomeIcon icon={faUser} />
-                    <div>
-                      {isGroupEditor
-                        ? `${admin.shortname} (${admin.email})`
-                        : admin.shortname}
-                    </div>
-                  </div>
-                  {isGroupEditor && !admin.isSelf ? (
-                    <div className="flex flex-row gap-0">
-                      {group.isOwner ? (
-                        <Button
-                          basic
-                          disabled={loading}
-                          className={{ root: 'px-1.5 py-[0.35rem]' }}
-                          onClick={async () => {
-                            await onOwnershipTransfer({
-                              group,
-                              newOwnerId: admin.id!,
-                            })
-                          }}
-                          data={{
-                            cy: `transfer-group-ownership-${admin.shortname}`,
-                          }}
-                        >
-                          <Button.Icon
-                            withoutLabel
-                            icon={faUserTie}
-                            className={{ root: 'h-3.5 w-3.5' }}
-                          />
-                        </Button>
-                      ) : null}
-                      <Button
-                        basic
-                        disabled={loading}
-                        className={{ root: 'px-1.5 py-1' }}
-                        onClick={async () => {
-                          await onDemotion({
-                            groupId: group.id,
-                            adminId: admin.id!,
-                            adminShortname: admin.shortname,
-                            adminEmail: admin.email,
-                          })
-                        }}
-                        data={{ cy: `demote-group-admin-${admin.shortname}` }}
-                      >
-                        <Button.Icon withoutLabel icon={faUserMinus} />
-                      </Button>
-                      <Button
-                        basic
-                        disabled={loading}
-                        className={{
-                          root: 'px-1.5 py-1 text-red-600 hover:text-red-600',
-                        }}
-                        onClick={async () => {
-                          await onRemove({
-                            groupId: group.id,
-                            userId: admin.id!,
-                          })
-                        }}
-                        data={{ cy: `remove-group-admin-${admin.shortname}` }}
-                      >
-                        <Button.Icon withoutLabel icon={faUserXmark} />
-                      </Button>
-                    </div>
-                  ) : null}
+          </div>
+          {isGroupEditor ? (
+            <div className="flex flex-row justify-end gap-6 text-sm">
+              {group.isOwner ? (
+                <div className="flex flex-row items-center gap-2">
+                  <FontAwesomeIcon icon={faUserTie} className="h-4 w-4" />
+                  <div>{t('manage.userGroups.transferOwnership')}</div>
                 </div>
-              ))}
-              {isGroupEditor ? (
-                <AddUserGroupMember
-                  adminMode
-                  groupId={group.id}
-                  loading={loading}
-                />
               ) : null}
+              <div className="flex flex-row items-center gap-2">
+                <FontAwesomeIcon icon={faUserMinus} className="h-4 w-4" />
+                <div>{t('manage.userGroups.demoteAdminToMember')}</div>
+              </div>
+              <div className="flex flex-row items-center gap-2 text-red-600">
+                <FontAwesomeIcon icon={faUserXmark} className="h-4 w-4" />
+                <div>{t('manage.userGroups.removeUserFromGroup')}</div>
+              </div>
             </div>
-            {isGroupEditor ? (
-              <div className="flex flex-row justify-end gap-6 text-sm">
-                {group.isOwner ? (
-                  <div className="flex flex-row items-center gap-2">
-                    <FontAwesomeIcon icon={faUserTie} className="h-4 w-4" />
-                    <div>{t('manage.userGroups.transferOwnership')}</div>
+          ) : null}
+        </>
+      )}
+
+      <H4 className={{ root: 'mt-4' }}>{t('manage.userGroups.members')}</H4>
+      {!group.members || group.members.length === 0 ? (
+        <>
+          {isGroupEditor ? (
+            <AddUserGroupMember groupId={group.id} loading={loading} />
+          ) : null}
+          <UserNotification
+            type="info"
+            message={t('manage.userGroups.noMembers')}
+            className={{ root: 'my-2' }}
+          />
+        </>
+      ) : (
+        <>
+          <div className="mb-2">
+            {group.members.map((member) => (
+              <div
+                key={`group-member-${member.id}`}
+                data-cy={`group-member-${member.shortname}`}
+                className="flex flex-row justify-between border-b py-1 text-sm first:border-t"
+              >
+                <div className="flex flex-row items-center gap-2">
+                  <FontAwesomeIcon icon={faUser} />
+                  <div>
+                    {isGroupEditor
+                      ? `${member.shortname} (${member.email})`
+                      : member.shortname}
+                  </div>
+                </div>
+                {isGroupEditor && !member.isSelf ? (
+                  <div className="flex flex-row gap-0">
+                    <Button
+                      basic
+                      disabled={loading}
+                      className={{ root: 'px-1.5 py-1' }}
+                      onClick={async () => {
+                        onPromotion({
+                          groupId: group.id,
+                          memberId: member.id!,
+                          memberShortname: member.shortname,
+                          memberEmail: member.email,
+                        })
+                      }}
+                      data={{
+                        cy: `promote-group-member-${member.shortname}`,
+                      }}
+                    >
+                      <Button.Icon withoutLabel icon={faUserPlus} />
+                    </Button>
+                    <Button
+                      basic
+                      disabled={loading}
+                      className={{
+                        root: 'px-1.5 py-1 text-red-600 hover:text-red-600',
+                      }}
+                      onClick={async () => {
+                        await onRemove({
+                          groupId: group.id,
+                          userId: member.id!,
+                        })
+                      }}
+                      data={{ cy: `remove-group-member-${member.shortname}` }}
+                    >
+                      <Button.Icon withoutLabel icon={faUserXmark} />
+                    </Button>
                   </div>
                 ) : null}
-                <div className="flex flex-row items-center gap-2">
-                  <FontAwesomeIcon icon={faUserMinus} className="h-4 w-4" />
-                  <div>{t('manage.userGroups.demoteAdminToMember')}</div>
-                </div>
-                <div className="flex flex-row items-center gap-2 text-red-600">
-                  <FontAwesomeIcon icon={faUserXmark} className="h-4 w-4" />
-                  <div>{t('manage.userGroups.removeUserFromGroup')}</div>
-                </div>
               </div>
-            ) : null}
-          </>
-        )}
-
-        <H4 className={{ root: 'mt-4' }}>{t('manage.userGroups.members')}</H4>
-        {!group.members || group.members.length === 0 ? (
-          <>
+            ))}
             {isGroupEditor ? (
               <AddUserGroupMember groupId={group.id} loading={loading} />
             ) : null}
-            <UserNotification
-              type="info"
-              message={t('manage.userGroups.noMembers')}
-              className={{ root: 'my-2' }}
-            />
-          </>
-        ) : (
-          <>
-            <div className="mb-2">
-              {group.members.map((member) => (
-                <div
-                  key={`group-member-${member.id}`}
-                  data-cy={`group-member-${member.shortname}`}
-                  className="flex flex-row justify-between border-b py-1 text-sm first:border-t"
-                >
-                  <div className="flex flex-row items-center gap-2">
-                    <FontAwesomeIcon icon={faUser} />
-                    <div>
-                      {isGroupEditor
-                        ? `${member.shortname} (${member.email})`
-                        : member.shortname}
-                    </div>
-                  </div>
-                  {isGroupEditor && !member.isSelf ? (
-                    <div className="flex flex-row gap-0">
-                      <Button
-                        basic
-                        disabled={loading}
-                        className={{ root: 'px-1.5 py-1' }}
-                        onClick={async () => {
-                          onPromotion({
-                            groupId: group.id,
-                            memberId: member.id!,
-                            memberShortname: member.shortname,
-                            memberEmail: member.email,
-                          })
-                        }}
-                        data={{
-                          cy: `promote-group-member-${member.shortname}`,
-                        }}
-                      >
-                        <Button.Icon withoutLabel icon={faUserPlus} />
-                      </Button>
-                      <Button
-                        basic
-                        disabled={loading}
-                        className={{
-                          root: 'px-1.5 py-1 text-red-600 hover:text-red-600',
-                        }}
-                        onClick={async () => {
-                          await onRemove({
-                            groupId: group.id,
-                            userId: member.id!,
-                          })
-                        }}
-                        data={{ cy: `remove-group-member-${member.shortname}` }}
-                      >
-                        <Button.Icon withoutLabel icon={faUserXmark} />
-                      </Button>
-                    </div>
-                  ) : null}
-                </div>
-              ))}
-              {isGroupEditor ? (
-                <AddUserGroupMember groupId={group.id} loading={loading} />
-              ) : null}
-            </div>
-            {isGroupEditor ? (
-              <div className="flex flex-row justify-end gap-6 text-sm">
-                <div className="flex flex-row items-center gap-2">
-                  <FontAwesomeIcon icon={faUserPlus} className="h-4 w-4" />
-                  <div>{t('manage.userGroups.promoteUserToAdmin')}</div>
-                </div>
-                <div className="flex flex-row items-center gap-2 text-red-600">
-                  <FontAwesomeIcon icon={faUserXmark} className="h-4 w-4" />
-                  <div>{t('manage.userGroups.removeUserFromGroup')}</div>
-                </div>
+          </div>
+          {isGroupEditor ? (
+            <div className="flex flex-row justify-end gap-6 text-sm">
+              <div className="flex flex-row items-center gap-2">
+                <FontAwesomeIcon icon={faUserPlus} className="h-4 w-4" />
+                <div>{t('manage.userGroups.promoteUserToAdmin')}</div>
               </div>
-            ) : null}
-          </>
-        )}
-      </Modal>
-    </>
+              <div className="flex flex-row items-center gap-2 text-red-600">
+                <FontAwesomeIcon icon={faUserXmark} className="h-4 w-4" />
+                <div>{t('manage.userGroups.removeUserFromGroup')}</div>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+    </Modal>
   )
 }
 

--- a/apps/frontend-manage/src/components/groups/UserGroupEntry.tsx
+++ b/apps/frontend-manage/src/components/groups/UserGroupEntry.tsx
@@ -107,41 +107,41 @@ function UserGroupEntry({ group }: { group: UserGroup }) {
         </div>
       </div>
 
-      <LeaveUserGroupModal
-        open={leaveGroupModal}
-        onClose={() => setLeaveGroupModal(false)}
-        onSuccess={() => {
-          toast({
-            type: 'success',
-            message: t('manage.userGroups.leaveGroupSuccess'),
-            options: { duration: 3000 },
-          })
-          setLeaveGroupModal(false)
-        }}
-        groupId={group.id}
-        groupName={group.name}
-      />
+      {leaveGroupModal && (
+        <LeaveUserGroupModal
+          onClose={() => setLeaveGroupModal(false)}
+          onSuccess={() => {
+            toast({
+              type: 'success',
+              message: t('manage.userGroups.leaveGroupSuccess'),
+              options: { duration: 3000 },
+            })
+            setLeaveGroupModal(false)
+          }}
+          groupId={group.id}
+          groupName={group.name}
+        />
+      )}
 
-      <DeleteUserGroupModal
-        open={deleteGroupModal}
-        onClose={() => setDeleteGroupModal(false)}
-        groupId={group.id}
-        groupName={group.name}
-        onSuccess={() => {
-          toast({
-            type: 'success',
-            message: t('manage.userGroups.deleteGroupSuccess'),
-            options: { duration: 3000 },
-          })
-          setDeleteGroupModal(false)
-        }}
-      />
+      {deleteGroupModal && (
+        <DeleteUserGroupModal
+          onClose={() => setDeleteGroupModal(false)}
+          groupId={group.id}
+          groupName={group.name}
+          onSuccess={() => {
+            toast({
+              type: 'success',
+              message: t('manage.userGroups.deleteGroupSuccess'),
+              options: { duration: 3000 },
+            })
+            setDeleteGroupModal(false)
+          }}
+        />
+      )}
 
-      <UserGroupEditModal
-        open={editModal}
-        onClose={() => setEditModal(false)}
-        group={group}
-      />
+      {editModal && (
+        <UserGroupEditModal onClose={() => setEditModal(false)} group={group} />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/liveQuiz/EmbeddingModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/EmbeddingModal.tsx
@@ -44,19 +44,15 @@ function HMACLink({
   )
 }
 
-interface EmbeddingModalProps {
-  open: boolean
-  onClose: () => void
-  quizId: string
-  elements?: { id: number; name: string }[]
-}
-
 function EmbeddingModal({
-  open,
   onClose,
   quizId,
   elements,
-}: EmbeddingModalProps) {
+}: {
+  onClose: () => void
+  quizId: string
+  elements?: { id: number; name: string }[]
+}) {
   const t = useTranslations()
   const [showSolution, setShowSolution] = useState(false)
   const [showExplanation, setShowExplanation] = useState(false)
@@ -67,8 +63,8 @@ function EmbeddingModal({
 
   return (
     <Modal
+      open
       title={t('manage.liveQuizzes.evaluationLinksEmbedding')}
-      open={open}
       onClose={onClose}
       primaryLabel={t('shared.generic.close')}
       primaryButtonStyle="default"

--- a/apps/frontend-manage/src/components/liveQuiz/LiveQuiz.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/LiveQuiz.tsx
@@ -245,23 +245,24 @@ function LiveQuiz({
                           {t('manage.liveQuizzes.embeddingEvaluation')}
                         </Button.Label>
                       </Button>
-                      <EmbeddingModal
-                        key={quiz.id}
-                        open={embedModalOpen}
-                        onClose={() => setEmbedModalOpen(false)}
-                        quizId={quiz.id}
-                        elements={quiz.blocks
-                          ?.flatMap((block) => block.elements)
-                          .filter(
-                            (instance) =>
-                              typeof instance !== 'undefined' &&
-                              instance !== null
-                          )
-                          .map((instance) => ({
-                            id: instance.id,
-                            name: instance.elementData.name,
-                          }))}
-                      />
+                      {embedModalOpen && (
+                        <EmbeddingModal
+                          key={quiz.id}
+                          onClose={() => setEmbedModalOpen(false)}
+                          quizId={quiz.id}
+                          elements={quiz.blocks
+                            ?.flatMap((block) => block.elements)
+                            .filter(
+                              (instance) =>
+                                typeof instance !== 'undefined' &&
+                                instance !== null
+                            )
+                            .map((instance) => ({
+                              id: instance.id,
+                              name: instance.elementData.name,
+                            }))}
+                        />
+                      )}
                     </>
                   )}
 
@@ -278,11 +279,12 @@ function LiveQuiz({
                           {t('manage.general.qrCode')}
                         </Button.Label>
                       </Button>
-                      <LiveQuizQRModal
-                        quizId={quiz.id}
-                        open={qrModalOpen}
-                        setOpen={setQrModalOpen}
-                      />
+                      {qrModalOpen && (
+                        <LiveQuizQRModal
+                          quizId={quiz.id}
+                          onClose={() => setQrModalOpen(false)}
+                        />
+                      )}
                     </>
                   )}
 
@@ -543,81 +545,88 @@ function LiveQuiz({
         </Collapsible>
       </div>
       <div>
-        <LiveQuizDeletionModal
-          quizId={quiz.id}
-          open={deletionModal}
-          setOpen={setDeletionModal}
-          onDelete={deleteLiveQuiz}
-          deleting={deletingLiveQuiz}
-        />
-        <ActivityNameChangeModal
-          id={quiz.id}
-          name={quiz.name}
-          type={ActivityType.LiveQuiz}
-          displayName={quiz.displayName}
-          open={changeName}
-          setOpen={setChangeName}
-        />
-        <TemplateDeletionModal
-          activityId={quiz.id}
-          activityType={ActivityType.LiveQuiz}
-          open={deletionTemplateModal}
-          setOpen={setDeletionTemplateModal}
-          onSuccess={() =>
-            toast({
-              type: 'success',
-              message: t('manage.template.templateDeletionSuccess'),
-              options: { duration: 3000 },
-            })
-          }
-          onError={() =>
-            toast({
-              type: 'error',
-              message: t('manage.template.templateDeletionError'),
-              options: { duration: 4500 },
-            })
-          }
-        />
-        <TemplateEditModal
-          activityId={quiz.id}
-          activityType={ActivityType.LiveQuiz}
-          open={editTemplateModal}
-          setOpen={setEditTemplateModal}
-          onSuccess={() =>
-            toast({
-              type: 'success',
-              message: t('manage.template.templateEditSuccess'),
-              options: { duration: 3000 },
-            })
-          }
-          onError={() =>
-            toast({
-              type: 'error',
-              message: t('manage.template.templateEditError'),
-              options: { duration: 4500 },
-            })
-          }
-        />
+        {deletionModal && (
+          <LiveQuizDeletionModal
+            quizId={quiz.id}
+            onClose={() => setDeletionModal(false)}
+            onDelete={deleteLiveQuiz}
+            deleting={deletingLiveQuiz}
+          />
+        )}
+        {changeName && (
+          <ActivityNameChangeModal
+            id={quiz.id}
+            name={quiz.name}
+            type={ActivityType.LiveQuiz}
+            displayName={quiz.displayName}
+            onClose={() => setChangeName(false)}
+          />
+        )}
+        {deletionTemplateModal && (
+          <TemplateDeletionModal
+            activityId={quiz.id}
+            activityType={ActivityType.LiveQuiz}
+            onClose={() => setDeletionTemplateModal(false)}
+            onSuccess={() =>
+              toast({
+                type: 'success',
+                message: t('manage.template.templateDeletionSuccess'),
+                options: { duration: 3000 },
+              })
+            }
+            onError={() =>
+              toast({
+                type: 'error',
+                message: t('manage.template.templateDeletionError'),
+                options: { duration: 4500 },
+              })
+            }
+          />
+        )}
+        {editTemplateModal && (
+          <TemplateEditModal
+            activityId={quiz.id}
+            activityType={ActivityType.LiveQuiz}
+            onClose={() => setEditTemplateModal(false)}
+            onSuccess={() =>
+              toast({
+                type: 'success',
+                message: t('manage.template.templateEditSuccess'),
+                options: { duration: 3000 },
+              })
+            }
+            onError={() =>
+              toast({
+                type: 'error',
+                message: t('manage.template.templateEditError'),
+                options: { duration: 4500 },
+              })
+            }
+          />
+        )}
 
-        <TemplateConversionModal
-          open={conversionModal.open}
-          setOpen={(open) => setConversionModal({ ...conversionModal, open })}
-          activityId={conversionModal.activityId}
-          activityType={conversionModal.activityType}
-          onSuccess={() =>
-            toast({
-              type: 'success',
-              message: t('manage.template.templateCreationSuccess'),
-              options: { duration: 3500 },
-            })
-          }
-          onError={() =>
-            toast({
-              type: 'error',
-              message: t('manage.template.templateCreationError'),
-            })
-          }
-        />
+        {conversionModal.open && (
+          <TemplateConversionModal
+            onClose={() =>
+              setConversionModal((prev) => ({ ...prev, open: false }))
+            }
+            activityId={conversionModal.activityId}
+            activityType={conversionModal.activityType}
+            onSuccess={() =>
+              toast({
+                type: 'success',
+                message: t('manage.template.templateCreationSuccess'),
+                options: { duration: 3500 },
+              })
+            }
+            onError={() =>
+              toast({
+                type: 'error',
+                message: t('manage.template.templateCreationError'),
+              })
+            }
+          />
+        )}
       </div>
     </>
   )

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/CancelLiveQuizModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/CancelLiveQuizModal.tsx
@@ -23,13 +23,11 @@ export interface LiveQuizAbortionConfirmationType {
 function CancelLiveQuizModal({
   quizId,
   title,
-  open,
-  setOpen,
+  onClose,
 }: {
   quizId: string
   title: string
-  open: boolean
-  setOpen: (value: boolean) => void
+  onClose: () => void
 }) {
   const router = useRouter()
   const t = useTranslations()
@@ -105,9 +103,9 @@ function CancelLiveQuizModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={() => {
-        setOpen(false)
+        onClose()
         setConfirmations({ ...initialConfirmations })
       }}
       title={t('manage.cockpit.confirmAbortLiveQuiz', { title: title })}
@@ -123,13 +121,13 @@ function CancelLiveQuizModal({
         router.push(
           dataUser?.userProfile?.privatePreview ? '/activities' : '/quizzes'
         )
-        setOpen(false)
+        onClose()
         setConfirmations({ ...initialConfirmations })
       }}
       dataPrimaryAction={{ cy: 'confirm-cancel-live-quiz' }}
       secondaryLabel={t('shared.generic.close')}
       onSecondaryAction={() => {
-        setOpen(false)
+        onClose()
         setConfirmations({ ...initialConfirmations })
       }}
       dataSecondaryAction={{ cy: 'abort-cancel-live-quiz' }}

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/CancelLiveQuizModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/CancelLiveQuizModal.tsx
@@ -7,6 +7,7 @@ import {
   GetUserRunningLiveQuizzesDocument,
   UserProfileDocument,
 } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
@@ -94,12 +95,7 @@ function CancelLiveQuizModal({
         data.getLiveQuizSummary.numOfLeaderboardEntries === 0,
     })
   }, [data?.getLiveQuizSummary])
-
-  if (!data?.getLiveQuizSummary) {
-    return null
-  }
-
-  const summary = data.getLiveQuizSummary
+  const summary = data?.getLiveQuizSummary
 
   return (
     <Modal
@@ -133,11 +129,15 @@ function CancelLiveQuizModal({
       dataSecondaryAction={{ cy: 'abort-cancel-live-quiz' }}
       className={{ content: 'max-w-[60rem]' }}
     >
-      <LiveQuizAbortionConfirmations
-        summary={summary}
-        confirmations={confirmations}
-        setConfirmations={setConfirmations}
-      />
+      {queryLoading || !summary ? (
+        <Loader />
+      ) : (
+        <LiveQuizAbortionConfirmations
+          summary={summary}
+          confirmations={confirmations}
+          setConfirmations={setConfirmations}
+        />
+      )}
     </Modal>
   )
 }

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizQRModal.tsx
@@ -4,19 +4,16 @@ import QR from '@pages/qr/[...args]'
 import { Button, H3, Modal, Prose } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
-import React, { Dispatch, SetStateAction } from 'react'
+import React from 'react'
 
 function LiveQuizQRModal({
   quizId,
-  open,
-  setOpen,
+  onClose,
 }: {
   quizId: string
-  open: boolean
-  setOpen: Dispatch<SetStateAction<boolean>>
+  onClose: () => void
 }): React.ReactElement {
   const t = useTranslations()
-
   const { data } = useQuery(UserProfileDocument, {
     fetchPolicy: 'cache-only',
   })
@@ -27,9 +24,9 @@ function LiveQuizQRModal({
 
   return (
     <Modal
+      open
       title={t('manage.cockpit.liveQuizQRCodes')}
-      open={open}
-      onClose={() => setOpen(false)}
+      onClose={onClose}
       className={{ content: '!w-full max-w-6xl pb-2' }}
     >
       <div className="flex flex-col gap-8 md:flex-row">

--- a/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizTimeline.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/cockpit/LiveQuizTimeline.tsx
@@ -126,10 +126,9 @@ function LiveQuizTimeline({
                 {t('manage.liveQuizzes.embeddingEvaluation')}
               </Button.Label>
             </Button>
-            {!isFeedbackQuiz && (
+            {!isFeedbackQuiz && embedModalOpen ? (
               <EmbeddingModal
                 key={quizId}
-                open={embedModalOpen}
                 onClose={() => setEmbedModalOpen(false)}
                 quizId={quizId}
                 elements={blocks
@@ -143,7 +142,7 @@ function LiveQuizTimeline({
                     name: instance.elementData.name,
                   }))}
               />
-            )}
+            ) : null}
             <Button
               className={{ root: 'h-8 sm:w-max' }}
               onClick={() => setQRModal(true)}
@@ -297,15 +296,18 @@ function LiveQuizTimeline({
               </Button.Label>
             </Button>
           </div>
-          <CancelLiveQuizModal
-            open={cancelLiveQuizModal}
-            setOpen={setCancelLiveQuizModal}
-            quizId={quizId}
-            title={quizName}
-          />
         </>
       )}
-      <LiveQuizQRModal quizId={quizId} open={qrModal} setOpen={setQRModal} />
+      {cancelLiveQuizModal && (
+        <CancelLiveQuizModal
+          onClose={() => setCancelLiveQuizModal(false)}
+          quizId={quizId}
+          title={quizName}
+        />
+      )}
+      {qrModal && (
+        <LiveQuizQRModal quizId={quizId} onClose={() => setQRModal(false)} />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/questions/Element.tsx
+++ b/apps/frontend-manage/src/components/questions/Element.tsx
@@ -304,7 +304,6 @@ function Element({
       {showRecoveryPrompt && (
         <RecoveryPrompt
           editMode
-          open={showRecoveryPrompt}
           onRecovery={() => {
             setShowRecoveryPrompt(false)
             setModificationModalOpen(true)
@@ -353,23 +352,24 @@ function Element({
           unsetDeletedQuestion={unsetDeletedQuestion}
         />
       )}
-      {isSharingModalOpen && element.isManager && (
+      {isSharingModalOpen && element.isManager ? (
         <ObjectSharingModalWrapper
           objectId={element.id}
           objectName={element.name}
           objectType={ObjectType.Element}
           isOwner={element.isOwner ?? false}
-          open={isSharingModalOpen}
           onClose={() => setSharingModalOpen(false)}
         />
-      )}
+      ) : null}
 
-      <ActivityLogDialog
-        objectId={element.id}
-        objectType={ObjectType.Element}
-        open={isActivityLogOpen}
-        onOpenChange={setActivityLogOpen}
-      />
+      {isActivityLogOpen && (
+        <ActivityLogDialog
+          objectId={element.id}
+          objectType={ObjectType.Element}
+          open={isActivityLogOpen}
+          onClose={() => setActivityLogOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementDeletionModal.tsx
@@ -47,8 +47,7 @@ function ElementDeletionModal({
 
   return (
     <ActivityConfirmationModal
-      open={isModalOpen}
-      setOpen={setModalOpen}
+      onClose={() => setModalOpen(false)}
       title={t('manage.questionPool.deleteElement')}
       message={t.rich('manage.questionPool.confirmDeletion', {
         name: title,

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
@@ -6,6 +6,7 @@ import {
   GetAnswerCollectionsElementsDocument,
   ObjectType,
 } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { H3, Modal, TabContent, Tabs, toast } from '@uzh-bf/design-system'
 import { Form, Formik } from 'formik'
 import { useTranslations } from 'next-intl'
@@ -145,7 +146,11 @@ function ElementEditForm({
           submitForm,
         }) => {
           if (loading) {
-            return null
+            return (
+              <Modal open onClose={() => onClose()} fullScreen>
+                <Loader />
+              </Modal>
+            )
           }
 
           return (

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditForm.tsx
@@ -38,7 +38,6 @@ function ElementEditForm({
   isTemplate = false,
   inputsDisabled = false,
   templateId,
-  open,
   onClose,
   onSuccess,
   mode,
@@ -59,7 +58,6 @@ function ElementEditForm({
   isTemplate?: boolean
   templateId?: string
   // modal state props
-  open: boolean
   onClose: () => void
   onSuccess: () => void
   // element mode and identification
@@ -152,9 +150,9 @@ function ElementEditForm({
 
           return (
             <Modal
+              open
               fullScreen
               title={t(`manage.elements.${mode}Title`)}
-              open={open}
               onClose={() => onClose()}
               escapeDisabled={true}
               onPrimaryAction={() => submitForm()}
@@ -390,7 +388,6 @@ function ElementEditForm({
         <AnswerCollectionEditModal
           inlineEditing
           collectionId={collectionModal.id}
-          open={collectionModal.open}
           onClose={() => setCollectionModal({ open: false, id: undefined })}
           refetchAnswerCollections={async () => {
             await refetch()

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
@@ -15,7 +15,9 @@ import {
   ManipulateSelectionQuestionDocument,
   UpdateElementInstancesDocument,
 } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { useLocalStorage } from '@uidotdev/usehooks'
+import { Modal } from '@uzh-bf/design-system'
 import React, { useMemo, useState } from 'react'
 import ElementEditForm from './ElementEditForm'
 import {
@@ -117,7 +119,11 @@ function ElementEditModal({
   }, [isOpen, isDuplication, initialValues])
 
   if (!formikInitialValues || Object.keys(formikInitialValues).length === 0) {
-    return <div />
+    return (
+      <Modal open onClose={() => null} fullScreen>
+        <Loader />
+      </Modal>
+    )
   }
 
   return (

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementEditModal.tsx
@@ -16,7 +16,6 @@ import {
   UpdateElementInstancesDocument,
 } from '@klicker-uzh/graphql/dist/ops'
 import { useLocalStorage } from '@uidotdev/usehooks'
-import { useTranslations } from 'next-intl'
 import React, { useMemo, useState } from 'react'
 import ElementEditForm from './ElementEditForm'
 import {
@@ -56,8 +55,6 @@ function ElementEditModal({
   elementId,
   mode,
 }: ElementEditModalProps): React.ReactElement {
-  const t = useTranslations()
-
   const isDuplication = mode === ElementEditMode.DUPLICATE
   const [updateInstances, setUpdateInstances] = useState(true)
   const [includeTemplateUpdates, setIncludeTemplateUpdates] = useState(false)
@@ -131,7 +128,6 @@ function ElementEditModal({
       loading={loadingQuestion}
       initialValues={formikInitialValues}
       initialStatus={dataQuestion?.question?.status ?? ElementStatus.Ready}
-      open={isOpen}
       onClose={() => handleSetIsOpen(false)}
       updateInstances={updateInstances}
       setUpdateInstances={setUpdateInstances}

--- a/apps/frontend-manage/src/components/questions/manipulation/ElementRemovalModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/ElementRemovalModal.tsx
@@ -52,8 +52,7 @@ function ElementRemovalModal({
 
   return (
     <ActivityConfirmationModal
-      open={isModalOpen}
-      setOpen={setModalOpen}
+      onClose={() => setModalOpen(false)}
       title={t('manage.questionPool.removeElement')}
       message={t.rich('manage.questionPool.confirmElementRemoval', {
         name: title,

--- a/apps/frontend-manage/src/components/questions/manipulation/RecoveryPrompt.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/RecoveryPrompt.tsx
@@ -4,12 +4,10 @@ import { Modal, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function RecoveryPrompt({
-  open,
   onRecovery,
   onDiscard,
   editMode = false,
 }: {
-  open: boolean
   onRecovery: () => void
   onDiscard: () => void
   editMode?: boolean
@@ -18,9 +16,9 @@ function RecoveryPrompt({
 
   return (
     <Modal
+      open
       hideCloseButton
       escapeDisabled
-      open={open}
       onClose={() => null}
       title={t('manage.elements.recoverData')}
       secondaryLabel={

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCollectionChangeModal.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCollectionChangeModal.tsx
@@ -2,11 +2,9 @@ import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function CaseStudyCollectionChangeModal({
-  open,
   onClose,
   onConfirm,
 }: {
-  open: boolean
   onClose: () => void
   onConfirm: () => void
 }) {
@@ -14,7 +12,7 @@ function CaseStudyCollectionChangeModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.elements.changeOfAnswerCollection')}
       primaryLabel={t('shared.generic.confirm')}

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCollectionSelection.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCollectionSelection.tsx
@@ -266,20 +266,21 @@ function CaseStudyCollectionSelection({
             noOptionsMessage={() => t('manage.elements.noMatchingOptionFound')}
           />
         </div>
-        <CaseStudyCollectionChangeModal
-          open={changeModalOpen}
-          onClose={() => {
-            setNewValue('')
-            setChangeModalOpen(false)
-          }}
-          onConfirm={() => {
-            // set the selected answer collection to the new value
-            collectionHelpers.setValue(newValue)
+        {changeModalOpen && (
+          <CaseStudyCollectionChangeModal
+            onClose={() => {
+              setNewValue('')
+              setChangeModalOpen(false)
+            }}
+            onConfirm={() => {
+              // set the selected answer collection to the new value
+              collectionHelpers.setValue(newValue)
 
-            // reset the selected items
-            itemsHelpers.setValue([])
-          }}
-        />
+              // reset the selected items
+              itemsHelpers.setValue([])
+            }}
+          />
+        )}
       </div>
     </>
   )

--- a/apps/frontend-manage/src/components/questions/tags/TagActions.tsx
+++ b/apps/frontend-manage/src/components/questions/tags/TagActions.tsx
@@ -84,14 +84,13 @@ function TagActions({
           <Button.Icon withoutLabel icon={faTrash} />
         </Button>
       )}
-      {setIsDeletionModalOpen && (
+      {isDeletionModalOpen && setIsDeletionModalOpen ? (
         <TagDeletionModal
           id={tag.id}
           name={tag.name}
-          open={isDeletionModalOpen ?? false}
-          setOpen={setIsDeletionModalOpen}
+          onClose={() => setIsDeletionModalOpen(false)}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionDuplicationModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionDuplicationModal.tsx
@@ -11,12 +11,10 @@ import { useTranslations } from 'next-intl'
 
 function AnswerCollectionDuplicationModal({
   collectionId,
-  open,
   onClose,
   onSuccess,
 }: {
   collectionId: number
-  open: boolean
   onClose: () => void
   onSuccess: () => void
 }) {
@@ -34,7 +32,7 @@ function AnswerCollectionDuplicationModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={t('manage.resources.duplicateCollection')}
       secondaryLabel={

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@apollo/client'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { GetSingleAnswerCollectionDocument } from '@klicker-uzh/graphql/dist/ops'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
 import {
   Accordion,
   AccordionContent,
@@ -91,10 +92,6 @@ function AnswerCollectionEditModal({
     return search.search(searchQuery) as typeof collection.entries
   }, [collection, search, searchQuery])
 
-  if (loading || !collection) {
-    return null
-  }
-
   return (
     <Modal
       open
@@ -103,125 +100,134 @@ function AnswerCollectionEditModal({
         setOptionsEditingDisabled(false)
         onClose()
       }}
-      title={t('manage.resources.answerCollection', { name: collection.name })}
+      title={t('manage.resources.answerCollection', {
+        name:
+          loading || !collection
+            ? t('shared.generic.loading')
+            : collection.name,
+      })}
       dataCloseButton={{ cy: 'close-answer-collection-edit-modal' }}
       className={{
         content: twMerge('max-h-[calc(100vh-1.5rem)] pb-2', className?.content),
         overlay: className?.overlay,
       }}
     >
-      <Accordion
-        collapsible
-        type="single"
-        defaultValue={'metadata'}
-        value={accordionState}
-        onValueChange={(newValue) => {
-          if (metadataTouched || optionsTouched) {
-            onErrorToast()
-          } else {
-            setAccordionState(newValue as 'metadata' | 'options')
-          }
-        }}
-        className="w-full"
-      >
-        <AccordionItem value="metadata">
-          <AccordionTrigger
-            className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
-            data-cy="open-answer-collection-metadata"
-          >
-            {t('manage.resources.nameAndDescription')}
-          </AccordionTrigger>
-          <AccordionContent className="px-1">
-            <AnswerCollectionMetaForm
-              collection={collection}
-              onSuccess={() => {
-                setMetadataTouched(false)
-                onSuccessToast()
-              }}
-              metadataTouched={metadataTouched}
-              setMetadataTouched={setMetadataTouched}
-              inlineEditing={inlineEditing}
-              refetchAnswerCollections={refetchAnswerCollections}
-            />
-          </AccordionContent>
-        </AccordionItem>
-
-        <AccordionItem value="options">
-          <AccordionTrigger
-            className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
-            data-cy="open-answer-collection-options"
-          >
-            {t('manage.resources.answerOptions')}
-          </AccordionTrigger>
-          <AccordionContent className="px-1 pb-2">
-            <div className="my-1.5 text-sm">
-              {t('manage.resources.changesImmediateEffect')}
-            </div>
-            {collection.entries?.some(
-              (entry) => (entry.numSolutionUsages ?? 0) > 0
-            ) ? (
-              <UserNotification
-                message={t('manage.resources.answerOptionUsed')}
-                type="warning"
-                className={{ root: 'mb-2' }}
+      {loading || !collection ? (
+        <Loader />
+      ) : (
+        <Accordion
+          collapsible
+          type="single"
+          defaultValue={'metadata'}
+          value={accordionState}
+          onValueChange={(newValue) => {
+            if (metadataTouched || optionsTouched) {
+              onErrorToast()
+            } else {
+              setAccordionState(newValue as 'metadata' | 'options')
+            }
+          }}
+          className="w-full"
+        >
+          <AccordionItem value="metadata">
+            <AccordionTrigger
+              className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
+              data-cy="open-answer-collection-metadata"
+            >
+              {t('manage.resources.nameAndDescription')}
+            </AccordionTrigger>
+            <AccordionContent className="px-1">
+              <AnswerCollectionMetaForm
+                collection={collection}
+                onSuccess={() => {
+                  setMetadataTouched(false)
+                  onSuccessToast()
+                }}
+                metadataTouched={metadataTouched}
+                setMetadataTouched={setMetadataTouched}
+                inlineEditing={inlineEditing}
+                refetchAnswerCollections={refetchAnswerCollections}
               />
-            ) : null}
+            </AccordionContent>
+          </AccordionItem>
 
-            <TextField
-              value={searchQuery}
-              onChange={(searchString) => setSearchQuery(searchString)}
-              icon={faSearch}
-              placeholder={t('manage.resources.searchAnswerOptions')}
-              data={{ cy: 'search-answer-options' }}
-              className={{ field: 'mb-2 w-full', input: 'h-8 !pl-8 text-sm' }}
-            />
-            <div className="my-2 flex max-h-[calc(100vh-35rem)] flex-col gap-1 overflow-y-auto md:max-h-[calc(100vh-29rem)] lg:max-h-[calc(100vh-26rem)]">
-              {filteredEntries.length === 0 ? (
-                <UserNotification type="info">
-                  {t('manage.resources.noMatchingOptions')}
-                </UserNotification>
-              ) : (
-                filteredEntries.map((entry, ix) => (
-                  <AnswerCollectionOption
-                    key={`collection-entry-${entry.id}`}
-                    entry={entry}
-                    otherEntries={collection
-                      .entries!.filter((e) => e.id !== entry.id)
-                      .map((e) => e.value)}
-                    last={ix === filteredEntries.length - 1}
-                    collectionId={collection.id}
-                    deletionDisabled={collection.entries!.length <= 2}
-                    editDisabled={optionsEditingDisabled}
-                    setEditDisabled={setOptionsEditingDisabled}
-                    onTouched={() => setOptionsTouched(true)}
-                    onSuccess={() => {
-                      setOptionsTouched(false)
-                      onSuccessToast()
-                    }}
-                    inlineEditing={inlineEditing}
-                    refetchAnswerCollections={refetchAnswerCollections}
-                  />
-                ))
-              )}
-            </div>
-            <AddAnswerCollectionEntry
-              collectionId={collection.id}
-              entries={collection.entries ?? []}
-              setOptionsEditingDisabled={setOptionsEditingDisabled}
-              onTouched={() => setOptionsTouched(true)}
-              onUntouched={() => {
-                setOptionsTouched(false)
-              }}
-              onSuccess={() => {
-                setOptionsTouched(false)
-                onSuccessToast()
-              }}
-              inlineEditing={inlineEditing}
-              refetchAnswerCollections={refetchAnswerCollections}
-            />
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
+          <AccordionItem value="options">
+            <AccordionTrigger
+              className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
+              data-cy="open-answer-collection-options"
+            >
+              {t('manage.resources.answerOptions')}
+            </AccordionTrigger>
+            <AccordionContent className="px-1 pb-2">
+              <div className="my-1.5 text-sm">
+                {t('manage.resources.changesImmediateEffect')}
+              </div>
+              {collection.entries?.some(
+                (entry) => (entry.numSolutionUsages ?? 0) > 0
+              ) ? (
+                <UserNotification
+                  message={t('manage.resources.answerOptionUsed')}
+                  type="warning"
+                  className={{ root: 'mb-2' }}
+                />
+              ) : null}
+
+              <TextField
+                value={searchQuery}
+                onChange={(searchString) => setSearchQuery(searchString)}
+                icon={faSearch}
+                placeholder={t('manage.resources.searchAnswerOptions')}
+                data={{ cy: 'search-answer-options' }}
+                className={{ field: 'mb-2 w-full', input: 'h-8 !pl-8 text-sm' }}
+              />
+              <div className="my-2 flex max-h-[calc(100vh-35rem)] flex-col gap-1 overflow-y-auto md:max-h-[calc(100vh-29rem)] lg:max-h-[calc(100vh-26rem)]">
+                {filteredEntries.length === 0 ? (
+                  <UserNotification type="info">
+                    {t('manage.resources.noMatchingOptions')}
+                  </UserNotification>
+                ) : (
+                  filteredEntries.map((entry, ix) => (
+                    <AnswerCollectionOption
+                      key={`collection-entry-${entry.id}`}
+                      entry={entry}
+                      otherEntries={collection
+                        .entries!.filter((e) => e.id !== entry.id)
+                        .map((e) => e.value)}
+                      last={ix === filteredEntries.length - 1}
+                      collectionId={collection.id}
+                      deletionDisabled={collection.entries!.length <= 2}
+                      editDisabled={optionsEditingDisabled}
+                      setEditDisabled={setOptionsEditingDisabled}
+                      onTouched={() => setOptionsTouched(true)}
+                      onSuccess={() => {
+                        setOptionsTouched(false)
+                        onSuccessToast()
+                      }}
+                      inlineEditing={inlineEditing}
+                      refetchAnswerCollections={refetchAnswerCollections}
+                    />
+                  ))
+                )}
+              </div>
+              <AddAnswerCollectionEntry
+                collectionId={collection.id}
+                entries={collection.entries ?? []}
+                setOptionsEditingDisabled={setOptionsEditingDisabled}
+                onTouched={() => setOptionsTouched(true)}
+                onUntouched={() => {
+                  setOptionsTouched(false)
+                }}
+                onSuccess={() => {
+                  setOptionsTouched(false)
+                  onSuccessToast()
+                }}
+                inlineEditing={inlineEditing}
+                refetchAnswerCollections={refetchAnswerCollections}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
     </Modal>
   )
 }

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionEditModal.tsx
@@ -21,14 +21,12 @@ import AnswerCollectionOption from './AnswerCollectionOption'
 
 function AnswerCollectionEditModal({
   collectionId,
-  open,
   onClose,
   inlineEditing = false,
   refetchAnswerCollections,
   className,
 }: {
   collectionId: number
-  open: boolean
   onClose: () => void
   inlineEditing?: boolean
   refetchAnswerCollections?: () => Promise<any>
@@ -99,8 +97,8 @@ function AnswerCollectionEditModal({
 
   return (
     <Modal
+      open
       escapeDisabled
-      open={open}
       onClose={() => {
         setOptionsEditingDisabled(false)
         onClose()

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionItem.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionItem.tsx
@@ -155,17 +155,15 @@ function AnswerCollectionItem({
       </div>
 
       {/* editing and viewing modal components */}
-      {collection.isEditor && (
+      {collection.isEditor && editModal && (
         <AnswerCollectionEditModal
           collectionId={collection.id}
-          open={editModal}
           onClose={() => setEditModal(false)}
         />
       )}
       {duplicationModal && (
         <AnswerCollectionDuplicationModal
           collectionId={collection.id}
-          open={duplicationModal}
           onClose={() => setDuplicationModal(false)}
           onSuccess={() =>
             toast({
@@ -177,10 +175,9 @@ function AnswerCollectionItem({
         />
       )}
 
-      {!collection.isEditor && (
+      {!collection.isEditor && viewingModal && (
         <AnswerCollectionViewingModal
           collectionId={collection.id}
-          open={viewingModal}
           onClose={() => setViewingModal(false)}
         />
       )}
@@ -188,38 +185,41 @@ function AnswerCollectionItem({
       {/* sharing functionalities modals to add / revoke / ... access */}
       {collection.isManager && (
         <>
-          <ObjectSharingModalWrapper
-            objectId={collection.id}
-            objectName={collection.name}
-            objectType={ObjectType.AnswerCollection}
-            isOwner={collection.isOwner ?? false}
-            open={sharingModal}
-            onClose={() => setSharingModal(false)}
-          />
-          <CollectionDeletionModal
-            collection={collection}
-            deletionModal={deletionModal}
-            setDeletionModal={setDeletionModal}
-          />
+          {sharingModal && (
+            <ObjectSharingModalWrapper
+              objectId={collection.id}
+              objectName={collection.name}
+              objectType={ObjectType.AnswerCollection}
+              isOwner={collection.isOwner ?? false}
+              onClose={() => setSharingModal(false)}
+            />
+          )}
+          {deletionModal && (
+            <CollectionDeletionModal
+              collection={collection}
+              setDeletionModal={setDeletionModal}
+            />
+          )}
         </>
       )}
 
       {/* removal modal for non-owners */}
-      {!collection.isOwner && (
+      {!collection.isOwner && removalModal ? (
         <AnswerCollectionRemovalModal
           id={collection.id}
           name={collection.name}
-          removalModal={removalModal}
-          setRemovalModal={setRemovalModal}
+          onClose={() => setRemovalModal(false)}
+        />
+      ) : null}
+
+      {activityLogOpen && (
+        <ActivityLogDialog
+          objectId={collection.id}
+          objectType={ObjectType.AnswerCollection}
+          open={activityLogOpen}
+          onClose={() => setActivityLogOpen(false)}
         />
       )}
-
-      <ActivityLogDialog
-        objectId={collection.id}
-        objectType={ObjectType.AnswerCollection}
-        open={activityLogOpen}
-        onOpenChange={setActivityLogOpen}
-      />
     </>
   )
 }

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionViewingModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionViewingModal.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { GetSingleAnswerCollectionDocument } from '@klicker-uzh/graphql/dist/ops'
 import { Markdown } from '@klicker-uzh/markdown'
+import Loader from '@klicker-uzh/shared-components/src/Loader'
 import {
   Accordion,
   AccordionContent,
@@ -53,10 +54,6 @@ function AnswerCollectionViewingModal({
     return search.search(searchQuery) as typeof collection.entries
   }, [collection, search, searchQuery])
 
-  if (loading || !collection) {
-    return null
-  }
-
   return (
     <Modal
       open
@@ -66,80 +63,90 @@ function AnswerCollectionViewingModal({
           className="flex flex-row items-end gap-2"
           data-cy="viewing-collection-title"
         >
-          <div className="text-lg font-semibold">{collection.name}</div>
-          <div className="mb-0.5 hidden text-base font-normal text-gray-500 md:block">
-            {t('manage.resources.byOwner', {
-              owner: collection.ownerShortname,
-            })}
+          <div className="text-lg font-semibold">
+            {loading || !collection
+              ? t('shared.generic.loading')
+              : collection.name}
           </div>
+          {loading || !collection ? null : (
+            <div className="mb-0.5 hidden text-base font-normal text-gray-500 md:block">
+              {t('manage.resources.byOwner', {
+                owner: collection.ownerShortname,
+              })}
+            </div>
+          )}
         </div>
       }
       dataCloseButton={{ cy: 'close-viewing-collection-modal' }}
       className={{ content: 'max-w-2xl pb-2' }}
     >
-      <Accordion
-        collapsible
-        type="single"
-        defaultValue="description"
-        className="w-full"
-      >
-        <AccordionItem value="description">
-          <AccordionTrigger
-            className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
-            data-cy="open-collection-description"
-          >
-            {t('shared.generic.description')}
-          </AccordionTrigger>
-          <AccordionContent className="px-1">
-            <div
-              data-cy="viewing-collection-description"
-              className="rounded-md bg-gray-100 p-4"
+      {loading || !collection ? (
+        <Loader />
+      ) : (
+        <Accordion
+          collapsible
+          type="single"
+          defaultValue="description"
+          className="w-full"
+        >
+          <AccordionItem value="description">
+            <AccordionTrigger
+              className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
+              data-cy="open-collection-description"
             >
-              <Markdown content={collection.description} />
-            </div>
-          </AccordionContent>
-        </AccordionItem>
+              {t('shared.generic.description')}
+            </AccordionTrigger>
+            <AccordionContent className="px-1">
+              <div
+                data-cy="viewing-collection-description"
+                className="rounded-md bg-gray-100 p-4"
+              >
+                <Markdown content={collection.description} />
+              </div>
+            </AccordionContent>
+          </AccordionItem>
 
-        <AccordionItem value="options">
-          <AccordionTrigger
-            className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
-            data-cy="open-collection-options"
-          >
-            {t('manage.resources.answerOptions')} (
-            {collection.entries?.length || 0})
-          </AccordionTrigger>
-          <AccordionContent className="px-1 pb-2 pt-0.5">
-            <TextField
-              value={searchQuery}
-              onChange={(searchString) => setSearchQuery(searchString)}
-              icon={faSearch}
-              placeholder={t('manage.resources.searchAnswerOptions')}
-              data={{ cy: 'search-viewing-answer-options' }}
-              className={{ field: 'mb-2 w-full', input: 'h-8 !pl-8 text-sm' }}
-            />
+          <AccordionItem value="options">
+            <AccordionTrigger
+              className="hover:bg-accent px-1 py-2 font-semibold hover:no-underline"
+              data-cy="open-collection-options"
+            >
+              {t('manage.resources.answerOptions')} (
+              {collection.entries?.length || 0})
+            </AccordionTrigger>
+            <AccordionContent className="px-1 pb-2 pt-0.5">
+              <TextField
+                value={searchQuery}
+                onChange={(searchString) => setSearchQuery(searchString)}
+                icon={faSearch}
+                placeholder={t('manage.resources.searchAnswerOptions')}
+                data={{ cy: 'search-viewing-answer-options' }}
+                className={{ field: 'mb-2 w-full', input: 'h-8 !pl-8 text-sm' }}
+              />
 
-            <div className="max-h-[calc(100vh-16rem)] overflow-y-auto rounded-md border border-gray-200">
-              {filteredEntries.length === 0 ? (
-                <div className="p-4 text-center">
-                  <UserNotification type="info">
-                    {t('manage.resources.noMatchingOptions')}
-                  </UserNotification>
-                </div>
-              ) : (
-                filteredEntries.map((entry, ix) => (
-                  <div
-                    key={entry.id}
-                    data-cy={`viewing-collection-answer-${ix}`}
-                    className="break-words border-b border-gray-200 p-3 last:border-b-0 hover:bg-gray-50"
-                  >
-                    {entry.value}
+              <div className="max-h-[calc(100vh-16rem)] overflow-y-auto rounded-md border border-gray-200">
+                {filteredEntries.length === 0 ? (
+                  <div className="p-4 text-center">
+                    <UserNotification type="info">
+                      {t('manage.resources.noMatchingOptions')}
+                    </UserNotification>
                   </div>
-                ))
-              )}
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
+                ) : (
+                  filteredEntries.map((entry, ix) => (
+                    <div
+                      key={entry.id}
+                      data-cy={`viewing-collection-answer-${ix}`}
+                      className="break-words border-b border-gray-200 p-3 last:border-b-0 hover:bg-gray-50"
+                    >
+                      {entry.value}
+                    </div>
+                  ))
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
     </Modal>
   )
 }

--- a/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionViewingModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/AnswerCollectionViewingModal.tsx
@@ -17,11 +17,9 @@ import { useMemo, useState } from 'react'
 
 function AnswerCollectionViewingModal({
   collectionId,
-  open,
   onClose,
 }: {
   collectionId: number
-  open: boolean
   onClose: () => void
 }) {
   const t = useTranslations()
@@ -53,7 +51,7 @@ function AnswerCollectionViewingModal({
     }
 
     return search.search(searchQuery) as typeof collection.entries
-  }, [collection?.entries, searchQuery, search])
+  }, [collection, search, searchQuery])
 
   if (loading || !collection) {
     return null
@@ -61,7 +59,7 @@ function AnswerCollectionViewingModal({
 
   return (
     <Modal
-      open={open}
+      open
       onClose={onClose}
       title={
         <div

--- a/apps/frontend-manage/src/components/resources/answerCollections/CollectionDeletionModal.tsx
+++ b/apps/frontend-manage/src/components/resources/answerCollections/CollectionDeletionModal.tsx
@@ -12,11 +12,9 @@ import { Dispatch, SetStateAction } from 'react'
 
 function CollectionDeletionModal({
   collection,
-  deletionModal,
   setDeletionModal,
 }: {
   collection: AnswerCollection
-  deletionModal: boolean
   setDeletionModal: Dispatch<SetStateAction<boolean>>
 }) {
   const t = useTranslations()
@@ -33,8 +31,8 @@ function CollectionDeletionModal({
 
   return (
     <Modal
+      open
       title={t('manage.resources.deleteAnswerCollection')}
-      open={deletionModal}
       onClose={() => setDeletionModal(false)}
       primaryLabel={
         <div className="flex flex-row items-center gap-2.5">

--- a/apps/frontend-manage/src/components/sharing/ActivityLogDialog.tsx
+++ b/apps/frontend-manage/src/components/sharing/ActivityLogDialog.tsx
@@ -1,32 +1,25 @@
 import { ObjectType } from '@klicker-uzh/graphql/dist/ops'
 import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
-import { Dispatch, SetStateAction } from 'react'
 import ActivityLog from './ActivityLog'
-
-interface ActivityLogDialogProps {
-  // the ID of the object to fetch activity for
-  objectId: string | number
-  // the type of object (Element, Course, etc.)
-  objectType: ObjectType
-  // controlled open state
-  open: boolean
-  // callback for open state change
-  onOpenChange: Dispatch<SetStateAction<boolean>>
-}
 
 function ActivityLogDialog({
   objectId,
   objectType,
   open,
-  onOpenChange,
-}: ActivityLogDialogProps) {
+  onClose,
+}: {
+  objectId: string | number
+  objectType: ObjectType
+  open: boolean
+  onClose: () => void
+}) {
   const t = useTranslations()
 
   return (
     <Modal
-      open={open}
-      onClose={() => onOpenChange(false)}
+      open
+      onClose={onClose}
       title={t('shared.activity.title')}
       data={{ cy: 'activity-log-dialog' }}
       dataCloseButton={{ cy: 'close-activity-log' }}

--- a/apps/frontend-manage/src/components/sharing/AnswerCollectionRemovalModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/AnswerCollectionRemovalModal.tsx
@@ -8,18 +8,15 @@ import {
 } from '@klicker-uzh/graphql/dist/ops'
 import { Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
-import { Dispatch, SetStateAction } from 'react'
 
 function AnswerCollectionRemovalModal({
   id,
   name,
-  removalModal,
-  setRemovalModal,
+  onClose,
 }: {
   id: number
   name: string
-  removalModal: boolean
-  setRemovalModal: Dispatch<SetStateAction<boolean>>
+  onClose: () => void
 }) {
   const t = useTranslations()
   const [removeObject, { loading: removing }] =
@@ -34,9 +31,9 @@ function AnswerCollectionRemovalModal({
 
   return (
     <Modal
+      open
       title={t(`manage.sharing.remove${ObjectType.AnswerCollection}`)}
-      open={removalModal}
-      onClose={() => setRemovalModal(false)}
+      onClose={onClose}
       primaryLabel={
         <div className="flex flex-row items-center gap-2.5">
           {!removing && <FontAwesomeIcon icon={faX} />}
@@ -67,7 +64,7 @@ function AnswerCollectionRemovalModal({
               message: t('manage.sharing.removalSuccessful'),
               options: { duration: 3000 },
             })
-            setRemovalModal(false)
+            onClose()
           } else {
             onRemovalError()
           }

--- a/apps/frontend-manage/src/components/sharing/ExistingPermissionEntries.tsx
+++ b/apps/frontend-manage/src/components/sharing/ExistingPermissionEntries.tsx
@@ -226,25 +226,29 @@ function ExistingPermissionEntries({
           </tr>
         ))}
 
-      <ModifyOwnPermissionsModal
-        open={modifyOwnPermissionsModal.open}
-        onClose={() =>
-          setModifyOwnPermissionsModal({
-            ...modifyOwnPermissionsModal,
-            open: false,
-          })
-        }
-        onConfirm={confirmModifyOwnPermissions}
-        action={modifyOwnPermissionsModal.action}
-        newPermissionLevel={modifyOwnPermissionsModal.newPermissionLevel}
-      />
-      <PermissionRevocationModal
-        open={revocationModal.open}
-        onClose={() => setRevocationModal({ ...revocationModal, open: false })}
-        onRevocation={confirmRevocation}
-        username={revocationModal.username}
-        userGroup={revocationModal.userGroup}
-      />
+      {modifyOwnPermissionsModal.open && (
+        <ModifyOwnPermissionsModal
+          onClose={() =>
+            setModifyOwnPermissionsModal({
+              ...modifyOwnPermissionsModal,
+              open: false,
+            })
+          }
+          onConfirm={confirmModifyOwnPermissions}
+          action={modifyOwnPermissionsModal.action}
+          newPermissionLevel={modifyOwnPermissionsModal.newPermissionLevel}
+        />
+      )}
+      {revocationModal.open && (
+        <PermissionRevocationModal
+          onClose={() =>
+            setRevocationModal({ ...revocationModal, open: false })
+          }
+          onRevocation={confirmRevocation}
+          username={revocationModal.username}
+          userGroup={revocationModal.userGroup}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/sharing/ModifyOwnPermissionsModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/ModifyOwnPermissionsModal.tsx
@@ -3,7 +3,6 @@ import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 interface ModifyOwnPermissionsModalProps {
-  open: boolean
   onClose: () => void
   onConfirm: () => void
   action: 'change' | 'remove'
@@ -11,7 +10,6 @@ interface ModifyOwnPermissionsModalProps {
 }
 
 function ModifyOwnPermissionsModal({
-  open,
   onClose,
   onConfirm,
   action,
@@ -21,8 +19,8 @@ function ModifyOwnPermissionsModal({
 
   return (
     <Modal
+      open
       hideCloseButton
-      open={open}
       onClose={onClose}
       title={t('manage.sharing.modifyOwnPermissionsTitle')}
       secondaryLabel={t('shared.generic.cancel')}

--- a/apps/frontend-manage/src/components/sharing/ObjectSharingModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/ObjectSharingModal.tsx
@@ -14,7 +14,6 @@ import usePermissionLevelChange from './usePermissionLevelChange'
 import usePermissionRevocation from './usePermissionRevocation'
 
 function ObjectSharingModal({
-  open,
   onClose,
   objectId,
   objectType,
@@ -24,7 +23,6 @@ function ObjectSharingModal({
   isOwner,
   derivedPermissionsAvailable,
 }: {
-  open: boolean
   onClose: () => void
   objectId: number | string
   objectType: ObjectType
@@ -101,9 +99,9 @@ function ObjectSharingModal({
 
   return (
     <Modal
+      open
       fullScreen
       title={t(`manage.sharing.share${objectType}`)}
-      open={open}
       onClose={onClose}
       dataCloseButton={{ cy: 'close-share-object' }}
       className={{ content: 'h-max max-w-5xl pb-0' }}

--- a/apps/frontend-manage/src/components/sharing/ObjectSharingModalWrapper.tsx
+++ b/apps/frontend-manage/src/components/sharing/ObjectSharingModalWrapper.tsx
@@ -12,7 +12,6 @@ interface ObjectSharingModalBaseProps {
   courseId?: string
   catalogCollectionId?: string
   isOwner: boolean
-  open: boolean
   onClose: () => void
 }
 
@@ -33,7 +32,6 @@ function ObjectSharingModalWrapper({
   isTemplate = false,
   catalogCollectionId,
   isOwner,
-  open,
   onClose,
 }: ObjectSharingModalIdProps | ObjectSharingModalUuidProps) {
   const [transferModalOpen, setTransferModalOpen] = useState(false)
@@ -45,7 +43,6 @@ function ObjectSharingModalWrapper({
   return (
     <>
       <ObjectSharingModal
-        open={open}
         onClose={onClose}
         objectId={typeof objectId !== 'undefined' ? objectId : objectUuid!}
         objectType={objectType}
@@ -57,15 +54,16 @@ function ObjectSharingModalWrapper({
           objectType !== ObjectType.Course
         }
       />
-      <TransferOwnershipModal
-        open={transferModalOpen}
-        onClose={() => setTransferModalOpen(false)}
-        objectId={typeof objectId !== 'undefined' ? objectId : objectUuid!}
-        objectType={objectType}
-        objectName={objectName}
-        isTemplate={isTemplate}
-        catalogCollectionId={catalogCollectionId}
-      />
+      {transferModalOpen && (
+        <TransferOwnershipModal
+          onClose={() => setTransferModalOpen(false)}
+          objectId={typeof objectId !== 'undefined' ? objectId : objectUuid!}
+          objectType={objectType}
+          objectName={objectName}
+          isTemplate={isTemplate}
+          catalogCollectionId={catalogCollectionId}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/sharing/PermissionRevocationModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/PermissionRevocationModal.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 
 interface PermissionRevocationModalProps {
-  open: boolean
   onClose: () => void
   onRevocation: () => Promise<void>
   username?: string
@@ -11,7 +10,6 @@ interface PermissionRevocationModalProps {
 }
 
 function PermissionRevocationModal({
-  open,
   onClose,
   onRevocation,
   username,
@@ -32,8 +30,8 @@ function PermissionRevocationModal({
 
   return (
     <Modal
+      open
       hideCloseButton
-      open={open}
       onClose={onClose}
       title={t('manage.sharing.revokeDirectPermission')}
       secondaryLabel={t('shared.generic.cancel')}

--- a/apps/frontend-manage/src/components/sharing/TransferOwnershipModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/TransferOwnershipModal.tsx
@@ -7,7 +7,6 @@ import * as Yup from 'yup'
 import useTransferObjectOwnership from './useTransferObjectOwnership'
 
 function TransferOwnershipModal({
-  open,
   onClose,
   objectId,
   objectType,
@@ -15,7 +14,6 @@ function TransferOwnershipModal({
   isTemplate = false,
   catalogCollectionId,
 }: {
-  open: boolean
   onClose: () => void
   objectId: number | string
   objectType: ObjectType
@@ -47,9 +45,9 @@ function TransferOwnershipModal({
 
   return (
     <Modal
+      open
       escapeDisabled
       title={t('manage.sharing.transferOwnership')}
-      open={open}
       onClose={onClose}
       className={{ content: 'max-w-lg pb-2' }}
       dataCloseButton={{ cy: 'close-transfer-ownership-modal' }}

--- a/apps/frontend-manage/src/components/user/DelegatedAccessCreationModal.tsx
+++ b/apps/frontend-manage/src/components/user/DelegatedAccessCreationModal.tsx
@@ -3,16 +3,14 @@ import { Button, Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 function DelegatedAccessCreationModal({
-  confirmationModal,
-  setConfirmationModal,
+  onClose,
   shortname,
   values,
   isSubmitting,
   isValid,
   submitForm,
 }: {
-  confirmationModal: boolean
-  setConfirmationModal: (value: boolean) => void
+  onClose: () => void
   shortname: string
   values: { password: string }
   isSubmitting: boolean
@@ -23,9 +21,9 @@ function DelegatedAccessCreationModal({
 
   return (
     <Modal
+      open
       title={t('manage.settings.confirmDelegatedAccess')}
-      open={confirmationModal}
-      onClose={() => setConfirmationModal(false)}
+      onClose={onClose}
       className={{ content: 'h-max !min-h-[10rem] max-w-[35rem] !pb-1' }}
     >
       <div>{t('manage.settings.confirmDelegatedAccessTooltip')}</div>

--- a/apps/frontend-manage/src/components/user/DelegatedAccessSettings.tsx
+++ b/apps/frontend-manage/src/components/user/DelegatedAccessSettings.tsx
@@ -225,25 +225,30 @@ function DelegatedAccessSettings({ shortname }: { shortname?: string }) {
                       {t('manage.settings.createLogin')}
                     </Button.Label>
                   </Button>
-                  <DelegatedAccessCreationModal
-                    confirmationModal={confirmationModal}
-                    setConfirmationModal={setConfirmationModal}
-                    shortname={shortname ?? ''}
-                    values={values}
-                    isSubmitting={isSubmitting}
-                    isValid={isValid}
-                    submitForm={submitForm}
-                  />
+                  {confirmationModal && (
+                    <DelegatedAccessCreationModal
+                      onClose={() => setConfirmationModal(false)}
+                      shortname={shortname ?? ''}
+                      values={values}
+                      isSubmitting={isSubmitting}
+                      isValid={isValid}
+                      submitForm={submitForm}
+                    />
+                  )}
                 </Form>
               )
             }}
           </Formik>
         </div>
       </div>
-      <DelegatedPasswordChangeModal
-        changePasswordModal={changePasswordModal}
-        setChangePasswordModal={setChangePasswordModal}
-      />
+      {changePasswordModal.open && (
+        <DelegatedPasswordChangeModal
+          loginId={changePasswordModal.loginId}
+          onClose={() =>
+            setChangePasswordModal({ open: false, loginId: undefined })
+          }
+        />
+      )}
     </Setting>
   )
 }

--- a/apps/frontend-manage/src/components/user/DelegatedPasswordChangeModal.tsx
+++ b/apps/frontend-manage/src/components/user/DelegatedPasswordChangeModal.tsx
@@ -9,25 +9,24 @@ import * as Yup from 'yup'
 import DelegatedAccessPassword, { PW_SETTINGS } from './DelegatedAccessPassword'
 
 function DelegatedPasswordChangeModal({
-  changePasswordModal,
-  setChangePasswordModal,
+  loginId,
+  onClose,
 }: {
-  changePasswordModal: { open: boolean; loginId?: string }
-  setChangePasswordModal: (value: { open: boolean; loginId?: string }) => void
+  loginId?: string
+  onClose: () => void
 }) {
   const t = useTranslations()
   const [updateUserLogin] = useMutation(UpdateUserLoginDocument)
 
+  if (!loginId) {
+    return null
+  }
+
   return (
     <Modal
+      open
       title={t('manage.settings.changeDelegatedLoginPassword')}
-      open={changePasswordModal.open}
-      onClose={() =>
-        setChangePasswordModal({
-          open: false,
-          loginId: undefined,
-        })
-      }
+      onClose={onClose}
       className={{
         content: 'h-max !min-h-[10rem] max-w-[25rem] pb-2',
       }}
@@ -46,12 +45,12 @@ function DelegatedPasswordChangeModal({
           setSubmitting(true)
           await updateUserLogin({
             variables: {
-              id: changePasswordModal.loginId!,
+              id: loginId!,
               password: values.password,
             },
           })
           setSubmitting(false)
-          setChangePasswordModal({ open: false, loginId: undefined })
+          onClose()
         }}
       >
         {({ values, setFieldValue, isValid, isSubmitting }) => (

--- a/apps/frontend-manage/src/pages/courses/grading/groupActivity/[id].tsx
+++ b/apps/frontend-manage/src/pages/courses/grading/groupActivity/[id].tsx
@@ -173,18 +173,20 @@ function GroupActivityGrading() {
           )}
         </div>
       </div>
-      <SubmissionSwitchModal
-        nextSubmission={nextSubmission}
-        switchingModal={switchingModal}
-        setSelectedSubmission={setSelectedSubmission}
-        setCurrentEditing={setCurrentEditing}
-        setSwitchingModal={setSwitchingModal}
-      />
-      <FinalizeGradingModal
-        open={finalizeModal}
-        setOpen={setFinalizeModal}
-        activityId={groupActivity.id}
-      />
+      {switchingModal && (
+        <SubmissionSwitchModal
+          nextSubmission={nextSubmission}
+          setSelectedSubmission={setSelectedSubmission}
+          setCurrentEditing={setCurrentEditing}
+          setSwitchingModal={setSwitchingModal}
+        />
+      )}
+      {finalizeModal && (
+        <FinalizeGradingModal
+          onClose={() => setFinalizeModal(false)}
+          activityId={groupActivity.id}
+        />
+      )}
     </Layout>
   )
 }

--- a/apps/frontend-manage/src/pages/courses/index.tsx
+++ b/apps/frontend-manage/src/pages/courses/index.tsx
@@ -131,78 +131,79 @@ function CourseSelectionPage() {
               />
             </div>
           )}
-          <CourseArchiveModal
-            open={archiveModal.open}
-            setOpen={(newOpen) =>
-              showArchiveModal((prev) =>
-                newOpen
-                  ? { ...prev, open: newOpen }
-                  : { open: false, courseId: null, isArchived: false }
-              )
-            }
-            courseId={archiveModal.courseId}
-            isArchived={archiveModal.isArchived}
-          />
-          <CourseDeletionModal
-            open={deletionModal.open}
-            setOpen={(newOpen) =>
-              showDeletionModal((prev) =>
-                newOpen
-                  ? { ...prev, open: newOpen }
-                  : { open: false, courseId: null }
-              )
-            }
-            courseId={deletionModal.courseId}
-          />
-          <CourseManipulationModal
-            modalOpen={createCourseModal}
-            onModalClose={() => showCreateCourseModal(false)}
-            onSubmit={async (
-              values: CourseManipulationFormData,
-              setSubmitting,
-              onError
-            ) => {
-              try {
-                // convert dates to UTC
-                const startDateUTC = dayjs(values.startDate).utc().toISOString()
-                const endDateUTC = dayjs(values.endDate).utc().toISOString()
-                const groupDeadlineDateUTC = dayjs(values.groupCreationDeadline)
-                  .utc()
-                  .toISOString()
-
-                const result = await createCourse({
-                  variables: {
-                    name: values.name,
-                    displayName: values.displayName,
-                    description: values.description,
-                    color: values.color,
-                    startDate: startDateUTC,
-                    endDate: endDateUTC,
-                    isGamificationEnabled: values.isGamificationEnabled,
-                    isGroupCreationEnabled: values.isGroupCreationEnabled,
-                    groupDeadlineDate: groupDeadlineDateUTC,
-                    maxGroupSize: parseInt(String(values.maxGroupSize)),
-                    preferredGroupSize: parseInt(
-                      String(values.preferredGroupSize)
-                    ),
-                  },
-                  refetchQueries: [{ query: GetUserCoursesDocument }],
+          {archiveModal.open && (
+            <CourseArchiveModal
+              onClose={() =>
+                showArchiveModal({
+                  open: false,
+                  courseId: null,
+                  isArchived: false,
                 })
+              }
+              courseId={archiveModal.courseId}
+              isArchived={archiveModal.isArchived}
+            />
+          )}
+          {deletionModal.open && (
+            <CourseDeletionModal
+              onClose={() => showDeletionModal({ open: false, courseId: null })}
+              courseId={deletionModal.courseId}
+            />
+          )}
+          {createCourseModal && (
+            <CourseManipulationModal
+              onModalClose={() => showCreateCourseModal(false)}
+              onSubmit={async (
+                values: CourseManipulationFormData,
+                setSubmitting,
+                onError
+              ) => {
+                try {
+                  // convert dates to UTC
+                  const startDateUTC = dayjs(values.startDate)
+                    .utc()
+                    .toISOString()
+                  const endDateUTC = dayjs(values.endDate).utc().toISOString()
+                  const groupDeadlineDateUTC = dayjs(
+                    values.groupCreationDeadline
+                  )
+                    .utc()
+                    .toISOString()
 
-                if (result.data?.createCourse) {
-                  showCreateCourseModal(false)
-                  router.push(`/courses/${result.data.createCourse.id}`)
-                } else {
+                  const result = await createCourse({
+                    variables: {
+                      name: values.name,
+                      displayName: values.displayName,
+                      description: values.description,
+                      color: values.color,
+                      startDate: startDateUTC,
+                      endDate: endDateUTC,
+                      isGamificationEnabled: values.isGamificationEnabled,
+                      isGroupCreationEnabled: values.isGroupCreationEnabled,
+                      groupDeadlineDate: groupDeadlineDateUTC,
+                      maxGroupSize: parseInt(String(values.maxGroupSize)),
+                      preferredGroupSize: parseInt(
+                        String(values.preferredGroupSize)
+                      ),
+                    },
+                    refetchQueries: [{ query: GetUserCoursesDocument }],
+                  })
+
+                  if (result.data?.createCourse) {
+                    showCreateCourseModal(false)
+                    router.push(`/courses/${result.data.createCourse.id}`)
+                  } else {
+                    onError()
+                    setSubmitting(false)
+                  }
+                } catch (error) {
                   onError()
                   setSubmitting(false)
+                  console.log(error)
                 }
-              } catch (error) {
-                onError()
-                setSubmitting(false)
-                console.log(error)
-              }
-            }}
-          />
+              }}
+            />
+          )}
           {removalModal.courseId && removalModal.courseName ? (
             <CourseRemovalModal
               courseId={removalModal.courseId}

--- a/apps/frontend-manage/src/pages/index.tsx
+++ b/apps/frontend-manage/src/pages/index.tsx
@@ -578,18 +578,19 @@ function Index() {
           mode={ElementEditMode.CREATE}
         />
       )}
-      <RecoveryPrompt
-        open={showRecoveryPrompt}
-        onRecovery={() => {
-          setShowRecoveryPrompt(false)
-          setIsQuestionCreationModalOpen(true)
-        }}
-        onDiscard={() => {
-          localStorage.removeItem('autosave-element-creation')
-          setShowRecoveryPrompt(false)
-          setIsQuestionCreationModalOpen(true)
-        }}
-      />
+      {showRecoveryPrompt && (
+        <RecoveryPrompt
+          onRecovery={() => {
+            setShowRecoveryPrompt(false)
+            setIsQuestionCreationModalOpen(true)
+          }}
+          onDiscard={() => {
+            localStorage.removeItem('autosave-element-creation')
+            setShowRecoveryPrompt(false)
+            setIsQuestionCreationModalOpen(true)
+          }}
+        />
+      )}
       <Suspense fallback={<div />}>
         <SuspendedFirstLoginModal />
       </Suspense>

--- a/apps/frontend-pwa/src/components/flags/FlagElementModal.tsx
+++ b/apps/frontend-pwa/src/components/flags/FlagElementModal.tsx
@@ -17,13 +17,12 @@ import {
 } from '@uzh-bf/design-system'
 import { Form, Formik } from 'formik'
 import { useTranslations } from 'next-intl'
+import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import * as Yup from 'yup'
 
 interface FlagElementModalProps {
   index: number
-  open: boolean
-  setOpen: (newValue: boolean) => void
   instanceId: number
   elementId: number
   feedbackValue?: string
@@ -33,8 +32,6 @@ interface FlagElementModalProps {
 
 function FlagElementModal({
   index,
-  open,
-  setOpen,
   instanceId,
   elementId,
   feedbackValue,
@@ -42,6 +39,7 @@ function FlagElementModal({
   stackInstanceIds,
 }: FlagElementModalProps) {
   const t = useTranslations()
+  const [open, setOpen] = useState(false)
   const [flagElement, { error }] = useMutation(FlagElementDocument)
 
   const flagElementSchema = Yup.object().shape({

--- a/apps/frontend-pwa/src/components/participant/LeaveLeaderboardModal.tsx
+++ b/apps/frontend-pwa/src/components/participant/LeaveLeaderboardModal.tsx
@@ -2,20 +2,19 @@ import { Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 
 interface LeaveLeaderboardModalProps {
-  isModalOpen: boolean
-  setIsModalOpen: (isModalOpen: boolean) => void
+  onClose: () => void
   onConfirm: () => void
 }
 
 function LeaveLeaderboardModal({
-  isModalOpen,
-  setIsModalOpen,
+  onClose,
   onConfirm,
 }: LeaveLeaderboardModalProps) {
   const t = useTranslations()
 
   return (
     <Modal
+      open
       hideCloseButton
       title={t('pwa.courses.leaveLeaderboardTitle')}
       primaryLabel={t('shared.generic.confirm')}
@@ -23,10 +22,9 @@ function LeaveLeaderboardModal({
       onPrimaryAction={() => onConfirm()}
       dataPrimaryAction={{ cy: 'confirm-leave-course-leaderboard' }}
       secondaryLabel={t('shared.generic.cancel')}
-      onSecondaryAction={() => setIsModalOpen(false)}
+      onSecondaryAction={onClose}
       dataSecondaryAction={{ cy: 'cancel-leave-course-leaderboard' }}
-      onClose={() => setIsModalOpen(false)}
-      open={isModalOpen}
+      onClose={onClose}
       className={{ content: 'max-w-xl', title: 'self-start' }}
     >
       <div>{t('pwa.courses.leaveLeaderboardConfirmation')}</div>

--- a/apps/frontend-pwa/src/components/participant/ParticipantProfileModal.tsx
+++ b/apps/frontend-pwa/src/components/participant/ParticipantProfileModal.tsx
@@ -7,15 +7,13 @@ import { twMerge } from 'tailwind-merge'
 import ProfileData from './ProfileData'
 
 interface ParticipantProfileModalProps {
-  isProfileModalOpen: boolean
-  closeProfileModal: () => void
+  onClose: () => void
   participantId: string
   top10Participants: string[]
 }
 
 function ParticipantProfileModal({
-  isProfileModalOpen,
-  closeProfileModal,
+  onClose,
   participantId,
   top10Participants,
 }: ParticipantProfileModalProps) {
@@ -26,7 +24,6 @@ function ParticipantProfileModal({
   )
   const { data, loading } = useQuery(GetPublicParticipantProfileDocument, {
     variables: { id: selectedParticipant },
-    skip: !isProfileModalOpen,
   })
 
   const participant = data?.publicParticipantProfile
@@ -46,8 +43,8 @@ function ParticipantProfileModal({
 
   return (
     <Modal
-      open={isProfileModalOpen}
-      onClose={closeProfileModal}
+      open
+      onClose={onClose}
       className={{
         content: 'my-auto w-[500px]',
         title: 'text-3xl',

--- a/apps/frontend-pwa/src/components/practiceQuiz/InstanceHeader.tsx
+++ b/apps/frontend-pwa/src/components/practiceQuiz/InstanceHeader.tsx
@@ -48,7 +48,7 @@ function InstanceHeader({
   const t = useTranslations()
   const [rateElement, { loading: ratingLoading }] =
     useMutation(RateElementDocument)
-  const [modalOpen, setModalOpen] = useState(false)
+
   const [vote, setVote] = useState(
     previousElementFeedback?.upvote
       ? 1
@@ -198,8 +198,6 @@ function InstanceHeader({
             </Button>
             <FlagElementModal
               index={index}
-              open={modalOpen}
-              setOpen={setModalOpen}
               instanceId={instanceId}
               elementId={elementId}
               feedbackValue={feedbackValue}

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -547,23 +547,23 @@ function CourseOverview({
                 </TabContent>
               )}
             </Tabs>
-            {isProfileModalOpen && participantId && (
+            {isProfileModalOpen && participantId ? (
               <ParticipantProfileModal
-                isProfileModalOpen={isProfileModalOpen}
-                closeProfileModal={closeProfileModal}
+                onClose={closeProfileModal}
                 participantId={participantId}
                 top10Participants={top10Participants}
               />
-            )}
+            ) : null}
           </div>
-          <LeaveLeaderboardModal
-            isModalOpen={isLeaveCourseLeaderboardModalOpen}
-            setIsModalOpen={setIsLeaveCourseLeaderboardModalOpen}
-            onConfirm={() => {
-              leaveCourseLeaderboard()
-              setIsLeaveCourseLeaderboardModalOpen(false)
-            }}
-          />
+          {isLeaveCourseLeaderboardModalOpen && (
+            <LeaveLeaderboardModal
+              onClose={() => setIsLeaveCourseLeaderboardModalOpen(false)}
+              onConfirm={() => {
+                leaveCourseLeaderboard()
+                setIsLeaveCourseLeaderboardModalOpen(false)
+              }}
+            />
+          )}
         </>
       ) : (
         <UserNotification


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Modal components throughout the app now use a simplified open/close mechanism: they are conditionally rendered only when needed and always appear open when mounted.
  - The previous pattern of passing `open` and `setOpen` props to control modal visibility has been replaced with a single `onClose` callback for closing.
  - This change unifies and streamlines modal handling, making the UI more consistent and predictable for users.

- **Style**
  - Minor spacing and layout adjustments were made to improve visual consistency in some components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->