### PR TITLE
chore(packages/graphql): increase prisma transaction timeout as temporary fix for sharing functionalities

### DIFF
--- a/apps/office-addin/src/content/components/App.tsx
+++ b/apps/office-addin/src/content/components/App.tsx
@@ -100,7 +100,17 @@ export default function App({
           <div className="mb-4 flex flex-row gap-4">
             <div className="flex-1">
               <ol className="list-inside list-decimal">
-                <li>Go to https://manage.klicker.uzh.ch/activities</li>
+                <li>
+                  Go to{' '}
+                  <a
+                    href="https://manage.klicker.uzh.ch/activities"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    https://manage.klicker.uzh.ch/activities
+                  </a>
+                </li>
                 <li>
                   For the live quiz you want to embed, open the &ldquo;Embed
                   Evaluation&rdquo; dialog

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -703,40 +703,43 @@ export async function createCourse(
 
   const defaultMaxGroupSize = 5
   const defaultPreferredGroupSize = 3
-  const course = await ctx.prisma.$transaction(async (prisma) => {
-    const newCourse = await prisma.course.create({
-      data: {
-        name: name.trim(),
-        displayName: displayName.trim(),
-        description: description,
-        color: color ?? '#CCD5ED',
-        startDate: startDate,
-        endDate: endDate,
-        isGroupCreationEnabled: isGroupCreationEnabled ?? true,
-        groupDeadlineDate: groupDeadlineDate ?? endDate,
-        maxGroupSize: maxGroupSize ?? defaultMaxGroupSize,
-        preferredGroupSize: preferredGroupSize ?? defaultPreferredGroupSize,
-        notificationEmail: notificationEmail,
-        isGamificationEnabled: isGamificationEnabled,
-        pinCode: randomPin,
-        owner: {
-          connect: {
-            id: ctx.user.sub,
+  const course = await ctx.prisma.$transaction(
+    async (prisma) => {
+      const newCourse = await prisma.course.create({
+        data: {
+          name: name.trim(),
+          displayName: displayName.trim(),
+          description: description,
+          color: color ?? '#CCD5ED',
+          startDate: startDate,
+          endDate: endDate,
+          isGroupCreationEnabled: isGroupCreationEnabled ?? true,
+          groupDeadlineDate: groupDeadlineDate ?? endDate,
+          maxGroupSize: maxGroupSize ?? defaultMaxGroupSize,
+          preferredGroupSize: preferredGroupSize ?? defaultPreferredGroupSize,
+          notificationEmail: notificationEmail,
+          isGamificationEnabled: isGamificationEnabled,
+          pinCode: randomPin,
+          owner: {
+            connect: {
+              id: ctx.user.sub,
+            },
           },
         },
-      },
-    })
+      })
 
-    await recomputeDerivedPermissions(
-      {
-        courseId: newCourse.id,
-        userId: ctx.user.sub,
-      },
-      prisma
-    )
+      await recomputeDerivedPermissions(
+        {
+          courseId: newCourse.id,
+          userId: ctx.user.sub,
+        },
+        prisma
+      )
 
-    return newCourse
-  })
+      return newCourse
+    },
+    { timeout: 60000 }
+  )
 
   return course
 }
@@ -1057,45 +1060,48 @@ export async function deleteCourse(
     throw new Error('Course not found or permission denied')
   }
 
-  const deletedCourse = await ctx.prisma.$transaction(async (prisma) => {
-    // hard-delete the course -> cascading delete on practice quiz, microlearning, group activity and linked stacks
-    // live quizzes are disconnected from the course on deletion
-    const deleted = await prisma.course.delete({ where: { id } })
+  const deletedCourse = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // hard-delete the course -> cascading delete on practice quiz, microlearning, group activity and linked stacks
+      // live quizzes are disconnected from the course on deletion
+      const deleted = await prisma.course.delete({ where: { id } })
 
-    // trigger a recomputation of all permissions related to the live quizzes of the course
-    // this action should be executed sequentially to avoid race conditions (same element in multiple live quizzes)
-    for (const liveQuiz of course.liveQuizzes) {
-      await recomputeDerivedPermissions({ liveQuizId: liveQuiz.id }, prisma)
-    }
+      // trigger a recomputation of all permissions related to the live quizzes of the course
+      // this action should be executed sequentially to avoid race conditions (same element in multiple live quizzes)
+      for (const liveQuiz of course.liveQuizzes) {
+        await recomputeDerivedPermissions({ liveQuizId: liveQuiz.id }, prisma)
+      }
 
-    // trigger a recomputation of all permissions on element contained in the stacks of the deleted activities
-    // this action should be executed sequentially to avoid race conditions (same resource in multiple elements)
-    const elementIds = [
-      ...new Set([
-        ...course.practiceQuizzes.flatMap((quiz) =>
-          quiz.stacks.flatMap((stack) =>
-            stack.elements.map((instance) => instance.elementId)
-          )
-        ),
-        ...course.microLearnings.flatMap((ml) =>
-          ml.stacks.flatMap((stack) =>
-            stack.elements.map((instance) => instance.elementId)
-          )
-        ),
-        ...course.groupActivities.flatMap((ga) =>
-          ga.stacks.flatMap((stack) =>
-            stack.elements.map((instance) => instance.elementId)
-          )
-        ),
-      ]),
-    ]
+      // trigger a recomputation of all permissions on element contained in the stacks of the deleted activities
+      // this action should be executed sequentially to avoid race conditions (same resource in multiple elements)
+      const elementIds = [
+        ...new Set([
+          ...course.practiceQuizzes.flatMap((quiz) =>
+            quiz.stacks.flatMap((stack) =>
+              stack.elements.map((instance) => instance.elementId)
+            )
+          ),
+          ...course.microLearnings.flatMap((ml) =>
+            ml.stacks.flatMap((stack) =>
+              stack.elements.map((instance) => instance.elementId)
+            )
+          ),
+          ...course.groupActivities.flatMap((ga) =>
+            ga.stacks.flatMap((stack) =>
+              stack.elements.map((instance) => instance.elementId)
+            )
+          ),
+        ]),
+      ]
 
-    for (const elementId of elementIds) {
-      await recomputeDerivedPermissions({ elementId }, prisma)
-    }
+      for (const elementId of elementIds) {
+        await recomputeDerivedPermissions({ elementId }, prisma)
+      }
 
-    return deleted
-  })
+      return deleted
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', { typename: 'Course', id })
   return deletedCourse
@@ -1115,30 +1121,33 @@ export async function removeCourse(
   }
 
   // remove direct permission and recompute derived permissions for this course and user
-  await ctx.prisma.$transaction(async (prisma) => {
-    // remove the direct permission of the user on the course
-    await prisma.course.update({
-      where: { id },
-      data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // remove the direct permission of the user on the course
+      await prisma.course.update({
+        where: { id },
+        data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
+      })
 
-    // create an audit log entry for the removal
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.PERMISSION_REMOVED,
-        objectId: String(id),
-        objectType: DB.ObjectType.COURSE,
-        sourceUserId: ctx.user.sub,
-        message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.COURSE} (ID: ${id})`,
-      },
-    })
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(id),
+          objectType: DB.ObjectType.COURSE,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.COURSE} (ID: ${id})`,
+        },
+      })
 
-    // recompute derived permissions for the user on the course
-    await recomputeDerivedPermissions(
-      { courseId: id, userId: ctx.user.sub },
-      prisma
-    )
-  })
+      // recompute derived permissions for the user on the course
+      await recomputeDerivedPermissions(
+        { courseId: id, userId: ctx.user.sub },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'Course',

--- a/packages/graphql/src/services/groups.ts
+++ b/packages/graphql/src/services/groups.ts
@@ -1036,63 +1036,66 @@ export async function manipulateGroupActivity(
   }
 
   // Use a transaction to ensure atomicity of all database operations
-  const activity = await ctx.prisma.$transaction(async (prisma) => {
-    // delete all instances that are not used anymore
-    await prisma.elementInstance.deleteMany({
-      where: { id: { in: instancesToDelete } },
-    })
-
-    // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
-    for (const instance of persistentInstances) {
-      const elementMultiplier =
-        'pointsMultiplier' in instance.elementData
-          ? ((instance.elementData.pointsMultiplier as number) ?? 1)
-          : 1
-
-      await prisma.elementInstance.update({
-        where: {
-          id: instance.id,
-        },
-        data: {
-          elementStackId: null,
-          order: persistentInstanceOrderMap[instance.id],
-          options: {
-            ...instance.options,
-            pointsMultiplier: multiplier * elementMultiplier,
-          },
-        },
+  const activity = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // delete all instances that are not used anymore
+      await prisma.elementInstance.deleteMany({
+        where: { id: { in: instancesToDelete } },
       })
-    }
 
-    // delete all stacks
-    await prisma.elementStack.deleteMany({
-      where: { id: { in: stacksToDelete } },
-    })
+      // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
+      for (const instance of persistentInstances) {
+        const elementMultiplier =
+          'pointsMultiplier' in instance.elementData
+            ? ((instance.elementData.pointsMultiplier as number) ?? 1)
+            : 1
 
-    const upsertedActivity = await prisma.groupActivity.upsert({
-      where: { id: id ?? newId },
-      create: {
-        ...createOrUpdateJSON,
-        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
-      },
-      update: createOrUpdateJSON,
-    })
-
-    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
-    if (unlinkedElementIds.length > 0) {
-      for (const elementId of unlinkedElementIds) {
-        await recomputeDerivedPermissions({ elementId }, prisma)
+        await prisma.elementInstance.update({
+          where: {
+            id: instance.id,
+          },
+          data: {
+            elementStackId: null,
+            order: persistentInstanceOrderMap[instance.id],
+            options: {
+              ...instance.options,
+              pointsMultiplier: multiplier * elementMultiplier,
+            },
+          },
+        })
       }
-    }
 
-    // update all permissions linked to this group activity (since course might have changed on edit as well --> new derived permissions)
-    await recomputeDerivedPermissions(
-      { groupActivityId: upsertedActivity.id },
-      prisma
-    )
+      // delete all stacks
+      await prisma.elementStack.deleteMany({
+        where: { id: { in: stacksToDelete } },
+      })
 
-    return upsertedActivity
-  })
+      const upsertedActivity = await prisma.groupActivity.upsert({
+        where: { id: id ?? newId },
+        create: {
+          ...createOrUpdateJSON,
+          owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+        },
+        update: createOrUpdateJSON,
+      })
+
+      // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+      if (unlinkedElementIds.length > 0) {
+        for (const elementId of unlinkedElementIds) {
+          await recomputeDerivedPermissions({ elementId }, prisma)
+        }
+      }
+
+      // update all permissions linked to this group activity (since course might have changed on edit as well --> new derived permissions)
+      await recomputeDerivedPermissions(
+        { groupActivityId: upsertedActivity.id },
+        prisma
+      )
+
+      return upsertedActivity
+    },
+    { timeout: 60000 }
+  )
 
   return activity
 }
@@ -1719,7 +1722,8 @@ export async function deleteGroupActivity(
         )
 
         return updatedActivity
-      }
+      },
+      { timeout: 60000 }
     )
 
     ctx.emitter.emit('invalidate', { typename: 'GroupActivity', id })
@@ -1741,28 +1745,31 @@ export async function removeGroupActivity(
   }
 
   // remove direct permission and recompute derived permissions for this group activity and user
-  await ctx.prisma.$transaction(async (prisma) => {
-    await prisma.groupActivity.update({
-      where: { id },
-      data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      await prisma.groupActivity.update({
+        where: { id },
+        data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
+      })
 
-    // create an audit log entry for the removal
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.PERMISSION_REMOVED,
-        objectId: String(id),
-        objectType: DB.ObjectType.GROUP_ACTIVITY,
-        sourceUserId: ctx.user.sub,
-        message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.GROUP_ACTIVITY} (ID: ${id})`,
-      },
-    })
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(id),
+          objectType: DB.ObjectType.GROUP_ACTIVITY,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.GROUP_ACTIVITY} (ID: ${id})`,
+        },
+      })
 
-    await recomputeDerivedPermissions(
-      { groupActivityId: id, userId: ctx.user.sub },
-      prisma
-    )
-  })
+      await recomputeDerivedPermissions(
+        { groupActivityId: id, userId: ctx.user.sub },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'GroupActivity',

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -610,72 +610,75 @@ export async function manipulateLiveQuiz(
     },
   }
 
