### PR TITLE
enhance(packages/shared-components): add possibility to override lower and upper bounds of histogram within bounds

### DIFF
--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2126,6 +2126,16 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       selection: 'Auswahl',
       histogramRange: 'Bereich',
       histogramBins: 'Unterteilungen',
+      histogramBinsError:
+        'Bitte geben Sie eine Anzahl Unterteilungen zwischen 2 und 100 ein.',
+      histogramLowerLimit: 'Untere Grenze',
+      histogramUpperLimit: 'Obere Grenze',
+      histogramLowerLimitError:
+        'Die untere Grenze muss grösser als {minValue} sein.',
+      histogramUpperLimitError:
+        'Die obere Grenze muss kleiner als {maxValue} sein.',
+      histogramRangeError:
+        'Bitte stellen Sie sicher, dass die untere Grenze kleiner als die obere Grenze ist.',
       correctLabel: 'Korrekt',
       correctLabelValue: 'Korrekt: {value}',
       resetSorting: 'Sortierung zurücksetzen',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2093,6 +2093,15 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       selection: 'Selection',
       histogramRange: 'Range',
       histogramBins: 'Bins',
+      histogramBinsError: 'Please enter a number of bins between 2 and 100.',
+      histogramLowerLimit: 'Lower Limit',
+      histogramUpperLimit: 'Upper Limit',
+      histogramLowerLimitError:
+        'The lower limit must be greater than {minValue}.',
+      histogramUpperLimitError:
+        'The upper limit must be smaller than {maxValue}.',
+      histogramRangeError:
+        'Please ensure that the lower limit is smaller than the upper limit.',
       correctLabel: 'Correct',
       correctLabelValue: 'Correct: {value}',
       resetSorting: 'Reset sorting',

--- a/packages/shared-components/dist/utilities.css
+++ b/packages/shared-components/dist/utilities.css
@@ -315,6 +315,10 @@
   width: 0.75rem
 }
 
+.w-44 {
+  width: 11rem
+}
+
 .w-8 {
   width: 2rem
 }