-  const activity = await ctx.prisma.$transaction(async (prisma) => {
-    // delete all instances that are not used anymore
-    await prisma.elementInstance.deleteMany({
-      where: { id: { in: instancesToDelete } },
-    })
+  const activity = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // delete all instances that are not used anymore
+      await prisma.elementInstance.deleteMany({
+        where: { id: { in: instancesToDelete } },
+      })
 
-    // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
-    for (const instance of persistentInstances) {
-      const elementMultiplier =
-        'pointsMultiplier' in instance.elementData
-          ? ((instance.elementData.pointsMultiplier as number) ?? 1)
-          : 1
+      // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
+      for (const instance of persistentInstances) {
+        const elementMultiplier =
+          'pointsMultiplier' in instance.elementData
+            ? ((instance.elementData.pointsMultiplier as number) ?? 1)
+            : 1
 
-      await prisma.elementInstance.update({
-        where: { id: instance.id },
-        data: {
-          elementBlockId: null,
-          order: persistentInstanceOrderMap[instance.id],
-          options: {
-            ...instance.options,
-            pointsMultiplier: multiplier * elementMultiplier,
+        await prisma.elementInstance.update({
+          where: { id: instance.id },
+          data: {
+            elementBlockId: null,
+            order: persistentInstanceOrderMap[instance.id],
+            options: {
+              ...instance.options,
+              pointsMultiplier: multiplier * elementMultiplier,
+            },
+          },
+        })
+      }
+
+      // delete all blocks
+      await prisma.elementBlock.deleteMany({
+        where: {
+          id: { in: blocksToDelete },
+        },
+      })
+
+      const upsertedQuiz = await prisma.liveQuiz.upsert({
+        where: { id: id ?? uuidv4() },
+        create: {
+          ...createOrUpdateJSON,
+          course: courseId !== null ? { connect: { id: courseId } } : undefined,
+          owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+        },
+        update: {
+          ...createOrUpdateJSON,
+          course:
+            courseId !== null
+              ? { connect: { id: courseId } }
+              : { disconnect: true },
+        },
+        include: {
+          course: true,
+          blocks: {
+            include: { elements: { orderBy: { order: 'asc' } } },
+            orderBy: { order: 'asc' },
           },
         },
       })
-    }
 
-    // delete all blocks
-    await prisma.elementBlock.deleteMany({
-      where: {
-        id: { in: blocksToDelete },
-      },
-    })
-
-    const upsertedQuiz = await prisma.liveQuiz.upsert({
-      where: { id: id ?? uuidv4() },
-      create: {
-        ...createOrUpdateJSON,
-        course: courseId !== null ? { connect: { id: courseId } } : undefined,
-        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
-      },
-      update: {
-        ...createOrUpdateJSON,
-        course:
-          courseId !== null
-            ? { connect: { id: courseId } }
-            : { disconnect: true },
-      },
-      include: {
-        course: true,
-        blocks: {
-          include: { elements: { orderBy: { order: 'asc' } } },
-          orderBy: { order: 'asc' },
-        },
-      },
-    })
-
-    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
-    if (unlinkedElementIds.length > 0) {
-      for (const elementId of unlinkedElementIds) {
-        await recomputeDerivedPermissions({ elementId }, prisma)
+      // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+      if (unlinkedElementIds.length > 0) {
+        for (const elementId of unlinkedElementIds) {
+          await recomputeDerivedPermissions({ elementId }, prisma)
+        }
       }
-    }
 
-    await recomputeDerivedPermissions({ liveQuizId: upsertedQuiz.id }, prisma)
-    return upsertedQuiz
-  })
+      await recomputeDerivedPermissions({ liveQuizId: upsertedQuiz.id }, prisma)
+      return upsertedQuiz
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'LiveQuiz',
@@ -699,28 +702,31 @@ export async function removeLiveQuiz(
   }
 
   // remove direct permission and recompute derived permissions for this live quiz and user
-  await ctx.prisma.$transaction(async (prisma) => {
-    await prisma.liveQuiz.update({
-      where: { id },
-      data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      await prisma.liveQuiz.update({
+        where: { id },
+        data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
+      })
 
-    // create an audit log entry for the removal
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.PERMISSION_REMOVED,
-        objectId: String(id),
-        objectType: DB.ObjectType.LIVE_QUIZ,
-        sourceUserId: ctx.user.sub,
-        message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.LIVE_QUIZ} (ID: ${id})`,
-      },
-    })
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(id),
+          objectType: DB.ObjectType.LIVE_QUIZ,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.LIVE_QUIZ} (ID: ${id})`,
+        },
+      })
 
-    await recomputeDerivedPermissions(
-      { liveQuizId: id, userId: ctx.user.sub },
-      prisma
-    )
-  })
+      await recomputeDerivedPermissions(
+        { liveQuizId: id, userId: ctx.user.sub },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'LiveQuiz',
@@ -2135,18 +2141,21 @@ export async function deleteLiveQuiz(
     // running live quizzes cannot be deleted
     return null
   } else if (liveQuiz.status === DB.PublicationStatus.ENDED) {
-    const deletedLiveQuiz = await ctx.prisma.$transaction(async (prisma) => {
-      const quiz = await prisma.liveQuiz.update({
-        where: { id, status: DB.PublicationStatus.ENDED },
-        data: { isDeleted: true },
-      })
+    const deletedLiveQuiz = await ctx.prisma.$transaction(
+      async (prisma) => {
+        const quiz = await prisma.liveQuiz.update({
+          where: { id, status: DB.PublicationStatus.ENDED },
+          data: { isDeleted: true },
+        })
 
-      // update derived permissions for this live quiz (after soft deletion)
-      // this function call automatically includes permission updates for all linked elements
-      await recomputeDerivedPermissions({ liveQuizId: quiz.id }, prisma)
+        // update derived permissions for this live quiz (after soft deletion)
+        // this function call automatically includes permission updates for all linked elements
+        await recomputeDerivedPermissions({ liveQuizId: quiz.id }, prisma)
 
-      return quiz
-    })
+        return quiz
+      },
+      { timeout: 60000 }
+    )
 
     ctx.emitter.emit('invalidate', {
       typename: 'LiveQuiz',
@@ -2155,26 +2164,29 @@ export async function deleteLiveQuiz(
 
     return deletedLiveQuiz
   } else {
-    const deletedLiveQuiz = await ctx.prisma.$transaction(async (prisma) => {
-      const quiz = await prisma.liveQuiz.delete({
-        where: {
-          id,
-          status: {
-            in: [DB.PublicationStatus.DRAFT, DB.PublicationStatus.SCHEDULED],
+    const deletedLiveQuiz = await ctx.prisma.$transaction(
+      async (prisma) => {
+        const quiz = await prisma.liveQuiz.delete({
+          where: {
+            id,
+            status: {
+              in: [DB.PublicationStatus.DRAFT, DB.PublicationStatus.SCHEDULED],
+            },
           },
-        },
-      })
+        })
 
-      // update derived permissions on all linked elements (to make sure that invalid derived permissions are also removed)
-      // this case cannot be handled by the permissions module, since the live quiz is already hard deleted
-      // access requests need to be updated as well, since the derived permissions on elements might have changed
-      await propagateActivityToElements(
-        { stacks: liveQuiz.blocks, updateAccessRequests: true },
-        prisma
-      )
+        // update derived permissions on all linked elements (to make sure that invalid derived permissions are also removed)
+        // this case cannot be handled by the permissions module, since the live quiz is already hard deleted
+        // access requests need to be updated as well, since the derived permissions on elements might have changed
+        await propagateActivityToElements(
+          { stacks: liveQuiz.blocks, updateAccessRequests: true },
+          prisma
+        )
 
-      return quiz
-    })
+        return quiz
+      },
+      { timeout: 60000 }
+    )
 
     ctx.emitter.emit('invalidate', {
       typename: 'LiveQuiz',

--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -277,81 +277,84 @@ export async function manipulateMicroLearning(
     course: { connect: { id: courseId } },
   }
 
-  const activity = await ctx.prisma.$transaction(async (prisma) => {
-    // delete all instances that are not used anymore
-    await prisma.elementInstance.deleteMany({
-      where: {
-        id: { in: instancesToDelete },
-      },
-    })
-
-    // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
-    for (const instance of persistentInstances) {
-      const elementMultiplier =
-        'pointsMultiplier' in instance.elementData
-          ? ((instance.elementData.pointsMultiplier as number) ?? 1)
-          : 1
-
-      await prisma.elementInstance.update({
+  const activity = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // delete all instances that are not used anymore
+      await prisma.elementInstance.deleteMany({
         where: {
-          id: instance.id,
+          id: { in: instancesToDelete },
         },
-        data: {
-          elementStackId: null,
-          order: persistentInstanceOrderMap[instance.id],
-          options: {
-            ...instance.options,
-            pointsMultiplier: multiplier * elementMultiplier,
+      })
+
+      // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
+      for (const instance of persistentInstances) {
+        const elementMultiplier =
+          'pointsMultiplier' in instance.elementData
+            ? ((instance.elementData.pointsMultiplier as number) ?? 1)
+            : 1
+
+        await prisma.elementInstance.update({
+          where: {
+            id: instance.id,
+          },
+          data: {
+            elementStackId: null,
+            order: persistentInstanceOrderMap[instance.id],
+            options: {
+              ...instance.options,
+              pointsMultiplier: multiplier * elementMultiplier,
+            },
+          },
+        })
+      }
+
+      // delete all stacks
+      await prisma.elementStack.deleteMany({
+        where: {
+          id: { in: stacksToDelete },
+        },
+      })
+
+      const upsertedMicrolearning = await prisma.microLearning.upsert({
+        where: { id: id ?? uuidv4() },
+        create: {
+          ...createOrUpdateJSON,
+          owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+        },
+        update: createOrUpdateJSON,
+        include: {
+          course: true,
+          stacks: {
+            include: {
+              elements: {
+                orderBy: {
+                  order: 'asc',
+                },
+              },
+            },
+            orderBy: {
+              order: 'asc',
+            },
           },
         },
       })
-    }
 
-    // delete all stacks
-    await prisma.elementStack.deleteMany({
-      where: {
-        id: { in: stacksToDelete },
-      },
-    })
-
-    const upsertedMicrolearning = await prisma.microLearning.upsert({
-      where: { id: id ?? uuidv4() },
-      create: {
-        ...createOrUpdateJSON,
-        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
-      },
-      update: createOrUpdateJSON,
-      include: {
-        course: true,
-        stacks: {
-          include: {
-            elements: {
-              orderBy: {
-                order: 'asc',
-              },
-            },
-          },
-          orderBy: {
-            order: 'asc',
-          },
-        },
-      },
-    })
-
-    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
-    if (unlinkedElementIds.length > 0) {
-      for (const elementId of unlinkedElementIds) {
-        await recomputeDerivedPermissions({ elementId }, prisma)
+      // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+      if (unlinkedElementIds.length > 0) {
+        for (const elementId of unlinkedElementIds) {
+          await recomputeDerivedPermissions({ elementId }, prisma)
+        }
       }
-    }
 
-    await recomputeDerivedPermissions(
-      { microLearningId: upsertedMicrolearning.id },
-      prisma
-    )
+      await recomputeDerivedPermissions(
+        { microLearningId: upsertedMicrolearning.id },
+        prisma
+      )
 
-    return upsertedMicrolearning
-  })
+      return upsertedMicrolearning
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'MicroLearning',
@@ -554,7 +557,8 @@ export async function deleteMicroLearning(
         )
 
         return updated
-      }
+      },
+      { timeout: 60000 }
     )
 
     ctx.emitter.emit('invalidate', { typename: 'MicroLearning', id })
@@ -576,30 +580,33 @@ export async function removeMicroLearning(
   }
 
   // remove direct permission and recompute derived permissions for this microlarning and user
-  await ctx.prisma.$transaction(async (prisma) => {
-    // remove the direct permission
-    await prisma.microLearning.update({
-      where: { id },
-      data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // remove the direct permission
+      await prisma.microLearning.update({
+        where: { id },
+        data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
+      })
 
-    // create an audit log entry for the removal
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.PERMISSION_REMOVED,
-        objectId: String(id),
-        objectType: DB.ObjectType.MICRO_LEARNING,
-        sourceUserId: ctx.user.sub,
-        message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.MICRO_LEARNING} (ID: ${id})`,
-      },
-    })
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(id),
+          objectType: DB.ObjectType.MICRO_LEARNING,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.MICRO_LEARNING} (ID: ${id})`,
+        },
+      })
 
-    // recompute derived permissions for this microlearning and user
-    await recomputeDerivedPermissions(
-      { microLearningId: id, userId: ctx.user.sub },
-      prisma
-    )
-  })
+      // recompute derived permissions for this microlearning and user
+      await recomputeDerivedPermissions(
+        { microLearningId: id, userId: ctx.user.sub },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'MicroLearning',

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -291,76 +291,79 @@ export async function manipulatePracticeQuiz(
     course: { connect: { id: courseId } },
   }
 
-  const activity = await ctx.prisma.$transaction(async (prisma) => {
-    // delete all instances that are not used anymore
-    await prisma.elementInstance.deleteMany({
-      where: { id: { in: instancesToDelete } },
-    })
+  const activity = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // delete all instances that are not used anymore
+      await prisma.elementInstance.deleteMany({
+        where: { id: { in: instancesToDelete } },
+      })
 
-    // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
-    for (const instance of persistentInstances) {
-      const elementMultiplier =
-        'pointsMultiplier' in instance.elementData
-          ? ((instance.elementData.pointsMultiplier as number) ?? 1)
-          : 1
+      // disconnect all instances that should be kept in edit mode and set new order value (to satisfy uniqueness constraints)
+      for (const instance of persistentInstances) {
+        const elementMultiplier =
+          'pointsMultiplier' in instance.elementData
+            ? ((instance.elementData.pointsMultiplier as number) ?? 1)
+            : 1
 
-      await prisma.elementInstance.update({
-        where: { id: instance.id },
-        data: {
-          elementStackId: null,
-          order: persistentInstanceOrderMap[instance.id],
-          options: {
-            ...instance.options,
-            resetTimeDays,
-            pointsMultiplier: multiplier * elementMultiplier,
+        await prisma.elementInstance.update({
+          where: { id: instance.id },
+          data: {
+            elementStackId: null,
+            order: persistentInstanceOrderMap[instance.id],
+            options: {
+              ...instance.options,
+              resetTimeDays,
+              pointsMultiplier: multiplier * elementMultiplier,
+            },
+          },
+        })
+      }
+
+      // delete all stacks
+      await prisma.elementStack.deleteMany({
+        where: { id: { in: stacksToDelete } },
+      })
+
+      const upsertedQuiz = await prisma.practiceQuiz.upsert({
+        where: { id: id ?? uuidv4() },
+        create: {
+          ...createOrUpdateJSON,
+          owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
+        },
+        update: createOrUpdateJSON,
+        include: {
+          course: true,
+          stacks: {
+            include: {
+              elements: {
+                orderBy: {
+                  order: 'asc',
+                },
+              },
+            },
+            orderBy: {
+              order: 'asc',
+            },
           },
         },
       })
-    }
 
-    // delete all stacks
-    await prisma.elementStack.deleteMany({
-      where: { id: { in: stacksToDelete } },
-    })
-
-    const upsertedQuiz = await prisma.practiceQuiz.upsert({
-      where: { id: id ?? uuidv4() },
-      create: {
-        ...createOrUpdateJSON,
-        owner: { connect: { id: ctx.user.sub } }, // only connect the owner during activity creation (not editing)!
-      },
-      update: createOrUpdateJSON,
-      include: {
-        course: true,
-        stacks: {
-          include: {
-            elements: {
-              orderBy: {
-                order: 'asc',
-              },
-            },
-          },
-          orderBy: {
-            order: 'asc',
-          },
-        },
-      },
-    })
-
-    // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
-    if (unlinkedElementIds.length > 0) {
-      for (const elementId of unlinkedElementIds) {
-        await recomputeDerivedPermissions({ elementId }, prisma)
+      // enforce dervied permissions update to elements that were potentially removed from the quiz (-> removal of derived permissions)
+      if (unlinkedElementIds.length > 0) {
+        for (const elementId of unlinkedElementIds) {
+          await recomputeDerivedPermissions({ elementId }, prisma)
+        }
       }
-    }
 
-    await recomputeDerivedPermissions(
-      { practiceQuizId: upsertedQuiz.id },
-      prisma
-    )
+      await recomputeDerivedPermissions(
+        { practiceQuizId: upsertedQuiz.id },
+        prisma
+      )
 
-    return upsertedQuiz
-  })
+      return upsertedQuiz
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'PracticeQuiz',
@@ -539,7 +542,8 @@ export async function deletePracticeQuiz(
         await recomputeDerivedPermissions({ practiceQuizId: quiz.id }, prisma)
 
         return quiz
-      }
+      },
+      { timeout: 60000 }
     )
 
     ctx.emitter.emit('invalidate', { typename: 'PracticeQuiz', id })
@@ -561,30 +565,33 @@ export async function removePracticeQuiz(
   }
 
   // remove direct permission and recompute derived permissions for this practice quiz and user
-  await ctx.prisma.$transaction(async (prisma) => {
-    // remove the direct permission for the user
-    await prisma.practiceQuiz.update({
-      where: { id },
-      data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // remove the direct permission for the user
+      await prisma.practiceQuiz.update({
+        where: { id },
+        data: { directPermissions: { deleteMany: { userId: ctx.user.sub } } },
+      })
 
-    // create an audit log entry for the removal
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.PERMISSION_REMOVED,
-        objectId: String(id),
-        objectType: DB.ObjectType.PRACTICE_QUIZ,
-        sourceUserId: ctx.user.sub,
-        message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.PRACTICE_QUIZ} (ID: ${id})`,
-      },
-    })
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(id),
+          objectType: DB.ObjectType.PRACTICE_QUIZ,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.PRACTICE_QUIZ} (ID: ${id})`,
+        },
+      })
 
-    // recompute derived permissions for the user and the practice quiz
-    await recomputeDerivedPermissions(
-      { practiceQuizId: id, userId: ctx.user.sub },
-      prisma
-    )
-  })
+      // recompute derived permissions for the user and the practice quiz
+      await recomputeDerivedPermissions(
+        { practiceQuizId: id, userId: ctx.user.sub },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'PracticeQuiz',

--- a/packages/graphql/src/services/questions.ts
+++ b/packages/graphql/src/services/questions.ts
@@ -611,7 +611,8 @@ export async function deleteElement(
       }
 
       return { deletedElement: element, originalElement }
-    }
+    },
+    { timeout: 60000 }
   )
 
   ctx.emitter.emit('invalidate', {
@@ -644,34 +645,37 @@ export async function removeElement(
   }
 
   // remove direct permission and recompute derived permissions for this element and user
-  await ctx.prisma.$transaction(async (prisma) => {
-    // remove the direct permission for the user on the element
-    await prisma.element.update({
-      where: { id },
-      data: {
-        directPermissions: {
-          deleteMany: { userId: ctx.user.sub },
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // remove the direct permission for the user on the element
+      await prisma.element.update({
+        where: { id },
+        data: {
+          directPermissions: {
+            deleteMany: { userId: ctx.user.sub },
+          },
         },
-      },
-    })
+      })
 
-    // create an audit log entry for the removal
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.PERMISSION_REMOVED,
-        objectId: String(id),
-        objectType: DB.ObjectType.ELEMENT,
-        sourceUserId: ctx.user.sub,
-        message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.ELEMENT} (ID: ${id})`,
-      },
-    })
+      // create an audit log entry for the removal
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.PERMISSION_REMOVED,
+          objectId: String(id),
+          objectType: DB.ObjectType.ELEMENT,
+          sourceUserId: ctx.user.sub,
+          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.ELEMENT} (ID: ${id})`,
+        },
+      })
 
-    // recompute derived permissions for the element
-    await recomputeDerivedPermissions(
-      { elementId: id, userId: ctx.user.sub },
-      prisma
-    )
-  })
+      // recompute derived permissions for the element
+      await recomputeDerivedPermissions(
+        { elementId: id, userId: ctx.user.sub },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   ctx.emitter.emit('invalidate', {
     typename: 'Element',

--- a/packages/graphql/src/services/resources.ts
+++ b/packages/graphql/src/services/resources.ts
@@ -638,26 +638,29 @@ export async function removeAnswerCollection(
     await ctx.prisma.answerCollection.delete({ where: { id: id } })
   } else {
     // otherwise, delete the sharing permission
-    await ctx.prisma.$transaction(async (prisma) => {
-      await prisma.permission.delete({ where: { id: permission.id } })
+    await ctx.prisma.$transaction(
+      async (prisma) => {
+        await prisma.permission.delete({ where: { id: permission.id } })
 
-      // create an audit log entry for the removal
-      await prisma.auditLogEntry.create({
-        data: {
-          type: DB.AuditLogType.PERMISSION_REMOVED,
-          objectId: String(id),
-          objectType: DB.ObjectType.ANSWER_COLLECTION,
-          sourceUserId: ctx.user.sub,
-          message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.ANSWER_COLLECTION} (ID: ${id})`,
-        },
-      })
+        // create an audit log entry for the removal
+        await prisma.auditLogEntry.create({
+          data: {
+            type: DB.AuditLogType.PERMISSION_REMOVED,
+            objectId: String(id),
+            objectType: DB.ObjectType.ANSWER_COLLECTION,
+            sourceUserId: ctx.user.sub,
+            message: `User ${ctx.user.sub} removed own permission on ${DB.ObjectType.ANSWER_COLLECTION} (ID: ${id})`,
+          },
+        })
 
-      // trigger recomputation of derived permissions
-      await recomputeDerivedPermissions(
-        { answerCollectionId: id, userId: ctx.user.sub },
-        prisma
-      )
-    })
+        // trigger recomputation of derived permissions
+        await recomputeDerivedPermissions(
+          { answerCollectionId: id, userId: ctx.user.sub },
+          prisma
+        )
+      },
+      { timeout: 60000 }
+    )
   }
 
   ctx.emitter.emit('invalidate', {

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -1565,279 +1565,282 @@ export async function resolveObjectSharingRequest(
     return false
   }
 
-  await ctx.prisma.$transaction(async (prisma) => {
-    if (approved) {
-      // add a direct permission for the user with approved request
-      await prisma.permission.upsert({
-        where: {
-          catalogCollectionId_userId:
-            pendingRequest.catalogCollectionId !== null
-              ? {
-                  catalogCollectionId: pendingRequest.catalogCollectionId,
-                  userId,
-                }
-              : undefined,
-          answerCollectionId_userId:
-            pendingRequest.answerCollectionId !== null
-              ? {
-                  answerCollectionId: pendingRequest.answerCollectionId,
-                  userId,
-                }
-              : undefined,
-          elementId_userId:
-            pendingRequest.elementId !== null
-              ? {
-                  elementId: pendingRequest.elementId,
-                  userId,
-                }
-              : undefined,
-          courseId_userId:
-            pendingRequest.courseId !== null
-              ? {
-                  courseId: pendingRequest.courseId,
-                  userId,
-                }
-              : undefined,
-          liveQuizId_userId:
-            pendingRequest.liveQuizId !== null
-              ? {
-                  liveQuizId: pendingRequest.liveQuizId,
-                  userId,
-                }
-              : undefined,
-          practiceQuizId_userId:
-            pendingRequest.practiceQuizId !== null
-              ? {
-                  practiceQuizId: pendingRequest.practiceQuizId,
-                  userId,
-                }
-              : undefined,
-          microLearningId_userId:
-            pendingRequest.microLearningId !== null
-              ? {
-                  microLearningId: pendingRequest.microLearningId,
-                  userId,
-                }
-              : undefined,
-          groupActivityId_userId:
-            pendingRequest.groupActivityId !== null
-              ? {
-                  groupActivityId: pendingRequest.groupActivityId,
-                  userId,
-                }
-              : undefined,
-        },
-        create: {
-          permissionLevel,
-          propagation,
-          user: {
-            connect: {
-              id: userId,
-            },
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      if (approved) {
+        // add a direct permission for the user with approved request
+        await prisma.permission.upsert({
+          where: {
+            catalogCollectionId_userId:
+              pendingRequest.catalogCollectionId !== null
+                ? {
+                    catalogCollectionId: pendingRequest.catalogCollectionId,
+                    userId,
+                  }
+                : undefined,
+            answerCollectionId_userId:
+              pendingRequest.answerCollectionId !== null
+                ? {
+                    answerCollectionId: pendingRequest.answerCollectionId,
+                    userId,
+                  }
+                : undefined,
+            elementId_userId:
+              pendingRequest.elementId !== null
+                ? {
+                    elementId: pendingRequest.elementId,
+                    userId,
+                  }
+                : undefined,
+            courseId_userId:
+              pendingRequest.courseId !== null
+                ? {
+                    courseId: pendingRequest.courseId,
+                    userId,
+                  }
+                : undefined,
+            liveQuizId_userId:
+              pendingRequest.liveQuizId !== null
+                ? {
+                    liveQuizId: pendingRequest.liveQuizId,
+                    userId,
+                  }
+                : undefined,
+            practiceQuizId_userId:
+              pendingRequest.practiceQuizId !== null
+                ? {
+                    practiceQuizId: pendingRequest.practiceQuizId,
+                    userId,
+                  }
+                : undefined,
+            microLearningId_userId:
+              pendingRequest.microLearningId !== null
+                ? {
+                    microLearningId: pendingRequest.microLearningId,
+                    userId,
+                  }
+                : undefined,
+            groupActivityId_userId:
+              pendingRequest.groupActivityId !== null
+                ? {
+                    groupActivityId: pendingRequest.groupActivityId,
+                    userId,
+                  }
+                : undefined,
           },
-          catalogCollection:
-            pendingRequest.catalogCollectionId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.catalogCollectionId,
-                  },
-                }
-              : undefined,
-          answerCollection:
-            pendingRequest.answerCollectionId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.answerCollectionId,
-                  },
-                }
-              : undefined,
-          element:
-            pendingRequest.elementId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.elementId,
-                  },
-                }
-              : undefined,
-          course:
-            pendingRequest.courseId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.courseId,
-                  },
-                }
-              : undefined,
-          liveQuiz:
-            pendingRequest.liveQuizId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.liveQuizId,
-                  },
-                }
-              : undefined,
-          practiceQuiz:
-            pendingRequest.practiceQuizId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.practiceQuizId,
-                  },
-                }
-              : undefined,
-          microLearning:
-            pendingRequest.microLearningId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.microLearningId,
-                  },
-                }
-              : undefined,
-          groupActivity:
-            pendingRequest.groupActivityId !== null
-              ? {
-                  connect: {
-                    id: pendingRequest.groupActivityId,
-                  },
-                }
-              : undefined,
-        },
-        update: {},
-      })
-    }
+          create: {
+            permissionLevel,
+            propagation,
+            user: {
+              connect: {
+                id: userId,
+              },
+            },
+            catalogCollection:
+              pendingRequest.catalogCollectionId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.catalogCollectionId,
+                    },
+                  }
+                : undefined,
+            answerCollection:
+              pendingRequest.answerCollectionId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.answerCollectionId,
+                    },
+                  }
+                : undefined,
+            element:
+              pendingRequest.elementId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.elementId,
+                    },
+                  }
+                : undefined,
+            course:
+              pendingRequest.courseId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.courseId,
+                    },
+                  }
+                : undefined,
+            liveQuiz:
+              pendingRequest.liveQuizId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.liveQuizId,
+                    },
+                  }
+                : undefined,
+            practiceQuiz:
+              pendingRequest.practiceQuizId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.practiceQuizId,
+                    },
+                  }
+                : undefined,
+            microLearning:
+              pendingRequest.microLearningId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.microLearningId,
+                    },
+                  }
+                : undefined,
+            groupActivity:
+              pendingRequest.groupActivityId !== null
+                ? {
+                    connect: {
+                      id: pendingRequest.groupActivityId,
+                    },
+                  }
+                : undefined,
+          },
+          update: {},
+        })
+      }
 
-    // remove the access request
-    await prisma.accessRequest.deleteMany({
-      where: {
-        userId,
-        catalogCollectionId: pendingRequest.catalogCollectionId ?? undefined,
-        answerCollectionId: pendingRequest.answerCollectionId ?? undefined,
-        elementId: pendingRequest.elementId ?? undefined,
-        courseId: pendingRequest.courseId ?? undefined,
-        liveQuizId: pendingRequest.liveQuizId ?? undefined,
-        practiceQuizId: pendingRequest.practiceQuizId ?? undefined,
-        microLearningId: pendingRequest.microLearningId ?? undefined,
-        groupActivityId: pendingRequest.groupActivityId ?? undefined,
-      },
-    })
-
-    // create an audit log entry for the resolved access request
-    const { objectType, objectId } = getAuditLogObjectType({
-      catalogCollectionId: pendingRequest.catalogCollectionId,
-      answerCollectionId: pendingRequest.answerCollectionId,
-      elementId: pendingRequest.elementId,
-      courseId: pendingRequest.courseId,
-      liveQuizId: pendingRequest.liveQuizId,
-      practiceQuizId: pendingRequest.practiceQuizId,
-      microLearningId: pendingRequest.microLearningId,
-      groupActivityId: pendingRequest.groupActivityId,
-    })
-    if (objectType && objectId) {
-      await prisma.auditLogEntry.create({
-        data: {
-          type: DB.AuditLogType.REQUEST_RESOLVED,
-          objectType,
-          objectId,
-          sourceUserId: ctx.user.sub,
-          targetUserId: userId,
-          message: `Access request ${
-            approved
-              ? `approved (with permission level ${permissionLevel})`
-              : 'declined'
-          } for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} for user ${userId}.`,
+      // remove the access request
+      await prisma.accessRequest.deleteMany({
+        where: {
+          userId,
+          catalogCollectionId: pendingRequest.catalogCollectionId ?? undefined,
+          answerCollectionId: pendingRequest.answerCollectionId ?? undefined,
+          elementId: pendingRequest.elementId ?? undefined,
+          courseId: pendingRequest.courseId ?? undefined,
+          liveQuizId: pendingRequest.liveQuizId ?? undefined,
+          practiceQuizId: pendingRequest.practiceQuizId ?? undefined,
+          microLearningId: pendingRequest.microLearningId ?? undefined,
+          groupActivityId: pendingRequest.groupActivityId ?? undefined,
         },
       })
-    } else {
-      throw new Error(
-        `Could not determine object type or ID for audit log entry. Request ID: ${requestId}, Details: ${JSON.stringify(
+
+      // create an audit log entry for the resolved access request
+      const { objectType, objectId } = getAuditLogObjectType({
+        catalogCollectionId: pendingRequest.catalogCollectionId,
+        answerCollectionId: pendingRequest.answerCollectionId,
+        elementId: pendingRequest.elementId,
+        courseId: pendingRequest.courseId,
+        liveQuizId: pendingRequest.liveQuizId,
+        practiceQuizId: pendingRequest.practiceQuizId,
+        microLearningId: pendingRequest.microLearningId,
+        groupActivityId: pendingRequest.groupActivityId,
+      })
+      if (objectType && objectId) {
+        await prisma.auditLogEntry.create({
+          data: {
+            type: DB.AuditLogType.REQUEST_RESOLVED,
+            objectType,
+            objectId,
+            sourceUserId: ctx.user.sub,
+            targetUserId: userId,
+            message: `Access request ${
+              approved
+                ? `approved (with permission level ${permissionLevel})`
+                : 'declined'
+            } for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} for user ${userId}.`,
+          },
+        })
+      } else {
+        throw new Error(
+          `Could not determine object type or ID for audit log entry. Request ID: ${requestId}, Details: ${JSON.stringify(
+            {
+              catalogCollectionId: pendingRequest.catalogCollectionId,
+              answerCollectionId: pendingRequest.answerCollectionId,
+              elementId: pendingRequest.elementId,
+              courseId: pendingRequest.courseId,
+              liveQuizId: pendingRequest.liveQuizId,
+              practiceQuizId: pendingRequest.practiceQuizId,
+              microLearningId: pendingRequest.microLearningId,
+              groupActivityId: pendingRequest.groupActivityId,
+            }
+          )}`
+        )
+      }
+
+      // trigger recomputation of derived permissions within the same transaction
+      const updateAccessRequests = permissionLevel === DB.PermissionLevel.ADMIN
+      if (pendingRequest.catalogCollectionId !== null) {
+        await recomputeDerivedPermissions(
           {
+            userId,
+            updateAccessRequests,
             catalogCollectionId: pendingRequest.catalogCollectionId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.answerCollectionId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             answerCollectionId: pendingRequest.answerCollectionId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.elementId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             elementId: pendingRequest.elementId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.courseId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             courseId: pendingRequest.courseId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.liveQuizId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             liveQuizId: pendingRequest.liveQuizId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.practiceQuizId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             practiceQuizId: pendingRequest.practiceQuizId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.microLearningId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             microLearningId: pendingRequest.microLearningId,
+          },
+          prisma
+        )
+      } else if (pendingRequest.groupActivityId !== null) {
+        await recomputeDerivedPermissions(
+          {
+            userId,
+            updateAccessRequests,
             groupActivityId: pendingRequest.groupActivityId,
-          }
-        )}`
-      )
-    }
-
-    // trigger recomputation of derived permissions within the same transaction
-    const updateAccessRequests = permissionLevel === DB.PermissionLevel.ADMIN
-    if (pendingRequest.catalogCollectionId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          catalogCollectionId: pendingRequest.catalogCollectionId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.answerCollectionId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          answerCollectionId: pendingRequest.answerCollectionId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.elementId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          elementId: pendingRequest.elementId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.courseId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          courseId: pendingRequest.courseId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.liveQuizId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          liveQuizId: pendingRequest.liveQuizId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.practiceQuizId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          practiceQuizId: pendingRequest.practiceQuizId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.microLearningId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          microLearningId: pendingRequest.microLearningId,
-        },
-        prisma
-      )
-    } else if (pendingRequest.groupActivityId !== null) {
-      await recomputeDerivedPermissions(
-        {
-          userId,
-          updateAccessRequests,
-          groupActivityId: pendingRequest.groupActivityId,
-        },
-        prisma
-      )
-    }
-  })
+          },
+          prisma
+        )
+      }
+    },
+    { timeout: 60000 }
+  )
 
   // invalidate the related objects
   if (pendingRequest.catalogCollectionId !== null) {
@@ -1944,11 +1947,116 @@ export async function changeObjectPermissionLevel(
       : null
 
   // execute the update and recomputation in a single transaction
-  const permission = await ctx.prisma.$transaction(async (prisma) => {
-    // update the access level of the permission
-    const updatedPermission = await prisma.permission.update({
-      where: {
-        id: permissionId,
+  const permission = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // update the access level of the permission
+      const updatedPermission = await prisma.permission.update({
+        where: {
+          id: permissionId,
+          catalogCollectionId,
+          answerCollectionId,
+          elementId,
+          courseId,
+          liveQuizId,
+          practiceQuizId,
+          microLearningId,
+          groupActivityId,
+        },
+        data: {
+          permissionLevel,
+          propagation,
+        },
+      })
+
+      // if the permission does not exist, return early
+      if (!updatedPermission) {
+        return false
+      }
+
+      // if the permission exists, trigger recomputation of derived permissions, potentially update the access requests and log the change
+      const affectedUserIds = updatedPermission.userId
+        ? [updatedPermission.userId]
+        : userGroup
+          ? [
+              userGroup.ownerId,
+              ...userGroup.admins.map((admin) => admin.id),
+              ...userGroup.members.map((member) => member.id),
+            ]
+          : []
+
+      // if an admin permission was granted or revoked, update the access request instances
+      const updateAccessRequests =
+        (previousPermission.permissionLevel !== DB.PermissionLevel.ADMIN &&
+          permissionLevel === DB.PermissionLevel.ADMIN) ||
+        (previousPermission.permissionLevel === DB.PermissionLevel.ADMIN &&
+          permissionLevel !== DB.PermissionLevel.ADMIN)
+
+      for (const affectedUserId of affectedUserIds) {
+        if (typeof catalogCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              catalogCollectionId,
+              userId: affectedUserId,
+              updateAccessRequests,
+            },
+            prisma
+          )
+        } else if (typeof answerCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              answerCollectionId,
+              userId: affectedUserId,
+              updateAccessRequests,
+            },
+            prisma
+          )
+        } else if (typeof elementId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { elementId, userId: affectedUserId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof courseId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { courseId, userId: affectedUserId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof liveQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { liveQuizId, userId: affectedUserId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof practiceQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              practiceQuizId,
+              userId: affectedUserId,
+              updateAccessRequests,
+            },
+            prisma
+          )
+        } else if (typeof microLearningId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              microLearningId,
+              userId: affectedUserId,
+              updateAccessRequests,
+            },
+            prisma
+          )
+        } else if (typeof groupActivityId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              groupActivityId,
+              userId: affectedUserId,
+              updateAccessRequests,
+            },
+            prisma
+          )
+        }
+      }
+
+      // create an audit log entry for the updated permission
+      const { objectType, objectId } = getAuditLogObjectType({
         catalogCollectionId,
         answerCollectionId,
         elementId,
@@ -1957,142 +2065,40 @@ export async function changeObjectPermissionLevel(
         practiceQuizId,
         microLearningId,
         groupActivityId,
-      },
-      data: {
-        permissionLevel,
-        propagation,
-      },
-    })
-
-    // if the permission does not exist, return early
-    if (!updatedPermission) {
-      return false
-    }
-
-    // if the permission exists, trigger recomputation of derived permissions, potentially update the access requests and log the change
-    const affectedUserIds = updatedPermission.userId
-      ? [updatedPermission.userId]
-      : userGroup
-        ? [
-            userGroup.ownerId,
-            ...userGroup.admins.map((admin) => admin.id),
-            ...userGroup.members.map((member) => member.id),
-          ]
-        : []
-
-    // if an admin permission was granted or revoked, update the access request instances
-    const updateAccessRequests =
-      (previousPermission.permissionLevel !== DB.PermissionLevel.ADMIN &&
-        permissionLevel === DB.PermissionLevel.ADMIN) ||
-      (previousPermission.permissionLevel === DB.PermissionLevel.ADMIN &&
-        permissionLevel !== DB.PermissionLevel.ADMIN)
-
-    for (const affectedUserId of affectedUserIds) {
-      if (typeof catalogCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            catalogCollectionId,
-            userId: affectedUserId,
-            updateAccessRequests,
+      })
+      if (objectType && objectId) {
+        await prisma.auditLogEntry.create({
+          data: {
+            type: DB.AuditLogType.PERMISSION_MODIFIED,
+            objectType,
+            objectId,
+            sourceUserId: ctx.user.sub,
+            targetUserId: updatedPermission.userId ?? undefined,
+            targetUserGroupId: updatedPermission.userGroupId ?? undefined,
+            message: `Permission level changed from ${previousPermission.permissionLevel} to ${permissionLevel} for ${objectType} (ID ${objectId}) through owner / admin ${ctx.user.sub} for ${updatedPermission.userId ? `user ${updatedPermission.userId}` : `user group ${updatedPermission.userGroupId}`}.`,
           },
-          prisma
-        )
-      } else if (typeof answerCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            answerCollectionId,
-            userId: affectedUserId,
-            updateAccessRequests,
-          },
-          prisma
-        )
-      } else if (typeof elementId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { elementId, userId: affectedUserId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof courseId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { courseId, userId: affectedUserId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof liveQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { liveQuizId, userId: affectedUserId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof practiceQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            practiceQuizId,
-            userId: affectedUserId,
-            updateAccessRequests,
-          },
-          prisma
-        )
-      } else if (typeof microLearningId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            microLearningId,
-            userId: affectedUserId,
-            updateAccessRequests,
-          },
-          prisma
-        )
-      } else if (typeof groupActivityId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            groupActivityId,
-            userId: affectedUserId,
-            updateAccessRequests,
-          },
-          prisma
+        })
+      } else {
+        throw new Error(
+          `Could not determine object type or ID for audit log entry. Permission ID: ${permissionId}, Details: ${JSON.stringify(
+            {
+              catalogCollectionId,
+              answerCollectionId,
+              elementId,
+              courseId,
+              liveQuizId,
+              practiceQuizId,
+              microLearningId,
+              groupActivityId,
+            }
+          )}`
         )
       }
-    }
 
-    // create an audit log entry for the updated permission
-    const { objectType, objectId } = getAuditLogObjectType({
-      catalogCollectionId,
-      answerCollectionId,
-      elementId,
-      courseId,
-      liveQuizId,
-      practiceQuizId,
-      microLearningId,
-      groupActivityId,
-    })
-    if (objectType && objectId) {
-      await prisma.auditLogEntry.create({
-        data: {
-          type: DB.AuditLogType.PERMISSION_MODIFIED,
-          objectType,
-          objectId,
-          sourceUserId: ctx.user.sub,
-          targetUserId: updatedPermission.userId ?? undefined,
-          targetUserGroupId: updatedPermission.userGroupId ?? undefined,
-          message: `Permission level changed from ${previousPermission.permissionLevel} to ${permissionLevel} for ${objectType} (ID ${objectId}) through owner / admin ${ctx.user.sub} for ${updatedPermission.userId ? `user ${updatedPermission.userId}` : `user group ${updatedPermission.userGroupId}`}.`,
-        },
-      })
-    } else {
-      throw new Error(
-        `Could not determine object type or ID for audit log entry. Permission ID: ${permissionId}, Details: ${JSON.stringify(
-          {
-            catalogCollectionId,
-            answerCollectionId,
-            elementId,
-            courseId,
-            liveQuizId,
-            practiceQuizId,
-            microLearningId,
-            groupActivityId,
-          }
-        )}`
-      )
-    }
-
-    return updatedPermission
-  })
+      return updatedPermission
+    },
+    { timeout: 60000 }
+  )
 
   // if the permission did not exist in the first place, return null
   if (!permission) {
@@ -2168,174 +2174,177 @@ export async function revokeObjectAccess(
   }
 
   // delete the direct permission and recompute derived permissions
-  const deletedPermission = await ctx.prisma.$transaction(async (prisma) => {
-    const deleted = await prisma.permission.delete({
-      where: { id: permissionId },
-    })
-
-    // add an audit log entry for the revoked permission
-    const { objectType, objectId } = getAuditLogObjectType({
-      catalogCollectionId,
-      answerCollectionId,
-      elementId,
-      courseId,
-      liveQuizId,
-      practiceQuizId,
-      microLearningId,
-      groupActivityId,
-    })
-    if (objectType && objectId) {
-      await prisma.auditLogEntry.create({
-        data: {
-          type: DB.AuditLogType.PERMISSION_REVOKED,
-          objectType,
-          objectId,
-          sourceUserId: ctx.user.sub,
-          targetUserId: permission.userId ?? undefined,
-          targetUserGroupId: permission.userGroupId ?? undefined,
-          message: `Permission revoked for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} for ${permission.user?.id ? `user ${permission.user?.id}` : `user group ${permission.userGroupId}`}.`,
-        },
+  const deletedPermission = await ctx.prisma.$transaction(
+    async (prisma) => {
+      const deleted = await prisma.permission.delete({
+        where: { id: permissionId },
       })
-    } else {
-      throw new Error(
-        `Could not determine object type or ID for audit log entry. Permission ID: ${permissionId}, Details: ${JSON.stringify(
-          {
-            catalogCollectionId,
-            answerCollectionId,
-            elementId,
-            courseId,
-            liveQuizId,
-            practiceQuizId,
-            microLearningId,
-            groupActivityId,
-          }
-        )}`
-      )
-    }
 
-    // compute the users affected by this permission revocation
-    const affectedUserIds = permission.userId
-      ? [permission.userId]
-      : userGroup
-        ? [
-            userGroup.ownerId,
-            ...userGroup.admins.map((admin) => admin.id),
-            ...userGroup.members.map((member) => member.id),
-          ]
-        : []
-
-    for (const affectedUserId of affectedUserIds) {
-      // update the derived permissions of all affected users
-      if (typeof catalogCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            catalogCollectionId,
-            userId: affectedUserId,
-            updateAccessRequests: false,
+      // add an audit log entry for the revoked permission
+      const { objectType, objectId } = getAuditLogObjectType({
+        catalogCollectionId,
+        answerCollectionId,
+        elementId,
+        courseId,
+        liveQuizId,
+        practiceQuizId,
+        microLearningId,
+        groupActivityId,
+      })
+      if (objectType && objectId) {
+        await prisma.auditLogEntry.create({
+          data: {
+            type: DB.AuditLogType.PERMISSION_REVOKED,
+            objectType,
+            objectId,
+            sourceUserId: ctx.user.sub,
+            targetUserId: permission.userId ?? undefined,
+            targetUserGroupId: permission.userGroupId ?? undefined,
+            message: `Permission revoked for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} for ${permission.user?.id ? `user ${permission.user?.id}` : `user group ${permission.userGroupId}`}.`,
           },
-          prisma
-        )
-      } else if (typeof answerCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            answerCollectionId,
-            userId: affectedUserId,
-            updateAccessRequests: false,
-          },
-          prisma
-        )
-      } else if (typeof elementId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { elementId, userId: affectedUserId, updateAccessRequests: false },
-          prisma
-        )
-      } else if (typeof courseId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { courseId, userId: affectedUserId, updateAccessRequests: false },
-          prisma
-        )
-      } else if (typeof liveQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { liveQuizId, userId: affectedUserId, updateAccessRequests: false },
-          prisma
-        )
-      } else if (typeof practiceQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            practiceQuizId,
-            userId: affectedUserId,
-            updateAccessRequests: false,
-          },
-          prisma
-        )
-      } else if (typeof microLearningId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            microLearningId,
-            userId: affectedUserId,
-            updateAccessRequests: false,
-          },
-          prisma
-        )
-      } else if (typeof groupActivityId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          {
-            groupActivityId,
-            userId: affectedUserId,
-            updateAccessRequests: false,
-          },
-          prisma
+        })
+      } else {
+        throw new Error(
+          `Could not determine object type or ID for audit log entry. Permission ID: ${permissionId}, Details: ${JSON.stringify(
+            {
+              catalogCollectionId,
+              answerCollectionId,
+              elementId,
+              courseId,
+              liveQuizId,
+              practiceQuizId,
+              microLearningId,
+              groupActivityId,
+            }
+          )}`
         )
       }
-    }
 
-    // if an admin permission was revoked, update the access request instances
-    if (permission.permissionLevel === DB.PermissionLevel.ADMIN) {
-      if (typeof catalogCollectionId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { catalogCollectionId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof answerCollectionId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { answerCollectionId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof elementId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { elementId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof courseId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { courseId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof liveQuizId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { liveQuizId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof practiceQuizId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { practiceQuizId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof microLearningId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { microLearningId, userId: permission.userId ?? undefined },
-          prisma
-        )
-      } else if (typeof groupActivityId !== 'undefined') {
-        await updateAccessRequestInstances(
-          { groupActivityId, userId: permission.userId ?? undefined },
-          prisma
-        )
+      // compute the users affected by this permission revocation
+      const affectedUserIds = permission.userId
+        ? [permission.userId]
+        : userGroup
+          ? [
+              userGroup.ownerId,
+              ...userGroup.admins.map((admin) => admin.id),
+              ...userGroup.members.map((member) => member.id),
+            ]
+          : []
+
+      for (const affectedUserId of affectedUserIds) {
+        // update the derived permissions of all affected users
+        if (typeof catalogCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              catalogCollectionId,
+              userId: affectedUserId,
+              updateAccessRequests: false,
+            },
+            prisma
+          )
+        } else if (typeof answerCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              answerCollectionId,
+              userId: affectedUserId,
+              updateAccessRequests: false,
+            },
+            prisma
+          )
+        } else if (typeof elementId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { elementId, userId: affectedUserId, updateAccessRequests: false },
+            prisma
+          )
+        } else if (typeof courseId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { courseId, userId: affectedUserId, updateAccessRequests: false },
+            prisma
+          )
+        } else if (typeof liveQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { liveQuizId, userId: affectedUserId, updateAccessRequests: false },
+            prisma
+          )
+        } else if (typeof practiceQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              practiceQuizId,
+              userId: affectedUserId,
+              updateAccessRequests: false,
+            },
+            prisma
+          )
+        } else if (typeof microLearningId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              microLearningId,
+              userId: affectedUserId,
+              updateAccessRequests: false,
+            },
+            prisma
+          )
+        } else if (typeof groupActivityId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            {
+              groupActivityId,
+              userId: affectedUserId,
+              updateAccessRequests: false,
+            },
+            prisma
+          )
+        }
       }
-    }
 
-    return deleted
-  })
+      // if an admin permission was revoked, update the access request instances
+      if (permission.permissionLevel === DB.PermissionLevel.ADMIN) {
+        if (typeof catalogCollectionId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { catalogCollectionId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof answerCollectionId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { answerCollectionId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof elementId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { elementId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof courseId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { courseId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof liveQuizId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { liveQuizId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof practiceQuizId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { practiceQuizId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof microLearningId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { microLearningId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        } else if (typeof groupActivityId !== 'undefined') {
+          await updateAccessRequestInstances(
+            { groupActivityId, userId: permission.userId ?? undefined },
+            prisma
+          )
+        }
+      }
+
+      return deleted
+    },
+    { timeout: 60000 }
+  )
 
   // invalidate permission
   ctx.emitter.emit('invalidate', {
@@ -3145,74 +3154,77 @@ export async function transferCourseOwnership(
     return null
   }
 
-  const updatedCourse = await ctx.prisma.$transaction(async (prisma) => {
-    // update the owner of the course and grant admin permissions to the current user
-    const updated = await prisma.course.update({
-      where: { id },
-      data: {
-        owner: { connect: { id: newOwner.id } },
-        directPermissions: {
-          upsert: {
-            where: {
-              courseId_userId: {
-                courseId: id,
-                userId: ctx.user.sub,
+  const updatedCourse = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // update the owner of the course and grant admin permissions to the current user
+      const updated = await prisma.course.update({
+        where: { id },
+        data: {
+          owner: { connect: { id: newOwner.id } },
+          directPermissions: {
+            upsert: {
+              where: {
+                courseId_userId: {
+                  courseId: id,
+                  userId: ctx.user.sub,
+                },
               },
+              create: {
+                permissionLevel: DB.PermissionLevel.ADMIN,
+                user: { connect: { id: ctx.user.sub } },
+              },
+              update: { permissionLevel: DB.PermissionLevel.ADMIN },
             },
-            create: {
-              permissionLevel: DB.PermissionLevel.ADMIN,
-              user: { connect: { id: ctx.user.sub } },
-            },
-            update: { permissionLevel: DB.PermissionLevel.ADMIN },
           },
         },
-      },
-      include: {
-        directPermissions: {
-          where: { userId: ctx.user.sub },
-          include: {
-            user: { select: { id: true, shortname: true, email: true } },
-          },
-        },
-      },
-    })
-
-    // if the new owner previously had a permission on the live quiz, delete it
-    if (newOwner.sharedObjects.length > 0) {
-      await prisma.permission.delete({
-        where: {
-          courseId_userId: {
-            courseId: id,
-            userId: newOwner.id,
+        include: {
+          directPermissions: {
+            where: { userId: ctx.user.sub },
+            include: {
+              user: { select: { id: true, shortname: true, email: true } },
+            },
           },
         },
       })
-    }
 
-    // create an audit log entry for the ownership transfer
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.OWNER_TRANSFERRED,
-        objectType: DB.ObjectType.COURSE,
-        objectId: id,
-        sourceUserId: ctx.user.sub,
-        targetUserId: newOwner.id,
-        message: `Ownership of ${DB.ObjectType.COURSE} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
-      },
-    })
+      // if the new owner previously had a permission on the live quiz, delete it
+      if (newOwner.sharedObjects.length > 0) {
+        await prisma.permission.delete({
+          where: {
+            courseId_userId: {
+              courseId: id,
+              userId: newOwner.id,
+            },
+          },
+        })
+      }
 
-    // trigger recomputation of derived permissions for the course for both users
-    await recomputeDerivedPermissions(
-      { courseId: id, userId: newOwner.id, updateAccessRequests: true },
-      prisma
-    )
-    await recomputeDerivedPermissions(
-      { courseId: id, userId: ctx.user.sub, updateAccessRequests: false },
-      prisma
-    )
+      // create an audit log entry for the ownership transfer
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.OWNER_TRANSFERRED,
+          objectType: DB.ObjectType.COURSE,
+          objectId: id,
+          sourceUserId: ctx.user.sub,
+          targetUserId: newOwner.id,
+          message: `Ownership of ${DB.ObjectType.COURSE} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+        },
+      })
 
-    return updated
-  })
+      // trigger recomputation of derived permissions for the course for both users
+      await recomputeDerivedPermissions(
+        { courseId: id, userId: newOwner.id, updateAccessRequests: true },
+        prisma
+      )
+      await recomputeDerivedPermissions(
+        { courseId: id, userId: ctx.user.sub, updateAccessRequests: false },
+        prisma
+      )
+
+      return updated
+    },
+    { timeout: 60000 }
+  )
 
   // return info for new admin permission and corresponding cache update
   const permission = updatedCourse.directPermissions[0]
@@ -3252,74 +3264,77 @@ export async function transferLiveQuizOwnership(
     return null
   }
 
-  const updatedLiveQuiz = await ctx.prisma.$transaction(async (prisma) => {
-    // update the owner of the live quiz and grant admin permissions to the current user
-    const updated = await prisma.liveQuiz.update({
-      where: { id },
-      data: {
-        owner: { connect: { id: newOwner.id } },
-        directPermissions: {
-          upsert: {
-            where: {
-              liveQuizId_userId: {
-                liveQuizId: id,
-                userId: ctx.user.sub,
+  const updatedLiveQuiz = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // update the owner of the live quiz and grant admin permissions to the current user
+      const updated = await prisma.liveQuiz.update({
+        where: { id },
+        data: {
+          owner: { connect: { id: newOwner.id } },
+          directPermissions: {
+            upsert: {
+              where: {
+                liveQuizId_userId: {
+                  liveQuizId: id,
+                  userId: ctx.user.sub,
+                },
               },
+              create: {
+                permissionLevel: DB.PermissionLevel.ADMIN,
+                user: { connect: { id: ctx.user.sub } },
+              },
+              update: { permissionLevel: DB.PermissionLevel.ADMIN },
             },
-            create: {
-              permissionLevel: DB.PermissionLevel.ADMIN,
-              user: { connect: { id: ctx.user.sub } },
-            },
-            update: { permissionLevel: DB.PermissionLevel.ADMIN },
           },
         },
-      },
-      include: {
-        directPermissions: {
-          where: { userId: ctx.user.sub },
-          include: {
-            user: { select: { id: true, shortname: true, email: true } },
-          },
-        },
-      },
-    })
-
-    // if the new owner previously had a permission on the live quiz, delete it
-    if (newOwner.sharedObjects.length > 0) {
-      await prisma.permission.delete({
-        where: {
-          liveQuizId_userId: {
-            liveQuizId: id,
-            userId: newOwner.id,
+        include: {
+          directPermissions: {
+            where: { userId: ctx.user.sub },
+            include: {
+              user: { select: { id: true, shortname: true, email: true } },
+            },
           },
         },
       })
-    }
 
-    // create an audit log entry for the ownership transfer
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.OWNER_TRANSFERRED,
-        objectType: DB.ObjectType.LIVE_QUIZ,
-        objectId: String(id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: newOwner.id,
-        message: `Ownership of ${DB.ObjectType.LIVE_QUIZ} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
-      },
-    })
+      // if the new owner previously had a permission on the live quiz, delete it
+      if (newOwner.sharedObjects.length > 0) {
+        await prisma.permission.delete({
+          where: {
+            liveQuizId_userId: {
+              liveQuizId: id,
+              userId: newOwner.id,
+            },
+          },
+        })
+      }
 
-    // trigger recomputation of derived permissions for the live quiz for both users
-    await recomputeDerivedPermissions(
-      { liveQuizId: id, userId: newOwner.id, updateAccessRequests: true },
-      prisma
-    )
-    await recomputeDerivedPermissions(
-      { liveQuizId: id, userId: ctx.user.sub, updateAccessRequests: false },
-      prisma
-    )
+      // create an audit log entry for the ownership transfer
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.OWNER_TRANSFERRED,
+          objectType: DB.ObjectType.LIVE_QUIZ,
+          objectId: String(id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: newOwner.id,
+          message: `Ownership of ${DB.ObjectType.LIVE_QUIZ} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+        },
+      })
 
-    return updated
-  })
+      // trigger recomputation of derived permissions for the live quiz for both users
+      await recomputeDerivedPermissions(
+        { liveQuizId: id, userId: newOwner.id, updateAccessRequests: true },
+        prisma
+      )
+      await recomputeDerivedPermissions(
+        { liveQuizId: id, userId: ctx.user.sub, updateAccessRequests: false },
+        prisma
+      )
+
+      return updated
+    },
+    { timeout: 60000 }
+  )
 
   // return info for new admin permission and corresponding cache update
   const permission = updatedLiveQuiz.directPermissions[0]
@@ -3359,74 +3374,81 @@ export async function transferPracticeQuizOwnership(
     return null
   }
 
-  const updatedPracticeQuiz = await ctx.prisma.$transaction(async (prisma) => {
-    // update the owner of the practice quiz and grant admin permissions to the current user
-    const updated = await prisma.practiceQuiz.update({
-      where: { id },
-      data: {
-        owner: { connect: { id: newOwner.id } },
-        directPermissions: {
-          upsert: {
-            where: {
-              practiceQuizId_userId: {
-                practiceQuizId: id,
-                userId: ctx.user.sub,
+  const updatedPracticeQuiz = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // update the owner of the practice quiz and grant admin permissions to the current user
+      const updated = await prisma.practiceQuiz.update({
+        where: { id },
+        data: {
+          owner: { connect: { id: newOwner.id } },
+          directPermissions: {
+            upsert: {
+              where: {
+                practiceQuizId_userId: {
+                  practiceQuizId: id,
+                  userId: ctx.user.sub,
+                },
               },
+              create: {
+                permissionLevel: DB.PermissionLevel.ADMIN,
+                user: { connect: { id: ctx.user.sub } },
+              },
+              update: { permissionLevel: DB.PermissionLevel.ADMIN },
             },
-            create: {
-              permissionLevel: DB.PermissionLevel.ADMIN,
-              user: { connect: { id: ctx.user.sub } },
-            },
-            update: { permissionLevel: DB.PermissionLevel.ADMIN },
           },
         },
-      },
-      include: {
-        directPermissions: {
-          where: { userId: ctx.user.sub },
-          include: {
-            user: { select: { id: true, shortname: true, email: true } },
-          },
-        },
-      },
-    })
-
-    // if the new owner previously had a permission on the practice quiz, delete it
-    if (newOwner.sharedObjects.length > 0) {
-      await prisma.permission.delete({
-        where: {
-          practiceQuizId_userId: {
-            practiceQuizId: id,
-            userId: newOwner.id,
+        include: {
+          directPermissions: {
+            where: { userId: ctx.user.sub },
+            include: {
+              user: { select: { id: true, shortname: true, email: true } },
+            },
           },
         },
       })
-    }
 
-    // create an audit log entry for the ownership transfer
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.OWNER_TRANSFERRED,
-        objectType: DB.ObjectType.PRACTICE_QUIZ,
-        objectId: String(id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: newOwner.id,
-        message: `Ownership of ${DB.ObjectType.PRACTICE_QUIZ} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
-      },
-    })
+      // if the new owner previously had a permission on the practice quiz, delete it
+      if (newOwner.sharedObjects.length > 0) {
+        await prisma.permission.delete({
+          where: {
+            practiceQuizId_userId: {
+              practiceQuizId: id,
+              userId: newOwner.id,
+            },
+          },
+        })
+      }
 
-    // trigger recomputation of derived permissions for the practice quiz for both users
-    await recomputeDerivedPermissions(
-      { practiceQuizId: id, userId: newOwner.id, updateAccessRequests: true },
-      prisma
-    )
-    await recomputeDerivedPermissions(
-      { practiceQuizId: id, userId: ctx.user.sub, updateAccessRequests: false },
-      prisma
-    )
+      // create an audit log entry for the ownership transfer
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.OWNER_TRANSFERRED,
+          objectType: DB.ObjectType.PRACTICE_QUIZ,
+          objectId: String(id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: newOwner.id,
+          message: `Ownership of ${DB.ObjectType.PRACTICE_QUIZ} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+        },
+      })
 
-    return updated
-  })
+      // trigger recomputation of derived permissions for the practice quiz for both users
+      await recomputeDerivedPermissions(
+        { practiceQuizId: id, userId: newOwner.id, updateAccessRequests: true },
+        prisma
+      )
+      await recomputeDerivedPermissions(
+        {
+          practiceQuizId: id,
+          userId: ctx.user.sub,
+          updateAccessRequests: false,
+        },
+        prisma
+      )
+
+      return updated
+    },
+    { timeout: 60000 }
+  )
 
   // return info for new admin permission and corresponding cache update
   const permission = updatedPracticeQuiz.directPermissions[0]
@@ -3466,78 +3488,85 @@ export async function transferMicroLearningOwnership(
     return null
   }
 
-  const updatedMicroLearning = await ctx.prisma.$transaction(async (prisma) => {
-    // update the owner of the microlearning and grant admin permissions to the current user
-    const updated = await prisma.microLearning.update({
-      where: { id },
-      data: {
-        owner: { connect: { id: newOwner.id } },
-        directPermissions: {
-          upsert: {
-            where: {
-              microLearningId_userId: {
-                microLearningId: id,
-                userId: ctx.user.sub,
+  const updatedMicroLearning = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // update the owner of the microlearning and grant admin permissions to the current user
+      const updated = await prisma.microLearning.update({
+        where: { id },
+        data: {
+          owner: { connect: { id: newOwner.id } },
+          directPermissions: {
+            upsert: {
+              where: {
+                microLearningId_userId: {
+                  microLearningId: id,
+                  userId: ctx.user.sub,
+                },
               },
+              create: {
+                permissionLevel: DB.PermissionLevel.ADMIN,
+                user: { connect: { id: ctx.user.sub } },
+              },
+              update: { permissionLevel: DB.PermissionLevel.ADMIN },
             },
-            create: {
-              permissionLevel: DB.PermissionLevel.ADMIN,
-              user: { connect: { id: ctx.user.sub } },
-            },
-            update: { permissionLevel: DB.PermissionLevel.ADMIN },
           },
         },
-      },
-      include: {
-        directPermissions: {
-          where: { userId: ctx.user.sub },
-          include: {
-            user: { select: { id: true, shortname: true, email: true } },
-          },
-        },
-      },
-    })
-
-    // if the new owner previously had a permission on the microlearning, delete it
-    if (newOwner.sharedObjects.length > 0) {
-      await prisma.permission.delete({
-        where: {
-          microLearningId_userId: {
-            microLearningId: id,
-            userId: newOwner.id,
+        include: {
+          directPermissions: {
+            where: { userId: ctx.user.sub },
+            include: {
+              user: { select: { id: true, shortname: true, email: true } },
+            },
           },
         },
       })
-    }
 
-    // create an audit log entry for the ownership transfer
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.OWNER_TRANSFERRED,
-        objectType: DB.ObjectType.MICRO_LEARNING,
-        objectId: String(id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: newOwner.id,
-        message: `Ownership of ${DB.ObjectType.MICRO_LEARNING} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
-      },
-    })
+      // if the new owner previously had a permission on the microlearning, delete it
+      if (newOwner.sharedObjects.length > 0) {
+        await prisma.permission.delete({
+          where: {
+            microLearningId_userId: {
+              microLearningId: id,
+              userId: newOwner.id,
+            },
+          },
+        })
+      }
 
-    // trigger recomputation of derived permissions for the microlearning for both users
-    await recomputeDerivedPermissions(
-      { microLearningId: id, userId: newOwner.id, updateAccessRequests: true },
-      prisma
-    )
-    await recomputeDerivedPermissions(
-      {
-        microLearningId: id,
-        userId: ctx.user.sub,
-        updateAccessRequests: false,
-      },
-      prisma
-    )
+      // create an audit log entry for the ownership transfer
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.OWNER_TRANSFERRED,
+          objectType: DB.ObjectType.MICRO_LEARNING,
+          objectId: String(id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: newOwner.id,
+          message: `Ownership of ${DB.ObjectType.MICRO_LEARNING} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+        },
+      })
 
-    return updated
-  })
+      // trigger recomputation of derived permissions for the microlearning for both users
+      await recomputeDerivedPermissions(
+        {
+          microLearningId: id,
+          userId: newOwner.id,
+          updateAccessRequests: true,
+        },
+        prisma
+      )
+      await recomputeDerivedPermissions(
+        {
+          microLearningId: id,
+          userId: ctx.user.sub,
+          updateAccessRequests: false,
+        },
+        prisma
+      )
+
+      return updated
+    },
+    { timeout: 60000 }
+  )
 
   // return info for new admin permission and corresponding cache update
   const permission = updatedMicroLearning.directPermissions[0]
@@ -3577,78 +3606,85 @@ export async function transferGroupActivityOwnership(
     return null
   }
 
-  const updatedGroupActivity = await ctx.prisma.$transaction(async (prisma) => {
-    // update the owner of the group activity and grant admin permissions to the current user
-    const updated = await prisma.groupActivity.update({
-      where: { id },
-      data: {
-        owner: { connect: { id: newOwner.id } },
-        directPermissions: {
-          upsert: {
-            where: {
-              groupActivityId_userId: {
-                groupActivityId: id,
-                userId: ctx.user.sub,
+  const updatedGroupActivity = await ctx.prisma.$transaction(
+    async (prisma) => {
+      // update the owner of the group activity and grant admin permissions to the current user
+      const updated = await prisma.groupActivity.update({
+        where: { id },
+        data: {
+          owner: { connect: { id: newOwner.id } },
+          directPermissions: {
+            upsert: {
+              where: {
+                groupActivityId_userId: {
+                  groupActivityId: id,
+                  userId: ctx.user.sub,
+                },
               },
+              create: {
+                permissionLevel: DB.PermissionLevel.ADMIN,
+                user: { connect: { id: ctx.user.sub } },
+              },
+              update: { permissionLevel: DB.PermissionLevel.ADMIN },
             },
-            create: {
-              permissionLevel: DB.PermissionLevel.ADMIN,
-              user: { connect: { id: ctx.user.sub } },
-            },
-            update: { permissionLevel: DB.PermissionLevel.ADMIN },
           },
         },
-      },
-      include: {
-        directPermissions: {
-          where: { userId: ctx.user.sub },
-          include: {
-            user: { select: { id: true, shortname: true, email: true } },
-          },
-        },
-      },
-    })
-
-    // if the new owner previously had a permission on the group activity, delete it
-    if (newOwner.sharedObjects.length > 0) {
-      await prisma.permission.delete({
-        where: {
-          groupActivityId_userId: {
-            groupActivityId: id,
-            userId: newOwner.id,
+        include: {
+          directPermissions: {
+            where: { userId: ctx.user.sub },
+            include: {
+              user: { select: { id: true, shortname: true, email: true } },
+            },
           },
         },
       })
-    }
 
-    // create an audit log entry for the ownership transfer
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.OWNER_TRANSFERRED,
-        objectType: DB.ObjectType.GROUP_ACTIVITY,
-        objectId: String(id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: newOwner.id,
-        message: `Ownership of ${DB.ObjectType.GROUP_ACTIVITY} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
-      },
-    })
+      // if the new owner previously had a permission on the group activity, delete it
+      if (newOwner.sharedObjects.length > 0) {
+        await prisma.permission.delete({
+          where: {
+            groupActivityId_userId: {
+              groupActivityId: id,
+              userId: newOwner.id,
+            },
+          },
+        })
+      }
 
-    // trigger recomputation of derived permissions for the group activity for both users
-    await recomputeDerivedPermissions(
-      { groupActivityId: id, userId: newOwner.id, updateAccessRequests: true },
-      prisma
-    )
-    await recomputeDerivedPermissions(
-      {
-        groupActivityId: id,
-        userId: ctx.user.sub,
-        updateAccessRequests: false,
-      },
-      prisma
-    )
+      // create an audit log entry for the ownership transfer
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.OWNER_TRANSFERRED,
+          objectType: DB.ObjectType.GROUP_ACTIVITY,
+          objectId: String(id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: newOwner.id,
+          message: `Ownership of ${DB.ObjectType.GROUP_ACTIVITY} (ID ${id}) transferred from user ${ctx.user.sub} to user ${newOwner.id}.`,
+        },
+      })
 
-    return updated
-  })
+      // trigger recomputation of derived permissions for the group activity for both users
+      await recomputeDerivedPermissions(
+        {
+          groupActivityId: id,
+          userId: newOwner.id,
+          updateAccessRequests: true,
+        },
+        prisma
+      )
+      await recomputeDerivedPermissions(
+        {
+          groupActivityId: id,
+          userId: ctx.user.sub,
+          updateAccessRequests: false,
+        },
+        prisma
+      )
+
+      return updated
+    },
+    { timeout: 60000 }
+  )
 
   // return info for new admin permission and corresponding cache update
   const permission = updatedGroupActivity.directPermissions[0]
@@ -3917,150 +3953,209 @@ export async function shareObject(
       return null
     }
 
-    const permission = await ctx.prisma.$transaction(async (prisma) => {
-      // upsert new permission for the answer collection under consideration
-      const newPermission = await prisma.permission.upsert({
-        where: {
-          catalogCollectionId_userId:
-            typeof catalogCollectionId !== 'undefined'
-              ? {
-                  catalogCollectionId,
-                  userId,
-                }
-              : undefined,
-          answerCollectionId_userId:
-            typeof answerCollectionId !== 'undefined'
-              ? {
-                  answerCollectionId,
-                  userId,
-                }
-              : undefined,
-          elementId_userId:
-            typeof elementId !== 'undefined'
-              ? {
-                  elementId,
-                  userId,
-                }
-              : undefined,
-          courseId_userId:
-            typeof courseId !== 'undefined'
-              ? {
-                  courseId,
-                  userId,
-                }
-              : undefined,
-          liveQuizId_userId:
-            typeof liveQuizId !== 'undefined'
-              ? {
-                  liveQuizId,
-                  userId,
-                }
-              : undefined,
-          practiceQuizId_userId:
-            typeof practiceQuizId !== 'undefined'
-              ? {
-                  practiceQuizId,
-                  userId,
-                }
-              : undefined,
-          microLearningId_userId:
-            typeof microLearningId !== 'undefined'
-              ? {
-                  microLearningId,
-                  userId,
-                }
-              : undefined,
-          groupActivityId_userId:
-            typeof groupActivityId !== 'undefined'
-              ? {
-                  groupActivityId,
-                  userId,
-                }
-              : undefined,
-        },
-        create: {
-          permissionLevel,
-          propagation,
-          user: {
-            connect: {
-              id: userId,
-            },
+    const permission = await ctx.prisma.$transaction(
+      async (prisma) => {
+        // upsert new permission for the answer collection under consideration
+        const newPermission = await prisma.permission.upsert({
+          where: {
+            catalogCollectionId_userId:
+              typeof catalogCollectionId !== 'undefined'
+                ? {
+                    catalogCollectionId,
+                    userId,
+                  }
+                : undefined,
+            answerCollectionId_userId:
+              typeof answerCollectionId !== 'undefined'
+                ? {
+                    answerCollectionId,
+                    userId,
+                  }
+                : undefined,
+            elementId_userId:
+              typeof elementId !== 'undefined'
+                ? {
+                    elementId,
+                    userId,
+                  }
+                : undefined,
+            courseId_userId:
+              typeof courseId !== 'undefined'
+                ? {
+                    courseId,
+                    userId,
+                  }
+                : undefined,
+            liveQuizId_userId:
+              typeof liveQuizId !== 'undefined'
+                ? {
+                    liveQuizId,
+                    userId,
+                  }
+                : undefined,
+            practiceQuizId_userId:
+              typeof practiceQuizId !== 'undefined'
+                ? {
+                    practiceQuizId,
+                    userId,
+                  }
+                : undefined,
+            microLearningId_userId:
+              typeof microLearningId !== 'undefined'
+                ? {
+                    microLearningId,
+                    userId,
+                  }
+                : undefined,
+            groupActivityId_userId:
+              typeof groupActivityId !== 'undefined'
+                ? {
+                    groupActivityId,
+                    userId,
+                  }
+                : undefined,
           },
-          catalogCollection:
-            typeof catalogCollectionId !== 'undefined'
-              ? {
-                  connect: {
-                    id: catalogCollectionId,
-                  },
-                }
-              : undefined,
-          answerCollection:
-            typeof answerCollectionId !== 'undefined'
-              ? {
-                  connect: {
-                    id: answerCollectionId,
-                  },
-                }
-              : undefined,
-          element:
-            typeof elementId !== 'undefined'
-              ? {
-                  connect: {
-                    id: elementId,
-                  },
-                }
-              : undefined,
-          course:
-            typeof courseId !== 'undefined'
-              ? {
-                  connect: {
-                    id: courseId,
-                  },
-                }
-              : undefined,
-          liveQuiz:
-            typeof liveQuizId !== 'undefined'
-              ? {
-                  connect: {
-                    id: liveQuizId,
-                  },
-                }
-              : undefined,
-          practiceQuiz:
-            typeof practiceQuizId !== 'undefined'
-              ? {
-                  connect: {
-                    id: practiceQuizId,
-                  },
-                }
-              : undefined,
-          microLearning:
-            typeof microLearningId !== 'undefined'
-              ? {
-                  connect: {
-                    id: microLearningId,
-                  },
-                }
-              : undefined,
-          groupActivity:
-            typeof groupActivityId !== 'undefined'
-              ? {
-                  connect: {
-                    id: groupActivityId,
-                  },
-                }
-              : undefined,
-        },
-        update: {
-          permissionLevel,
-          propagation,
-        },
-      })
+          create: {
+            permissionLevel,
+            propagation,
+            user: {
+              connect: {
+                id: userId,
+              },
+            },
+            catalogCollection:
+              typeof catalogCollectionId !== 'undefined'
+                ? {
+                    connect: {
+                      id: catalogCollectionId,
+                    },
+                  }
+                : undefined,
+            answerCollection:
+              typeof answerCollectionId !== 'undefined'
+                ? {
+                    connect: {
+                      id: answerCollectionId,
+                    },
+                  }
+                : undefined,
+            element:
+              typeof elementId !== 'undefined'
+                ? {
+                    connect: {
+                      id: elementId,
+                    },
+                  }
+                : undefined,
+            course:
+              typeof courseId !== 'undefined'
+                ? {
+                    connect: {
+                      id: courseId,
+                    },
+                  }
+                : undefined,
+            liveQuiz:
+              typeof liveQuizId !== 'undefined'
+                ? {
+                    connect: {
+                      id: liveQuizId,
+                    },
+                  }
+                : undefined,
+            practiceQuiz:
+              typeof practiceQuizId !== 'undefined'
+                ? {
+                    connect: {
+                      id: practiceQuizId,
+                    },
+                  }
+                : undefined,
+            microLearning:
+              typeof microLearningId !== 'undefined'
+                ? {
+                    connect: {
+                      id: microLearningId,
+                    },
+                  }
+                : undefined,
+            groupActivity:
+              typeof groupActivityId !== 'undefined'
+                ? {
+                    connect: {
+                      id: groupActivityId,
+                    },
+                  }
+                : undefined,
+          },
+          update: {
+            permissionLevel,
+            propagation,
+          },
+        })
 
-      // remove any pending access requests for the user
-      await prisma.accessRequest.deleteMany({
-        where: {
-          userId,
+        // remove any pending access requests for the user
+        await prisma.accessRequest.deleteMany({
+          where: {
+            userId,
+            catalogCollectionId,
+            answerCollectionId,
+            elementId,
+            courseId,
+            liveQuizId,
+            practiceQuizId,
+            microLearningId,
+            groupActivityId,
+          },
+        })
+
+        // trigger recomputation of derived permissions for the object
+        const updateAccessRequests =
+          permissionLevel === DB.PermissionLevel.ADMIN
+        if (typeof catalogCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { catalogCollectionId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof answerCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { answerCollectionId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof elementId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { elementId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof courseId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { courseId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof liveQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { liveQuizId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof practiceQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { practiceQuizId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof microLearningId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { microLearningId, userId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof groupActivityId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { groupActivityId, userId, updateAccessRequests },
+            prisma
+          )
+        }
+
+        // create an audit log entry for the newly created permission
+        const { objectType, objectId } = getAuditLogObjectType({
           catalogCollectionId,
           answerCollectionId,
           elementId,
@@ -4069,94 +4164,39 @@ export async function shareObject(
           practiceQuizId,
           microLearningId,
           groupActivityId,
-        },
-      })
-
-      // trigger recomputation of derived permissions for the object
-      const updateAccessRequests = permissionLevel === DB.PermissionLevel.ADMIN
-      if (typeof catalogCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { catalogCollectionId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof answerCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { answerCollectionId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof elementId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { elementId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof courseId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { courseId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof liveQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { liveQuizId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof practiceQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { practiceQuizId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof microLearningId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { microLearningId, userId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof groupActivityId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { groupActivityId, userId, updateAccessRequests },
-          prisma
-        )
-      }
-
-      // create an audit log entry for the newly created permission
-      const { objectType, objectId } = getAuditLogObjectType({
-        catalogCollectionId,
-        answerCollectionId,
-        elementId,
-        courseId,
-        liveQuizId,
-        practiceQuizId,
-        microLearningId,
-        groupActivityId,
-      })
-      if (objectType && objectId) {
-        await prisma.auditLogEntry.create({
-          data: {
-            type: DB.AuditLogType.PERMISSION_GRANTED,
-            objectType,
-            objectId,
-            sourceUserId: ctx.user.sub,
-            targetUserId: userId,
-            message: `Direct permission with level ${permissionLevel} granted for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} to user ${userId}.`,
-          },
         })
-      } else {
-        throw new Error(
-          `Could not determine object type or ID for audit log entry. Permission ID: ${newPermission.id}, Details: ${JSON.stringify(
-            {
-              catalogCollectionId,
-              answerCollectionId,
-              elementId,
-              courseId,
-              liveQuizId,
-              practiceQuizId,
-              microLearningId,
-              groupActivityId,
-            }
-          )}`
-        )
-      }
+        if (objectType && objectId) {
+          await prisma.auditLogEntry.create({
+            data: {
+              type: DB.AuditLogType.PERMISSION_GRANTED,
+              objectType,
+              objectId,
+              sourceUserId: ctx.user.sub,
+              targetUserId: userId,
+              message: `Direct permission with level ${permissionLevel} granted for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} to user ${userId}.`,
+            },
+          })
+        } else {
+          throw new Error(
+            `Could not determine object type or ID for audit log entry. Permission ID: ${newPermission.id}, Details: ${JSON.stringify(
+              {
+                catalogCollectionId,
+                answerCollectionId,
+                elementId,
+                courseId,
+                liveQuizId,
+                practiceQuizId,
+                microLearningId,
+                groupActivityId,
+              }
+            )}`
+          )
+        }
 
-      return newPermission
-    })
+        return newPermission
+      },
+      { timeout: 60000 }
+    )
 
     // invalidate permission
     ctx.emitter.emit('invalidate', {
@@ -4193,233 +4233,237 @@ export async function shareObject(
       return null
     }
 
-    const permission = await ctx.prisma.$transaction(async (prisma) => {
-      // upsert new permission for the answer collection under consideration
-      const newPermission = await prisma.permission.upsert({
-        where: {
-          catalogCollectionId_userGroupId:
-            typeof catalogCollectionId !== 'undefined'
-              ? {
-                  catalogCollectionId,
-                  userGroupId,
-                }
-              : undefined,
-          answerCollectionId_userGroupId:
-            typeof answerCollectionId !== 'undefined'
-              ? {
-                  answerCollectionId,
-                  userGroupId,
-                }
-              : undefined,
-          elementId_userGroupId:
-            typeof elementId !== 'undefined'
-              ? {
-                  elementId,
-                  userGroupId,
-                }
-              : undefined,
-          courseId_userGroupId:
-            typeof courseId !== 'undefined'
-              ? {
-                  courseId,
-                  userGroupId,
-                }
-              : undefined,
-          liveQuizId_userGroupId:
-            typeof liveQuizId !== 'undefined'
-              ? {
-                  liveQuizId,
-                  userGroupId,
-                }
-              : undefined,
-          practiceQuizId_userGroupId:
-            typeof practiceQuizId !== 'undefined'
-              ? {
-                  practiceQuizId,
-                  userGroupId,
-                }
-              : undefined,
-          microLearningId_userGroupId:
-            typeof microLearningId !== 'undefined'
-              ? {
-                  microLearningId,
-                  userGroupId,
-                }
-              : undefined,
-          groupActivityId_userGroupId:
-            typeof groupActivityId !== 'undefined'
-              ? {
-                  groupActivityId,
-                  userGroupId,
-                }
-              : undefined,
-        },
-        create: {
-          permissionLevel,
-          propagation,
-          userGroup: {
-            connect: {
-              id: userGroupId,
-            },
+    const permission = await ctx.prisma.$transaction(
+      async (prisma) => {
+        // upsert new permission for the answer collection under consideration
+        const newPermission = await prisma.permission.upsert({
+          where: {
+            catalogCollectionId_userGroupId:
+              typeof catalogCollectionId !== 'undefined'
+                ? {
+                    catalogCollectionId,
+                    userGroupId,
+                  }
+                : undefined,
+            answerCollectionId_userGroupId:
+              typeof answerCollectionId !== 'undefined'
+                ? {
+                    answerCollectionId,
+                    userGroupId,
+                  }
+                : undefined,
+            elementId_userGroupId:
+              typeof elementId !== 'undefined'
+                ? {
+                    elementId,
+                    userGroupId,
+                  }
+                : undefined,
+            courseId_userGroupId:
+              typeof courseId !== 'undefined'
+                ? {
+                    courseId,
+                    userGroupId,
+                  }
+                : undefined,
+            liveQuizId_userGroupId:
+              typeof liveQuizId !== 'undefined'
+                ? {
+                    liveQuizId,
+                    userGroupId,
+                  }
+                : undefined,
+            practiceQuizId_userGroupId:
+              typeof practiceQuizId !== 'undefined'
+                ? {
+                    practiceQuizId,
+                    userGroupId,
+                  }
+                : undefined,
+            microLearningId_userGroupId:
+              typeof microLearningId !== 'undefined'
+                ? {
+                    microLearningId,
+                    userGroupId,
+                  }
+                : undefined,
+            groupActivityId_userGroupId:
+              typeof groupActivityId !== 'undefined'
+                ? {
+                    groupActivityId,
+                    userGroupId,
+                  }
+                : undefined,
           },
-          catalogCollection:
-            typeof catalogCollectionId !== 'undefined'
-              ? {
-                  connect: {
-                    id: catalogCollectionId,
-                  },
-                }
-              : undefined,
-          answerCollection:
-            typeof answerCollectionId !== 'undefined'
-              ? {
-                  connect: {
-                    id: answerCollectionId,
-                  },
-                }
-              : undefined,
-          element:
-            typeof elementId !== 'undefined'
-              ? {
-                  connect: {
-                    id: elementId,
-                  },
-                }
-              : undefined,
-          course:
-            typeof courseId !== 'undefined'
-              ? {
-                  connect: {
-                    id: courseId,
-                  },
-                }
-              : undefined,
-          liveQuiz:
-            typeof liveQuizId !== 'undefined'
-              ? {
-                  connect: {
-                    id: liveQuizId,
-                  },
-                }
-              : undefined,
-          practiceQuiz:
-            typeof practiceQuizId !== 'undefined'
-              ? {
-                  connect: {
-                    id: practiceQuizId,
-                  },
-                }
-              : undefined,
-          microLearning:
-            typeof microLearningId !== 'undefined'
-              ? {
-                  connect: {
-                    id: microLearningId,
-                  },
-                }
-              : undefined,
-          groupActivity:
-            typeof groupActivityId !== 'undefined'
-              ? {
-                  connect: {
-                    id: groupActivityId,
-                  },
-                }
-              : undefined,
-        },
-        update: {
-          permissionLevel,
-          propagation,
-        },
-      })
-
-      // check if admin permissions were granted and the corresponding access requests need to be updated
-      const updateAccessRequests = permissionLevel === DB.PermissionLevel.ADMIN
-
-      // trigger recomputation of derived permissions for the object
-      if (typeof catalogCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { catalogCollectionId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof answerCollectionId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { answerCollectionId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof elementId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { elementId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof courseId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { courseId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof liveQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { liveQuizId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof practiceQuizId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { practiceQuizId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof microLearningId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { microLearningId, updateAccessRequests },
-          prisma
-        )
-      } else if (typeof groupActivityId !== 'undefined') {
-        await recomputeDerivedPermissions(
-          { groupActivityId, updateAccessRequests },
-          prisma
-        )
-      }
-
-      // create an audit log entry for the newly created permission
-      const { objectType, objectId } = getAuditLogObjectType({
-        catalogCollectionId,
-        answerCollectionId,
-        elementId,
-        courseId,
-        liveQuizId,
-        practiceQuizId,
-        microLearningId,
-        groupActivityId,
-      })
-      if (objectType && objectId) {
-        await prisma.auditLogEntry.create({
-          data: {
-            type: DB.AuditLogType.PERMISSION_GRANTED,
-            objectType,
-            objectId,
-            sourceUserId: ctx.user.sub,
-            targetUserGroupId: userGroupId,
-            message: `Direct permission with level ${permissionLevel} granted for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} to user group ${userGroupId}.`,
+          create: {
+            permissionLevel,
+            propagation,
+            userGroup: {
+              connect: {
+                id: userGroupId,
+              },
+            },
+            catalogCollection:
+              typeof catalogCollectionId !== 'undefined'
+                ? {
+                    connect: {
+                      id: catalogCollectionId,
+                    },
+                  }
+                : undefined,
+            answerCollection:
+              typeof answerCollectionId !== 'undefined'
+                ? {
+                    connect: {
+                      id: answerCollectionId,
+                    },
+                  }
+                : undefined,
+            element:
+              typeof elementId !== 'undefined'
+                ? {
+                    connect: {
+                      id: elementId,
+                    },
+                  }
+                : undefined,
+            course:
+              typeof courseId !== 'undefined'
+                ? {
+                    connect: {
+                      id: courseId,
+                    },
+                  }
+                : undefined,
+            liveQuiz:
+              typeof liveQuizId !== 'undefined'
+                ? {
+                    connect: {
+                      id: liveQuizId,
+                    },
+                  }
+                : undefined,
+            practiceQuiz:
+              typeof practiceQuizId !== 'undefined'
+                ? {
+                    connect: {
+                      id: practiceQuizId,
+                    },
+                  }
+                : undefined,
+            microLearning:
+              typeof microLearningId !== 'undefined'
+                ? {
+                    connect: {
+                      id: microLearningId,
+                    },
+                  }
+                : undefined,
+            groupActivity:
+              typeof groupActivityId !== 'undefined'
+                ? {
+                    connect: {
+                      id: groupActivityId,
+                    },
+                  }
+                : undefined,
+          },
+          update: {
+            permissionLevel,
+            propagation,
           },
         })
-      } else {
-        throw new Error(
-          `Could not determine object type or ID for audit log entry. Permission ID: ${newPermission.id}, Details: ${JSON.stringify(
-            {
-              catalogCollectionId,
-              answerCollectionId,
-              elementId,
-              courseId,
-              liveQuizId,
-              practiceQuizId,
-              microLearningId,
-              groupActivityId,
-            }
-          )}`
-        )
-      }
 
-      return newPermission
-    })
+        // check if admin permissions were granted and the corresponding access requests need to be updated
+        const updateAccessRequests =
+          permissionLevel === DB.PermissionLevel.ADMIN
+
+        // trigger recomputation of derived permissions for the object
+        if (typeof catalogCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { catalogCollectionId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof answerCollectionId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { answerCollectionId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof elementId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { elementId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof courseId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { courseId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof liveQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { liveQuizId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof practiceQuizId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { practiceQuizId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof microLearningId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { microLearningId, updateAccessRequests },
+            prisma
+          )
+        } else if (typeof groupActivityId !== 'undefined') {
+          await recomputeDerivedPermissions(
+            { groupActivityId, updateAccessRequests },
+            prisma
+          )
+        }
+
+        // create an audit log entry for the newly created permission
+        const { objectType, objectId } = getAuditLogObjectType({
+          catalogCollectionId,
+          answerCollectionId,
+          elementId,
+          courseId,
+          liveQuizId,
+          practiceQuizId,
+          microLearningId,
+          groupActivityId,
+        })
+        if (objectType && objectId) {
+          await prisma.auditLogEntry.create({
+            data: {
+              type: DB.AuditLogType.PERMISSION_GRANTED,
+              objectType,
+              objectId,
+              sourceUserId: ctx.user.sub,
+              targetUserGroupId: userGroupId,
+              message: `Direct permission with level ${permissionLevel} granted for ${objectType} (ID ${objectId}) by owner / admin ${ctx.user.sub} to user group ${userGroupId}.`,
+            },
+          })
+        } else {
+          throw new Error(
+            `Could not determine object type or ID for audit log entry. Permission ID: ${newPermission.id}, Details: ${JSON.stringify(
+              {
+                catalogCollectionId,
+                answerCollectionId,
+                elementId,
+                courseId,
+                liveQuizId,
+                practiceQuizId,
+                microLearningId,
+                groupActivityId,
+              }
+            )}`
+          )
+        }
+
+        return newPermission
+      },
+      { timeout: 60000 }
+    )
 
     // invalidate permission
     ctx.emitter.emit('invalidate', {
@@ -6142,44 +6186,47 @@ export async function leaveUserGroup(
     return false
   }
 
-  await ctx.prisma.$transaction(async (prisma) => {
-    const updated = await prisma.userGroup.update({
-      where: { id: groupId },
-      data: {
-        members:
-          userGroup.members.length > 0
-            ? { disconnect: { id: ctx.user.sub } }
-            : undefined,
-        admins:
-          userGroup.admins.length > 0
-            ? { disconnect: { id: ctx.user.sub } }
-            : undefined,
-      },
-      include: {
-        permissions: true,
-      },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      const updated = await prisma.userGroup.update({
+        where: { id: groupId },
+        data: {
+          members:
+            userGroup.members.length > 0
+              ? { disconnect: { id: ctx.user.sub } }
+              : undefined,
+          admins:
+            userGroup.admins.length > 0
+              ? { disconnect: { id: ctx.user.sub } }
+              : undefined,
+        },
+        include: {
+          permissions: true,
+        },
+      })
 
-    // create an audit log entry
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.USER_GROUP_USER_REMOVED,
-        objectType: DB.ObjectType.USER_GROUP,
-        objectId: String(updated.id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: ctx.user.sub,
-        message: `User left user group.`,
-      },
-    })
+      // create an audit log entry
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.USER_GROUP_USER_REMOVED,
+          objectType: DB.ObjectType.USER_GROUP,
+          objectId: String(updated.id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: ctx.user.sub,
+          message: `User left user group.`,
+        },
+      })
 
-    // trigger a derived permission recomputation for all objects that were shared with this group and this user
-    await recomputePermissionsUserGroupMember(
-      { permissions: updated.permissions, userId: ctx.user.sub },
-      prisma
-    )
+      // trigger a derived permission recomputation for all objects that were shared with this group and this user
+      await recomputePermissionsUserGroupMember(
+        { permissions: updated.permissions, userId: ctx.user.sub },
+        prisma
+      )
 
-    return updated
-  })
+      return updated
+    },
+    { timeout: 60000 }
+  )
 
   return true
 }
@@ -6198,68 +6245,71 @@ export async function deleteUserGroup(
     return false
   }
 
-  await ctx.prisma.$transaction(async (prisma) => {
-    // delete the user group
-    await prisma.userGroup.delete({
-      where: { id: groupId },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // delete the user group
+      await prisma.userGroup.delete({
+        where: { id: groupId },
+      })
 
-    // create an audit log entry
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.USER_GROUP_DELETED,
-        objectType: DB.ObjectType.USER_GROUP,
-        objectId: String(userGroup.id),
-        sourceUserId: ctx.user.sub,
-        message: `User group deleted by owner.`,
-      },
-    })
+      // create an audit log entry
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.USER_GROUP_DELETED,
+          objectType: DB.ObjectType.USER_GROUP,
+          objectId: String(userGroup.id),
+          sourceUserId: ctx.user.sub,
+          message: `User group deleted by owner.`,
+        },
+      })
 
-    // recompute the permissions for all objects that were shared with this user gruop
-    for (const permission of userGroup.permissions) {
-      if (permission.catalogCollectionId !== null) {
-        await recomputeDerivedPermissions(
-          { catalogCollectionId: permission.catalogCollectionId },
-          prisma
-        )
-      } else if (permission.answerCollectionId !== null) {
-        await recomputeDerivedPermissions(
-          { answerCollectionId: permission.answerCollectionId },
-          prisma
-        )
-      } else if (permission.elementId !== null) {
-        await recomputeDerivedPermissions(
-          { elementId: permission.elementId },
-          prisma
-        )
-      } else if (permission.courseId !== null) {
-        await recomputeDerivedPermissions(
-          { courseId: permission.courseId },
-          prisma
-        )
-      } else if (permission.liveQuizId !== null) {
-        await recomputeDerivedPermissions(
-          { liveQuizId: permission.liveQuizId },
-          prisma
-        )
-      } else if (permission.practiceQuizId !== null) {
-        await recomputeDerivedPermissions(
-          { practiceQuizId: permission.practiceQuizId },
-          prisma
-        )
-      } else if (permission.microLearningId !== null) {
-        await recomputeDerivedPermissions(
-          { microLearningId: permission.microLearningId },
-          prisma
-        )
-      } else if (permission.groupActivityId !== null) {
-        await recomputeDerivedPermissions(
-          { groupActivityId: permission.groupActivityId },
-          prisma
-        )
+      // recompute the permissions for all objects that were shared with this user gruop
+      for (const permission of userGroup.permissions) {
+        if (permission.catalogCollectionId !== null) {
+          await recomputeDerivedPermissions(
+            { catalogCollectionId: permission.catalogCollectionId },
+            prisma
+          )
+        } else if (permission.answerCollectionId !== null) {
+          await recomputeDerivedPermissions(
+            { answerCollectionId: permission.answerCollectionId },
+            prisma
+          )
+        } else if (permission.elementId !== null) {
+          await recomputeDerivedPermissions(
+            { elementId: permission.elementId },
+            prisma
+          )
+        } else if (permission.courseId !== null) {
+          await recomputeDerivedPermissions(
+            { courseId: permission.courseId },
+            prisma
+          )
+        } else if (permission.liveQuizId !== null) {
+          await recomputeDerivedPermissions(
+            { liveQuizId: permission.liveQuizId },
+            prisma
+          )
+        } else if (permission.practiceQuizId !== null) {
+          await recomputeDerivedPermissions(
+            { practiceQuizId: permission.practiceQuizId },
+            prisma
+          )
+        } else if (permission.microLearningId !== null) {
+          await recomputeDerivedPermissions(
+            { microLearningId: permission.microLearningId },
+            prisma
+          )
+        } else if (permission.groupActivityId !== null) {
+          await recomputeDerivedPermissions(
+            { groupActivityId: permission.groupActivityId },
+            prisma
+          )
+        }
       }
-    }
-  })
+    },
+    { timeout: 60000 }
+  )
 
   return true
 }
@@ -6388,37 +6438,40 @@ export async function removeUserFromGroup(
     return false
   }
 
-  await ctx.prisma.$transaction(async (prisma) => {
-    // disconnect the member from the members and admins
-    const updatedUserGroup = await prisma.userGroup.update({
-      where: { id: groupId },
-      data: {
-        admins: userIsAdmin ? { disconnect: { id: userId } } : undefined,
-        members: userIsMember ? { disconnect: { id: userId } } : undefined,
-      },
-      include: {
-        permissions: true,
-      },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // disconnect the member from the members and admins
+      const updatedUserGroup = await prisma.userGroup.update({
+        where: { id: groupId },
+        data: {
+          admins: userIsAdmin ? { disconnect: { id: userId } } : undefined,
+          members: userIsMember ? { disconnect: { id: userId } } : undefined,
+        },
+        include: {
+          permissions: true,
+        },
+      })
 
-    // create an audit log entry
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.USER_GROUP_USER_REMOVED,
-        objectType: DB.ObjectType.USER_GROUP,
-        objectId: String(updatedUserGroup.id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: userId,
-        message: `User removed from group.`,
-      },
-    })
+      // create an audit log entry
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.USER_GROUP_USER_REMOVED,
+          objectType: DB.ObjectType.USER_GROUP,
+          objectId: String(updatedUserGroup.id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: userId,
+          message: `User removed from group.`,
+        },
+      })
 
-    // trigger a derived permission recomputation for all objects that were shared with this group and this user
-    await recomputePermissionsUserGroupMember(
-      { permissions: updatedUserGroup.permissions, userId },
-      prisma
-    )
-  })
+      // trigger a derived permission recomputation for all objects that were shared with this group and this user
+      await recomputePermissionsUserGroupMember(
+        { permissions: updatedUserGroup.permissions, userId },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   return true
 }
@@ -6584,37 +6637,40 @@ export async function addUserToUserGroup(
     return null
   }
 
-  await ctx.prisma.$transaction(async (prisma) => {
-    // add the user to the group
-    const updatedUserGroup = await prisma.userGroup.update({
-      where: { id: groupId },
-      data: {
-        members: !asAdmin ? { connect: { id: userId } } : undefined,
-        admins: asAdmin ? { connect: { id: userId } } : undefined,
-      },
-      include: {
-        permissions: true,
-      },
-    })
+  await ctx.prisma.$transaction(
+    async (prisma) => {
+      // add the user to the group
+      const updatedUserGroup = await prisma.userGroup.update({
+        where: { id: groupId },
+        data: {
+          members: !asAdmin ? { connect: { id: userId } } : undefined,
+          admins: asAdmin ? { connect: { id: userId } } : undefined,
+        },
+        include: {
+          permissions: true,
+        },
+      })
 
-    // create an audit log entry
-    await prisma.auditLogEntry.create({
-      data: {
-        type: DB.AuditLogType.USER_GROUP_USER_ADDED,
-        objectType: DB.ObjectType.USER_GROUP,
-        objectId: String(updatedUserGroup.id),
-        sourceUserId: ctx.user.sub,
-        targetUserId: userId,
-        message: `New user added to group as ${asAdmin ? 'admin' : 'member'}.`,
-      },
-    })
+      // create an audit log entry
+      await prisma.auditLogEntry.create({
+        data: {
+          type: DB.AuditLogType.USER_GROUP_USER_ADDED,
+          objectType: DB.ObjectType.USER_GROUP,
+          objectId: String(updatedUserGroup.id),
+          sourceUserId: ctx.user.sub,
+          targetUserId: userId,
+          message: `New user added to group as ${asAdmin ? 'admin' : 'member'}.`,
+        },
+      })
 
-    // recompute all permissions for the newly added user for objects shared with the group
-    await recomputePermissionsUserGroupMember(
-      { permissions: updatedUserGroup.permissions, userId },
-      prisma
-    )
-  })
+      // recompute all permissions for the newly added user for objects shared with the group
+      await recomputePermissionsUserGroupMember(
+        { permissions: updatedUserGroup.permissions, userId },
+        prisma
+      )
+    },
+    { timeout: 60000 }
+  )
 
   return {
     id: user.id,

--- a/packages/graphql/src/services/templates.ts
+++ b/packages/graphql/src/services/templates.ts
@@ -464,7 +464,7 @@ export async function createActivityTemplate(
         blocks: (DB.ElementBlock & { elements: DB.ElementInstance[] })[]
       }
 
-      const liveQuizTemplate = await ctx.prisma.$transaction(async (prisma) => {
+      await ctx.prisma.$transaction(async (prisma) => {
         const template = await prisma.liveQuiz.create({
           data: {
             name: templateName,
@@ -558,90 +558,88 @@ export async function createActivityTemplate(
         stacks: (DB.ElementStack & { elements: DB.ElementInstance[] })[]
       }
 
-      const practiceQuizTemplate = await ctx.prisma.$transaction(
-        async (prisma) => {
-          const template = await prisma.practiceQuiz.create({
-            data: {
-              name: templateName,
-              displayName: practiceQuiz.displayName,
-              description: practiceQuiz.description,
-              status: DB.PublicationStatus.TEMPLATE,
-              pointsMultiplier: practiceQuiz.pointsMultiplier,
-              orderType: practiceQuiz.orderType,
-              resetTimeDays: practiceQuiz.resetTimeDays,
-              // add stacks with elements
-              stacks: {
-                create: practiceQuiz.stacks.map((stack) => ({
-                  type: DB.ElementStackType.PRACTICE_QUIZ,
-                  order: stack.order,
-                  displayName: stack.displayName,
-                  description: stack.description,
-                  elements: {
-                    create: stack.elements.map((element) => ({
-                      elementType: element.elementType,
-                      migrationId: uuidv4(),
-                      order: element.order,
-                      type: DB.ElementInstanceType.PRACTICE_QUIZ,
-                      elementData: element.elementData,
-                      options: element.options,
-                      results: element.results,
-                      anonymousResults: element.anonymousResults,
-                      instanceStatistics: {
-                        create: getInitialInstanceStatistics(
-                          DB.ElementInstanceType.PRACTICE_QUIZ
-                        ),
-                      },
-                      element: {
-                        connect: { id: element.elementId },
-                      },
-                      owner: {
-                        connect: { id: ctx.user.sub },
-                      },
-                    })),
-                  },
-                })),
-              },
-              // add template information
-              templateInfo: {
-                create: {
-                  description: templateDescription,
-                  instructions: templateInstructions,
-                  answerCollections:
-                    answerCollectionIds.length > 0
-                      ? {
-                          connect: answerCollectionIds.map((id) => ({ id })),
-                        }
-                      : undefined,
-                  answerCollectionItems:
-                    answerCollectionEntryIds.length > 0
-                      ? {
-                          connect: answerCollectionEntryIds.map((id) => ({
-                            id,
-                          })),
-                        }
-                      : undefined,
+      await ctx.prisma.$transaction(async (prisma) => {
+        const template = await prisma.practiceQuiz.create({
+          data: {
+            name: templateName,
+            displayName: practiceQuiz.displayName,
+            description: practiceQuiz.description,
+            status: DB.PublicationStatus.TEMPLATE,
+            pointsMultiplier: practiceQuiz.pointsMultiplier,
+            orderType: practiceQuiz.orderType,
+            resetTimeDays: practiceQuiz.resetTimeDays,
+            // add stacks with elements
+            stacks: {
+              create: practiceQuiz.stacks.map((stack) => ({
+                type: DB.ElementStackType.PRACTICE_QUIZ,
+                order: stack.order,
+                displayName: stack.displayName,
+                description: stack.description,
+                elements: {
+                  create: stack.elements.map((element) => ({
+                    elementType: element.elementType,
+                    migrationId: uuidv4(),
+                    order: element.order,
+                    type: DB.ElementInstanceType.PRACTICE_QUIZ,
+                    elementData: element.elementData,
+                    options: element.options,
+                    results: element.results,
+                    anonymousResults: element.anonymousResults,
+                    instanceStatistics: {
+                      create: getInitialInstanceStatistics(
+                        DB.ElementInstanceType.PRACTICE_QUIZ
+                      ),
+                    },
+                    element: {
+                      connect: { id: element.elementId },
+                    },
+                    owner: {
+                      connect: { id: ctx.user.sub },
+                    },
+                  })),
                 },
-              },
-              // templates from asynchronous activities are linked to the same course
-              course: {
-                connect: { id: practiceQuiz.courseId },
-              },
-              // creator of template becomes new owner of the template activity
-              owner: { connect: { id: ctx.user.sub } },
+              })),
             },
-          })
-
-          await recomputeDerivedPermissions(
-            {
-              practiceQuizId: template.id,
-              userId: ctx.user.sub,
+            // add template information
+            templateInfo: {
+              create: {
+                description: templateDescription,
+                instructions: templateInstructions,
+                answerCollections:
+                  answerCollectionIds.length > 0
+                    ? {
+                        connect: answerCollectionIds.map((id) => ({ id })),
+                      }
+                    : undefined,
+                answerCollectionItems:
+                  answerCollectionEntryIds.length > 0
+                    ? {
+                        connect: answerCollectionEntryIds.map((id) => ({
+                          id,
+                        })),
+                      }
+                    : undefined,
+              },
             },
-            prisma
-          )
+            // templates from asynchronous activities are linked to the same course
+            course: {
+              connect: { id: practiceQuiz.courseId },
+            },
+            // creator of template becomes new owner of the template activity
+            owner: { connect: { id: ctx.user.sub } },
+          },
+        })
 
-          return template
-        }
-      )
+        await recomputeDerivedPermissions(
+          {
+            practiceQuizId: template.id,
+            userId: ctx.user.sub,
+          },
+          prisma
+        )
+
+        return template
+      })
 
       return true
     } else if (activityType === ActivityType.MICRO_LEARNING) {
@@ -652,90 +650,88 @@ export async function createActivityTemplate(
         stacks: (DB.ElementStack & { elements: DB.ElementInstance[] })[]
       }
 
-      const microLearningTemplate = await ctx.prisma.$transaction(
-        async (prisma) => {
-          const template = await prisma.microLearning.create({
-            data: {
-              name: templateName,
-              displayName: microLearning.displayName,
-              description: microLearning.description,
-              status: DB.PublicationStatus.TEMPLATE,
-              pointsMultiplier: microLearning.pointsMultiplier,
-              scheduledStartAt: microLearning.scheduledStartAt,
-              scheduledEndAt: microLearning.scheduledEndAt,
-              // add stacks with elements
-              stacks: {
-                create: microLearning.stacks.map((stack) => ({
-                  type: DB.ElementStackType.MICROLEARNING,
-                  order: stack.order,
-                  displayName: stack.displayName,
-                  description: stack.description,
-                  elements: {
-                    create: stack.elements.map((element) => ({
-                      elementType: element.elementType,
-                      migrationId: uuidv4(),
-                      order: element.order,
-                      type: DB.ElementInstanceType.MICROLEARNING,
-                      elementData: element.elementData,
-                      options: element.options,
-                      results: element.results,
-                      anonymousResults: element.anonymousResults,
-                      instanceStatistics: {
-                        create: getInitialInstanceStatistics(
-                          DB.ElementInstanceType.MICROLEARNING
-                        ),
-                      },
-                      element: {
-                        connect: { id: element.elementId },
-                      },
-                      owner: {
-                        connect: { id: ctx.user.sub },
-                      },
-                    })),
-                  },
-                })),
-              },
-              // add template information
-              templateInfo: {
-                create: {
-                  description: templateDescription,
-                  instructions: templateInstructions,
-                  answerCollections:
-                    answerCollectionIds.length > 0
-                      ? {
-                          connect: answerCollectionIds.map((id) => ({ id })),
-                        }
-                      : undefined,
-                  answerCollectionItems:
-                    answerCollectionEntryIds.length > 0
-                      ? {
-                          connect: answerCollectionEntryIds.map((id) => ({
-                            id,
-                          })),
-                        }
-                      : undefined,
+      await ctx.prisma.$transaction(async (prisma) => {
+        const template = await prisma.microLearning.create({
+          data: {
+            name: templateName,
+            displayName: microLearning.displayName,
+            description: microLearning.description,
+            status: DB.PublicationStatus.TEMPLATE,
+            pointsMultiplier: microLearning.pointsMultiplier,
+            scheduledStartAt: microLearning.scheduledStartAt,
+            scheduledEndAt: microLearning.scheduledEndAt,
+            // add stacks with elements
+            stacks: {
+              create: microLearning.stacks.map((stack) => ({
+                type: DB.ElementStackType.MICROLEARNING,
+                order: stack.order,
+                displayName: stack.displayName,
+                description: stack.description,
+                elements: {
+                  create: stack.elements.map((element) => ({
+                    elementType: element.elementType,
+                    migrationId: uuidv4(),
+                    order: element.order,
+                    type: DB.ElementInstanceType.MICROLEARNING,
+                    elementData: element.elementData,
+                    options: element.options,
+                    results: element.results,
+                    anonymousResults: element.anonymousResults,
+                    instanceStatistics: {
+                      create: getInitialInstanceStatistics(
+                        DB.ElementInstanceType.MICROLEARNING
+                      ),
+                    },
+                    element: {
+                      connect: { id: element.elementId },
+                    },
+                    owner: {
+                      connect: { id: ctx.user.sub },
+                    },
+                  })),
                 },
-              },
-              // templates from asynchronous activities are linked to the same course
-              course: {
-                connect: { id: microLearning.courseId },
-              },
-              // creator of template becomes new owner of the template activity
-              owner: { connect: { id: ctx.user.sub } },
+              })),
             },
-          })
-
-          await recomputeDerivedPermissions(
-            {
-              microLearningId: template.id,
-              userId: ctx.user.sub,
+            // add template information
+            templateInfo: {
+              create: {
+                description: templateDescription,
+                instructions: templateInstructions,
+                answerCollections:
+                  answerCollectionIds.length > 0
+                    ? {
+                        connect: answerCollectionIds.map((id) => ({ id })),
+                      }
+                    : undefined,
+                answerCollectionItems:
+                  answerCollectionEntryIds.length > 0
+                    ? {
+                        connect: answerCollectionEntryIds.map((id) => ({
+                          id,
+                        })),
+                      }
+                    : undefined,
+              },
             },
-            prisma
-          )
+            // templates from asynchronous activities are linked to the same course
+            course: {
+              connect: { id: microLearning.courseId },
+            },
+            // creator of template becomes new owner of the template activity
+            owner: { connect: { id: ctx.user.sub } },
+          },
+        })
 
-          return template
-        }
-      )
+        await recomputeDerivedPermissions(
+          {
+            microLearningId: template.id,
+            userId: ctx.user.sub,
+          },
+          prisma
+        )
+
+        return template
+      })
 
       return true
     } else if (activityType === ActivityType.GROUP_ACTIVITY) {
@@ -748,103 +744,101 @@ export async function createActivityTemplate(
         clues: DB.GroupActivityClue[]
       }
 
-      const groupActivityTemplate = await ctx.prisma.$transaction(
-        async (prisma) => {
-          const template = await prisma.groupActivity.create({
-            data: {
-              name: templateName,
-              displayName: groupActivity.displayName,
-              description: groupActivity.description,
-              status: DB.PublicationStatus.TEMPLATE,
-              pointsMultiplier: groupActivity.pointsMultiplier,
-              scheduledStartAt: groupActivity.scheduledStartAt,
-              scheduledEndAt: groupActivity.scheduledEndAt,
-              // copy parameters and clues
-              parameters: {
-                create: groupActivity.parameters,
-              },
-              clues: {
-                create: groupActivity.clues,
-              },
-              // add stacks with elements
-              stacks: {
-                create: groupActivity.stacks.map((stack) => ({
-                  type: DB.ElementStackType.GROUP_ACTIVITY,
-                  order: stack.order,
-                  displayName: stack.displayName,
-                  description: stack.description,
-                  elements: {
-                    create: stack.elements.map((element) => ({
-                      elementType: element.elementType,
-                      migrationId: uuidv4(),
-                      order: element.order,
-                      type: DB.ElementInstanceType.GROUP_ACTIVITY,
-                      elementData: element.elementData,
-                      options: element.options,
-                      results: element.results,
-                      anonymousResults: element.anonymousResults,
-                      instanceStatistics: {
-                        create: getInitialInstanceStatistics(
-                          DB.ElementInstanceType.GROUP_ACTIVITY
-                        ),
-                      },
-                      element: {
-                        connect: { id: element.elementId },
-                      },
-                      owner: {
-                        connect: { id: ctx.user.sub },
-                      },
-                    })),
-                  },
-                })),
-              },
-              // add template information
-              templateInfo: {
-                create: {
-                  description: templateDescription,
-                  instructions: templateInstructions,
-                  answerCollections:
-                    answerCollectionIds.length > 0
-                      ? {
-                          connect: answerCollectionIds.map((id) => ({ id })),
-                        }
-                      : undefined,
-                  answerCollectionItems:
-                    answerCollectionEntryIds.length > 0
-                      ? {
-                          connect: answerCollectionEntryIds.map((id) => ({
-                            id,
-                          })),
-                        }
-                      : undefined,
+      await ctx.prisma.$transaction(async (prisma) => {
+        const template = await prisma.groupActivity.create({
+          data: {
+            name: templateName,
+            displayName: groupActivity.displayName,
+            description: groupActivity.description,
+            status: DB.PublicationStatus.TEMPLATE,
+            pointsMultiplier: groupActivity.pointsMultiplier,
+            scheduledStartAt: groupActivity.scheduledStartAt,
+            scheduledEndAt: groupActivity.scheduledEndAt,
+            // copy parameters and clues
+            parameters: {
+              create: groupActivity.parameters,
+            },
+            clues: {
+              create: groupActivity.clues,
+            },
+            // add stacks with elements
+            stacks: {
+              create: groupActivity.stacks.map((stack) => ({
+                type: DB.ElementStackType.GROUP_ACTIVITY,
+                order: stack.order,
+                displayName: stack.displayName,
+                description: stack.description,
+                elements: {
+                  create: stack.elements.map((element) => ({
+                    elementType: element.elementType,
+                    migrationId: uuidv4(),
+                    order: element.order,
+                    type: DB.ElementInstanceType.GROUP_ACTIVITY,
+                    elementData: element.elementData,
+                    options: element.options,
+                    results: element.results,
+                    anonymousResults: element.anonymousResults,
+                    instanceStatistics: {
+                      create: getInitialInstanceStatistics(
+                        DB.ElementInstanceType.GROUP_ACTIVITY
+                      ),
+                    },
+                    element: {
+                      connect: { id: element.elementId },
+                    },
+                    owner: {
+                      connect: { id: ctx.user.sub },
+                    },
+                  })),
                 },
-              },
-              // templates from asynchronous activities are linked to the same course
-              course: {
-                connect: { id: groupActivity.courseId },
-              },
-              // creator of template becomes new owner of the template activity
-              owner: { connect: { id: ctx.user.sub } },
+              })),
             },
-          })
-
-          await recomputeDerivedPermissions(
-            {
-              groupActivityId: template.id,
-              userId: ctx.user.sub,
+            // add template information
+            templateInfo: {
+              create: {
+                description: templateDescription,
+                instructions: templateInstructions,
+                answerCollections:
+                  answerCollectionIds.length > 0
+                    ? {
+                        connect: answerCollectionIds.map((id) => ({ id })),
+                      }
+                    : undefined,
+                answerCollectionItems:
+                  answerCollectionEntryIds.length > 0
+                    ? {
+                        connect: answerCollectionEntryIds.map((id) => ({
+                          id,
+                        })),
+                      }
+                    : undefined,
+              },
             },
-            prisma
-          )
+            // templates from asynchronous activities are linked to the same course
+            course: {
+              connect: { id: groupActivity.courseId },
+            },
+            // creator of template becomes new owner of the template activity
+            owner: { connect: { id: ctx.user.sub } },
+          },
+        })
 
-          return template
-        }
-      )
+        await recomputeDerivedPermissions(
+          {
+            groupActivityId: template.id,
+            userId: ctx.user.sub,
+          },
+          prisma
+        )
+
+        return template
+      })
 
       return true
     }
   } else {
     // create new template with the provided information and update activity status in a transaction
-    const template = await ctx.prisma.$transaction(async (tx) => {
+    await ctx.prisma.$transaction(async (tx) => {
       const newTemplate = await tx.activityTemplate.create({
         data: {
           description: templateDescription,
@@ -965,22 +959,25 @@ export async function deleteActivityTemplate(
       return null
     }
 
-    const deletedId = await ctx.prisma.$transaction(async (prisma) => {
-      const deletedLiveQuiz = await prisma.liveQuiz.delete({
-        where: {
-          id: activityId,
-        },
-      })
+    const deletedId = await ctx.prisma.$transaction(
+      async (prisma) => {
+        const deletedLiveQuiz = await prisma.liveQuiz.delete({
+          where: {
+            id: activityId,
+          },
+        })
 
-      // update derived permissions on all linked elements
-      // access requests need to be updated as well, since the derived permissions on elements might have changed
-      await propagateActivityToElements(
-        { stacks: liveQuiz.blocks, updateAccessRequests: true },
-        prisma
-      )
+        // update derived permissions on all linked elements
+        // access requests need to be updated as well, since the derived permissions on elements might have changed
+        await propagateActivityToElements(
+          { stacks: liveQuiz.blocks, updateAccessRequests: true },
+          prisma
+        )
 
-      return deletedLiveQuiz.id
-    })
+        return deletedLiveQuiz.id
+      },
+      { timeout: 60000 }
+    )
 
     return deletedId
   } else if (activityType === ActivityType.PRACTICE_QUIZ) {
@@ -1003,22 +1000,25 @@ export async function deleteActivityTemplate(
       return null
     }
 
-    const deletedId = await ctx.prisma.$transaction(async (prisma) => {
-      const deletedPracticeQuiz = await prisma.practiceQuiz.delete({
-        where: {
-          id: activityId,
-        },
-      })
+    const deletedId = await ctx.prisma.$transaction(
+      async (prisma) => {
+        const deletedPracticeQuiz = await prisma.practiceQuiz.delete({
+          where: {
+            id: activityId,
+          },
+        })
 
-      // update derived permissions on all linked elements
-      // access requests need to be updated as well, since the derived permissions on elements might have changed
-      await propagateActivityToElements(
-        { stacks: practiceQuiz.stacks, updateAccessRequests: true },
-        prisma
-      )
+        // update derived permissions on all linked elements
+        // access requests need to be updated as well, since the derived permissions on elements might have changed
+        await propagateActivityToElements(
+          { stacks: practiceQuiz.stacks, updateAccessRequests: true },
+          prisma
+        )
 
-      return deletedPracticeQuiz.id
-    })
+        return deletedPracticeQuiz.id
+      },
+      { timeout: 60000 }
+    )
 
     return deletedId
   } else if (activityType === ActivityType.MICRO_LEARNING) {
@@ -1041,22 +1041,25 @@ export async function deleteActivityTemplate(
       return null
     }
 
-    const deletedId = await ctx.prisma.$transaction(async (prisma) => {
-      const deletedMicroLearning = await prisma.microLearning.delete({
-        where: {
-          id: activityId,
-        },
-      })
+    const deletedId = await ctx.prisma.$transaction(
+      async (prisma) => {
+        const deletedMicroLearning = await prisma.microLearning.delete({
+          where: {
+            id: activityId,
+          },
+        })
 
-      // update derived permissions on all linked elements
-      // access requests need to be updated as well, since the derived permissions on elements might have changed
-      await propagateActivityToElements(
-        { stacks: microLearning.stacks, updateAccessRequests: true },
-        prisma
-      )
+        // update derived permissions on all linked elements
+        // access requests need to be updated as well, since the derived permissions on elements might have changed
+        await propagateActivityToElements(
+          { stacks: microLearning.stacks, updateAccessRequests: true },
+          prisma
+        )
 
-      return deletedMicroLearning.id
-    })
+        return deletedMicroLearning.id
+      },
+      { timeout: 60000 }
+    )
 
     return deletedId
   } else if (activityType === ActivityType.GROUP_ACTIVITY) {
@@ -1079,22 +1082,25 @@ export async function deleteActivityTemplate(
       return null
     }
 
-    const deletedId = await ctx.prisma.$transaction(async (prisma) => {
-      const deletedGroupActivity = await prisma.groupActivity.delete({
-        where: {
-          id: activityId,
-        },
-      })
+    const deletedId = await ctx.prisma.$transaction(
+      async (prisma) => {
+        const deletedGroupActivity = await prisma.groupActivity.delete({
+          where: {
+            id: activityId,
+          },
+        })
 
-      // update derived permissions on all linked elements
-      // access requests need to be updated as well, since the derived permissions on elements might have changed
-      await propagateActivityToElements(
-        { stacks: groupActivity.stacks, updateAccessRequests: true },
-        prisma
-      )
+        // update derived permissions on all linked elements
+        // access requests need to be updated as well, since the derived permissions on elements might have changed
+        await propagateActivityToElements(
+          { stacks: groupActivity.stacks, updateAccessRequests: true },
+          prisma
+        )
 
-      return deletedGroupActivity.id
-    })
+        return deletedGroupActivity.id
+      },
+      { timeout: 60000 }
+    )
 
     return deletedId
   }
@@ -1209,7 +1215,7 @@ export async function editActivityTemplate(
 ) {
   try {
     // update the metadata of the template and activity name in a transaction
-    const newTemplate = await ctx.prisma.$transaction(async (tx) => {
+    await ctx.prisma.$transaction(async (tx) => {
       // update the template metadata
       const updatedTemplate = await tx.activityTemplate.update({
         where: {
@@ -1561,337 +1567,345 @@ export async function createLiveQuizFromTemplate(
   }
 
   // inside a prisma transaction, create all required elements, permissions and the activity
-  const newLiveQuiz = await ctx.prisma.$transaction(async (prisma) => {
-    const liveQuizContent: {
-      blocks: {
-        order: number
-        timeLimit?: number | null
-        elements: {
+  const newLiveQuiz = await ctx.prisma.$transaction(
+    async (prisma) => {
+      const liveQuizContent: {
+        blocks: {
           order: number
-          element: DB.Element
+          timeLimit?: number | null
+          elements: {
+            order: number
+            element: DB.Element
+          }[]
         }[]
-      }[]
-    } = { blocks: [] }
+      } = { blocks: [] }
 
-    // iterate over all blocks and either fetch the existing element from the database or create a new one
-    for (const block of blocks) {
-      const elements: {
-        order: number
-        element: DB.Element & {
-          answerCollection?:
-            | (DB.AnswerCollection & { entries: DB.AnswerCollectionEntry[] })
-            | null
-          answerCollectionItems?: DB.AnswerCollectionEntry[] | null
-        }
-      }[] = []
-      for (const element of block.elements) {
-        if (element.useExistingElement) {
-          if (
-            element.existingElementId === null ||
-            typeof element.existingElementId === 'undefined'
-          ) {
-            throw new Error('Existing element id not provided')
+      // iterate over all blocks and either fetch the existing element from the database or create a new one
+      for (const block of blocks) {
+        const elements: {
+          order: number
+          element: DB.Element & {
+            answerCollection?:
+              | (DB.AnswerCollection & { entries: DB.AnswerCollectionEntry[] })
+              | null
+            answerCollectionItems?: DB.AnswerCollectionEntry[] | null
           }
-
-          // find existing element in user account
-          const existingElement = await prisma.element.findUnique({
-            where: {
-              id: element.existingElementId,
-              permissions: {
-                some: {
-                  userId: ctx.user.sub,
-                },
-              },
-            },
-            include: {
-              answerCollection: {
-                include: {
-                  entries: true,
-                },
-              },
-              answerCollectionItems: true,
-            },
-          })
-
-          if (!existingElement) {
-            console.log(
-              'Failed to find element with id',
-              element.existingElementId
-            )
-            throw new Error(
-              'Existing element does not exist or user does not have access to it'
-            )
-          }
-
-          // add existing element to content map
-          elements.push({
-            order: element.order,
-            element: existingElement,
-          })
-        } else if (element.useNewElement) {
-          if (
-            element.newElement === null ||
-            typeof element.newElement === 'undefined'
-          ) {
-            throw new Error('New element data not provided')
-          }
-
-          // set the options element options value depending on the element type
-          const values = element.newElement
-          if (
-            values.type === DB.ElementType.SC ||
-            values.type === DB.ElementType.MC ||
-            values.type === DB.ElementType.KPRIM
-          ) {
-            if (!('choicesOptions' in values)) {
-              throw new Error(
-                'Choices options not provided for Choices element'
-              )
-            }
-
-            values.options = values.choicesOptions
-          } else if (values.type === DB.ElementType.NUMERICAL) {
-            if (!('numericalOptions' in values)) {
-              throw new Error(
-                'Numerical options not provided for Numerical element'
-              )
-            }
-
-            values.options = values.numericalOptions
-          } else if (values.type === DB.ElementType.FREE_TEXT) {
-            if (!('freeTextOptions' in values)) {
-              throw new Error(
-                'Free text options not provided for Free Text element'
-              )
-            }
-
-            values.options = values.freeTextOptions
-          } else if (values.type === DB.ElementType.SELECTION) {
-            if (!('selectionOptions' in values)) {
-              throw new Error(
-                'Selection options not provided for Selection element'
-              )
-            }
-
-            values.options = values.selectionOptions
-          } else if (values.type === DB.ElementType.CASE_STUDY) {
-            if (!('caseStudyOptions' in values)) {
-              throw new Error(
-                'Case study options not provided for Case Study element'
-              )
-            }
-
-            values.options = values.caseStudyOptions
-          }
-
-          // check if the user has access to potential answer collections linked to the new element or if they are contained in the template
-          if (
-            values.type === DB.ElementType.SELECTION ||
-            values.type === DB.ElementType.CASE_STUDY
-          ) {
+        }[] = []
+        for (const element of block.elements) {
+          if (element.useExistingElement) {
             if (
-              !('options' in values) ||
-              !values.options ||
-              !('answerCollection' in values.options) ||
-              typeof values.options?.answerCollection === 'undefined' ||
-              values.options.answerCollection === null
+              element.existingElementId === null ||
+              typeof element.existingElementId === 'undefined'
             ) {
-              throw new Error(
-                'Answer collection not provided for selection or case study element'
-              )
+              throw new Error('Existing element id not provided')
             }
 
-            // get answer collection id that should be linked to the new element
-            const answerCollectionId = values.options.answerCollection
-
-            // check if the user already has access to the answer collection
-            const valid = await checkAccess(
-              [
-                {
-                  answerCollectionId: answerCollectionId,
-                  minimumPermissionLevel: DB.PermissionLevel.READ,
-                },
-              ],
-              { ...ctx, prisma }
-            )
-
-            if (!valid) {
-              // if access does not already exist, check if the answer collection is linked to the template
-              if (!availableAnswerCollections.includes(answerCollectionId)) {
-                throw new Error(
-                  'User does not have access to the answer collection linked to the template'
-                )
-              }
-
-              // otherwise, grant new direct READ permission for the user on the answer collection
-              await prisma.permission.upsert({
-                where: {
-                  answerCollectionId_userId: {
-                    answerCollectionId,
+            // find existing element in user account
+            const existingElement = await prisma.element.findUnique({
+              where: {
+                id: element.existingElementId,
+                permissions: {
+                  some: {
                     userId: ctx.user.sub,
                   },
                 },
-                create: {
-                  permissionLevel: DB.PermissionLevel.READ,
-                  user: {
-                    connect: { id: ctx.user.sub },
-                  },
-                  answerCollection: {
-                    connect: { id: answerCollectionId },
-                  },
-                },
-                update: {},
-              })
-            }
-          }
-
-          // combine the element options depending on the element type
-          let options: ElementOptionsInput | undefined | null = undefined
-          if (
-            values.type === DB.ElementType.SC ||
-            values.type === DB.ElementType.MC ||
-            values.type === DB.ElementType.KPRIM
-          ) {
-            options = values.choicesOptions
-          } else if (values.type === DB.ElementType.NUMERICAL) {
-            options = values.numericalOptions
-          } else if (values.type === DB.ElementType.FREE_TEXT) {
-            options = values.freeTextOptions
-          } else if (values.type === DB.ElementType.SELECTION) {
-            options = values.selectionOptions
-          } else if (values.type === DB.ElementType.CASE_STUDY) {
-            options = values.caseStudyOptions
-          }
-
-          // create a new element based on the provided data
-          const createdElement = await manipulateQuestion(
-            { ...values, options, templateId },
-            { ...ctx, prisma }
-          )
-
-          // throw an error if the element could not be created
-          if (!createdElement) {
-            console.log('Failed to create new element from form inputs', values)
-            throw new Error('Failed to create new element')
-          }
-
-          // TODO: make this a bit more efficient by not fetching the just created element again
-          // re-fetch the created element including the answer collection and corresponding entries
-          const newElement = await prisma.element.findUnique({
-            where: {
-              id: createdElement.id,
-              ownerId: ctx.user.sub,
-            },
-            include: {
-              answerCollection: {
-                include: {
-                  entries: true,
-                },
               },
-              answerCollectionItems: true,
-            },
-          })
+              include: {
+                answerCollection: {
+                  include: {
+                    entries: true,
+                  },
+                },
+                answerCollectionItems: true,
+              },
+            })
 
-          if (!newElement) {
-            console.log('Failed to fetch newly created element')
-            throw new Error('Failed to fetch newly created element')
-          }
+            if (!existingElement) {
+              console.log(
+                'Failed to find element with id',
+                element.existingElementId
+              )
+              throw new Error(
+                'Existing element does not exist or user does not have access to it'
+              )
+            }
 
-          elements.push({
-            order: element.order,
-            element: newElement,
-          })
-        } else {
-          // no option was selected for one of the elements -> invalid input
-          throw new Error('Invalid template element modification choice')
-        }
-      }
+            // add existing element to content map
+            elements.push({
+              order: element.order,
+              element: existingElement,
+            })
+          } else if (element.useNewElement) {
+            if (
+              element.newElement === null ||
+              typeof element.newElement === 'undefined'
+            ) {
+              throw new Error('New element data not provided')
+            }
 
-      liveQuizContent.blocks.push({
-        order: block.order,
-        timeLimit: block.timeLimit,
-        elements,
-      })
-    }
+            // set the options element options value depending on the element type
+            const values = element.newElement
+            if (
+              values.type === DB.ElementType.SC ||
+              values.type === DB.ElementType.MC ||
+              values.type === DB.ElementType.KPRIM
+            ) {
+              if (!('choicesOptions' in values)) {
+                throw new Error(
+                  'Choices options not provided for Choices element'
+                )
+              }
 
-    const quiz = await prisma.liveQuiz.create({
-      data: {
-        name: name.trim(),
-        displayName: displayName.trim(),
-        description,
-        templateName: templateLiveQuiz.name,
-        pointsMultiplier: templateLiveQuiz.pointsMultiplier,
-        defaultPoints: templateLiveQuiz.defaultPoints,
-        defaultCorrectPoints: templateLiveQuiz.defaultCorrectPoints,
-        maxBonusPoints: templateLiveQuiz.maxBonusPoints,
-        timeToZeroBonus: templateLiveQuiz.timeToZeroBonus,
-        isGamificationEnabled: isGamificationEnabled,
-        isConfusionFeedbackEnabled: templateLiveQuiz.isConfusionFeedbackEnabled,
-        isLiveQAEnabled: templateLiveQuiz.isLiveQAEnabled,
-        isModerationEnabled: templateLiveQuiz.isModerationEnabled,
-        blocks: {
-          create: liveQuizContent.blocks.map((block) => {
-            return {
-              order: block.order,
-              timeLimit: block.timeLimit,
-              elements: {
-                create: block.elements.map((entry) => {
-                  const elementData = processElementData(entry.element)
-                  const initialResults = getInitialInstanceResults(elementData)
+              values.options = values.choicesOptions
+            } else if (values.type === DB.ElementType.NUMERICAL) {
+              if (!('numericalOptions' in values)) {
+                throw new Error(
+                  'Numerical options not provided for Numerical element'
+                )
+              }
 
-                  return {
-                    elementType: entry.element.type,
-                    migrationId: uuidv4(),
-                    order: entry.order,
-                    type: DB.ElementInstanceType.LIVE_QUIZ,
-                    elementData,
-                    options: {
-                      basePoints: entry.element.basePoints,
-                      pointsMultiplier:
-                        templateLiveQuiz.pointsMultiplier *
-                        entry.element.pointsMultiplier,
+              values.options = values.numericalOptions
+            } else if (values.type === DB.ElementType.FREE_TEXT) {
+              if (!('freeTextOptions' in values)) {
+                throw new Error(
+                  'Free text options not provided for Free Text element'
+                )
+              }
+
+              values.options = values.freeTextOptions
+            } else if (values.type === DB.ElementType.SELECTION) {
+              if (!('selectionOptions' in values)) {
+                throw new Error(
+                  'Selection options not provided for Selection element'
+                )
+              }
+
+              values.options = values.selectionOptions
+            } else if (values.type === DB.ElementType.CASE_STUDY) {
+              if (!('caseStudyOptions' in values)) {
+                throw new Error(
+                  'Case study options not provided for Case Study element'
+                )
+              }
+
+              values.options = values.caseStudyOptions
+            }
+
+            // check if the user has access to potential answer collections linked to the new element or if they are contained in the template
+            if (
+              values.type === DB.ElementType.SELECTION ||
+              values.type === DB.ElementType.CASE_STUDY
+            ) {
+              if (
+                !('options' in values) ||
+                !values.options ||
+                !('answerCollection' in values.options) ||
+                typeof values.options?.answerCollection === 'undefined' ||
+                values.options.answerCollection === null
+              ) {
+                throw new Error(
+                  'Answer collection not provided for selection or case study element'
+                )
+              }
+
+              // get answer collection id that should be linked to the new element
+              const answerCollectionId = values.options.answerCollection
+
+              // check if the user already has access to the answer collection
+              const valid = await checkAccess(
+                [
+                  {
+                    answerCollectionId: answerCollectionId,
+                    minimumPermissionLevel: DB.PermissionLevel.READ,
+                  },
+                ],
+                { ...ctx, prisma }
+              )
+
+              if (!valid) {
+                // if access does not already exist, check if the answer collection is linked to the template
+                if (!availableAnswerCollections.includes(answerCollectionId)) {
+                  throw new Error(
+                    'User does not have access to the answer collection linked to the template'
+                  )
+                }
+
+                // otherwise, grant new direct READ permission for the user on the answer collection
+                await prisma.permission.upsert({
+                  where: {
+                    answerCollectionId_userId: {
+                      answerCollectionId,
+                      userId: ctx.user.sub,
                     },
-                    results: initialResults,
-                    anonymousResults: initialResults,
-                    instanceStatistics: {
-                      create: getInitialInstanceStatistics(
-                        DB.ElementInstanceType.LIVE_QUIZ
-                      ),
-                    },
-                    element: {
-                      connect: { id: entry.element.id },
-                    },
-                    owner: {
+                  },
+                  create: {
+                    permissionLevel: DB.PermissionLevel.READ,
+                    user: {
                       connect: { id: ctx.user.sub },
                     },
-                  }
-                }),
-              },
-            }
-          }),
-        },
-        owner: {
-          connect: { id: ctx.user.sub },
-        },
-        course:
-          typeof courseId === 'string' &&
-          courseId !== null &&
-          uuidValidate(courseId)
-            ? {
-                connect: { id: courseId },
+                    answerCollection: {
+                      connect: { id: answerCollectionId },
+                    },
+                  },
+                  update: {},
+                })
               }
-            : undefined,
-      },
-    })
+            }
 
-    // trigger recomputation of the derived permissions for the new activity
-    await recomputeDerivedPermissions(
-      { liveQuizId: quiz.id, userId: ctx.user.sub },
-      prisma
-    )
+            // combine the element options depending on the element type
+            let options: ElementOptionsInput | undefined | null = undefined
+            if (
+              values.type === DB.ElementType.SC ||
+              values.type === DB.ElementType.MC ||
+              values.type === DB.ElementType.KPRIM
+            ) {
+              options = values.choicesOptions
+            } else if (values.type === DB.ElementType.NUMERICAL) {
+              options = values.numericalOptions
+            } else if (values.type === DB.ElementType.FREE_TEXT) {
+              options = values.freeTextOptions
+            } else if (values.type === DB.ElementType.SELECTION) {
+              options = values.selectionOptions
+            } else if (values.type === DB.ElementType.CASE_STUDY) {
+              options = values.caseStudyOptions
+            }
 
-    return quiz
-  })
+            // create a new element based on the provided data
+            const createdElement = await manipulateQuestion(
+              { ...values, options, templateId },
+              { ...ctx, prisma }
+            )
+
+            // throw an error if the element could not be created
+            if (!createdElement) {
+              console.log(
+                'Failed to create new element from form inputs',
+                values
+              )
+              throw new Error('Failed to create new element')
+            }
+
+            // TODO: make this a bit more efficient by not fetching the just created element again
+            // re-fetch the created element including the answer collection and corresponding entries
+            const newElement = await prisma.element.findUnique({
+              where: {
+                id: createdElement.id,
+                ownerId: ctx.user.sub,
+              },
+              include: {
+                answerCollection: {
+                  include: {
+                    entries: true,
+                  },
+                },
+                answerCollectionItems: true,
+              },
+            })
+
+            if (!newElement) {
+              console.log('Failed to fetch newly created element')
+              throw new Error('Failed to fetch newly created element')
+            }
+
+            elements.push({
+              order: element.order,
+              element: newElement,
+            })
+          } else {
+            // no option was selected for one of the elements -> invalid input
+            throw new Error('Invalid template element modification choice')
+          }
+        }
+
+        liveQuizContent.blocks.push({
+          order: block.order,
+          timeLimit: block.timeLimit,
+          elements,
+        })
+      }
+
+      const quiz = await prisma.liveQuiz.create({
+        data: {
+          name: name.trim(),
+          displayName: displayName.trim(),
+          description,
+          templateName: templateLiveQuiz.name,
+          pointsMultiplier: templateLiveQuiz.pointsMultiplier,
+          defaultPoints: templateLiveQuiz.defaultPoints,
+          defaultCorrectPoints: templateLiveQuiz.defaultCorrectPoints,
+          maxBonusPoints: templateLiveQuiz.maxBonusPoints,
+          timeToZeroBonus: templateLiveQuiz.timeToZeroBonus,
+          isGamificationEnabled: isGamificationEnabled,
+          isConfusionFeedbackEnabled:
+            templateLiveQuiz.isConfusionFeedbackEnabled,
+          isLiveQAEnabled: templateLiveQuiz.isLiveQAEnabled,
+          isModerationEnabled: templateLiveQuiz.isModerationEnabled,
+          blocks: {
+            create: liveQuizContent.blocks.map((block) => {
+              return {
+                order: block.order,
+                timeLimit: block.timeLimit,
+                elements: {
+                  create: block.elements.map((entry) => {
+                    const elementData = processElementData(entry.element)
+                    const initialResults =
+                      getInitialInstanceResults(elementData)
+
+                    return {
+                      elementType: entry.element.type,
+                      migrationId: uuidv4(),
+                      order: entry.order,
+                      type: DB.ElementInstanceType.LIVE_QUIZ,
+                      elementData,
+                      options: {
+                        basePoints: entry.element.basePoints,
+                        pointsMultiplier:
+                          templateLiveQuiz.pointsMultiplier *
+                          entry.element.pointsMultiplier,
+                      },
+                      results: initialResults,
+                      anonymousResults: initialResults,
+                      instanceStatistics: {
+                        create: getInitialInstanceStatistics(
+                          DB.ElementInstanceType.LIVE_QUIZ
+                        ),
+                      },
+                      element: {
+                        connect: { id: entry.element.id },
+                      },
+                      owner: {
+                        connect: { id: ctx.user.sub },
+                      },
+                    }
+                  }),
+                },
+              }
+            }),
+          },
+          owner: {
+            connect: { id: ctx.user.sub },
+          },
+          course:
+            typeof courseId === 'string' &&
+            courseId !== null &&
+            uuidValidate(courseId)
+              ? {
+                  connect: { id: courseId },
+                }
+              : undefined,
+        },
+      })
+
+      // trigger recomputation of the derived permissions for the new activity
+      await recomputeDerivedPermissions(
+        { liveQuizId: quiz.id, userId: ctx.user.sub },
+        prisma
+      )
+
+      return quiz
+    },
+    { timeout: 60000 }
+  )
 
   return newLiveQuiz.id
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- URLs in user interface instructions are now clickable links that open in a new tab for improved accessibility.

- **Chores**
	- Added a 60-second timeout to various database transactions to enhance reliability and prevent long-running operations across several features, including courses, groups, quizzes, microlearning, questions, resources, and templates.
	- Cleaned up unused variable assignments in transaction calls for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->