--- a/packages/shared-components/src/charts/ElementHistogram.tsx
+++ b/packages/shared-components/src/charts/ElementHistogram.tsx
@@ -76,11 +76,13 @@ function ElementHistogram({
         )
       : undefined,
     minValue:
-      !lowerLimit || (typeof minValue === 'number' && lowerLimit < minValue)
+      lowerLimit == null ||
+      (typeof minValue === 'number' && lowerLimit < minValue)
         ? minValue
         : lowerLimit,
     maxValue:
-      !upperLimit || (typeof maxValue === 'number' && upperLimit > maxValue)
+      upperLimit == null ||
+      (typeof maxValue === 'number' && upperLimit > maxValue)
         ? maxValue
         : upperLimit,
     binCount:
@@ -330,7 +332,8 @@ function ElementHistogram({
             error={
               upperLimit === null || upperLimit > processedData.domain.max
                 ? t('manage.evaluation.histogramUpperLimitError', { maxValue })
-                : upperLimit < processedData.domain.min
+                : upperLimit < processedData.domain.min ||
+                    (lowerLimit != null && upperLimit < lowerLimit)
                   ? t('manage.evaluation.histogramRangeError')
                   : undefined
             }

--- a/packages/shared-components/src/charts/ElementHistogram.tsx
+++ b/packages/shared-components/src/charts/ElementHistogram.tsx
@@ -1,6 +1,7 @@
+import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons'
 import { ElementType, type Statistics } from '@klicker-uzh/graphql/dist/ops'
 import { CHART_SOLUTION_COLORS } from '@klicker-uzh/shared-components/src/constants'
-import { NumberField, UserNotification } from '@uzh-bf/design-system'
+import { Button, NumberField, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import React, { useState } from 'react'
 import {
@@ -35,7 +36,7 @@ interface ElementHistogramProps {
   }
   textSize: string
   reference?: number
-  hideBins?: boolean
+  hideOptions?: boolean
   basic?: boolean
   className?: { root?: string }
 }
@@ -52,13 +53,15 @@ function ElementHistogram({
   showStatistics,
   textSize,
   reference,
-  hideBins = false,
+  hideOptions = false,
   basic = false,
   className,
 }: ElementHistogramProps) {
   const t = useTranslations()
   const supportedElementTypes = [ElementType.Numerical]
   const [numBins, setNumBins] = useState('20')
+  const [lowerLimit, setLowerLimit] = useState<number | null>(minValue ?? null)
+  const [upperLimit, setUpperLimit] = useState<number | null>(maxValue ?? null)
 
   const showSolutionRanges = showSolution && solutionRanges
   const showExactSolutions =
@@ -72,9 +75,18 @@ function ElementHistogram({
           typeof solution === 'number' ? solution : parseFloat(solution)
         )
       : undefined,
-    minValue,
-    maxValue,
-    binCount: parseInt(numBins),
+    minValue:
+      !lowerLimit || (typeof minValue === 'number' && lowerLimit < minValue)
+        ? minValue
+        : lowerLimit,
+    maxValue:
+      !upperLimit || (typeof maxValue === 'number' && upperLimit > maxValue)
+        ? maxValue
+        : upperLimit,
+    binCount:
+      parseInt(numBins) > 1 && parseInt(numBins) <= 100
+        ? parseInt(numBins)
+        : 20,
   })
 
   if (!supportedElementTypes.includes(type) || !processedData) {
@@ -271,17 +283,97 @@ function ElementHistogram({
         </BarChart>
       </ResponsiveContainer>
 
-      {hideBins ? null : (
-        <div className="float-right -mt-4 mr-4 flex flex-row items-center gap-2">
+      {!hideOptions ? (
+        <div className="float-right -mt-4 mr-4 flex flex-row items-end gap-2">
+          {/* lower limit of shown histogram data - if invalid, defaults to standard min / max values */}
           <NumberField
+            isTouched
+            id="histogramLowerLimit"
+            label={t('manage.evaluation.histogramLowerLimit')}
+            value={lowerLimit ?? ''}
+            onChange={(value) => {
+              const parsedValue = parseFloat(value)
+
+              // otherwise, set the lower limit to the parsed value
+              setLowerLimit(isNaN(parsedValue) ? null : parsedValue)
+            }}
+            error={
+              lowerLimit === null || lowerLimit < processedData.domain.min
+                ? t('manage.evaluation.histogramLowerLimitError', { minValue })
+                : undefined
+            }
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              // if one of the arrow keys is pressed, stop the event from propagating (to prevent instance switching)
+              if (
+                e.key === 'ArrowUp' ||
+                e.key === 'ArrowDown' ||
+                e.key === 'ArrowLeft' ||
+                e.key === 'ArrowRight'
+              ) {
+                e.stopPropagation()
+              }
+            }}
+            className={{ field: 'w-44' }}
+          />
+          {/* upper limit of shown histogram data - if invalid, defaults to standard min / max values */}
+          <NumberField
+            isTouched
+            id="histogramUpperLimit"
+            label={t('manage.evaluation.histogramUpperLimit')}
+            value={upperLimit ?? ''}
+            onChange={(value) => {
+              const parsedValue = parseFloat(value)
+
+              // otherwise, set the upper limit to the parsed value
+              setUpperLimit(isNaN(parsedValue) ? null : parsedValue)
+            }}
+            error={
+              upperLimit === null || upperLimit > processedData.domain.max
+                ? t('manage.evaluation.histogramUpperLimitError', { maxValue })
+                : upperLimit < processedData.domain.min
+                  ? t('manage.evaluation.histogramRangeError')
+                  : undefined
+            }
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              // if one of the arrow keys is pressed, stop the event from propagating (to prevent instance switching)
+              if (
+                e.key === 'ArrowUp' ||
+                e.key === 'ArrowDown' ||
+                e.key === 'ArrowLeft' ||
+                e.key === 'ArrowRight'
+              ) {
+                e.stopPropagation()
+              }
+            }}
+            className={{ field: 'w-44' }}
+          />
+          {/* number bins that the data should be separated into - limited to 100 to avoid browser overload */}
+          <NumberField
+            isTouched
             precision={0}
             id="histogramBins"
             label={t('manage.evaluation.histogramBins')}
             value={numBins}
             onChange={(value) => setNumBins(value)}
+            error={
+              parseInt(numBins) >= 2 && parseInt(numBins) <= 100
+                ? undefined
+                : t('manage.evaluation.histogramBinsError')
+            }
+            className={{ field: 'w-44' }}
           />
+          <Button
+            className={{ root: 'h-9 w-9' }}
+            onClick={() => {
+              setLowerLimit(minValue ?? null)
+              setUpperLimit(maxValue ?? null)
+              setNumBins('20')
+            }}
+          >
+            <Button.Icon withoutLabel icon={faArrowsRotate} />
+          </Button>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/shared-components/src/evaluation/NREvaluation.tsx
+++ b/packages/shared-components/src/evaluation/NREvaluation.tsx
@@ -20,6 +20,9 @@ function NREvaluation({ options, evaluation, reference }: NREvaluationProps) {
     <div className="h-40 space-y-2">
       <div className="font-bold">{t('pwa.practiceQuiz.othersAnswered')}</div>
       <ElementHistogram
+        basic
+        hideOptions
+        showSolution
         type={ElementType.Numerical}
         responses={evaluation.responses ?? []}
         solutionRanges={options.solutionRanges ?? undefined}
@@ -29,9 +32,6 @@ function NREvaluation({ options, evaluation, reference }: NREvaluationProps) {
         textSize="md"
         className={{ root: 'h-40' }}
         reference={reference ? parseFloat(reference) : undefined}
-        showSolution
-        hideBins
-        basic
       />
     </div>
   )


### PR DESCRIPTION
![Screenshot 2025-06-16 at 22 44 50](https://github.com/user-attachments/assets/ef7213ef-cb3c-4e99-a64d-59e91d7fa9e5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added interactive controls to the histogram display, allowing users to adjust the data range (lower and upper limits) and bin count, with validation and error messages for invalid inputs.
	- Introduced a reset button to quickly restore histogram settings to their defaults.
- **Localization**
	- Added new German and English messages and labels for histogram input validation and controls, improving user feedback and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->