### PR TITLE
fix: ensure that users cannot share objects with themselves

### DIFF
--- a/apps/frontend-manage/src/components/sharing/DirectSharingForm.tsx
+++ b/apps/frontend-manage/src/components/sharing/DirectSharingForm.tsx
@@ -4,6 +4,7 @@ import {
   GetUserGroupsUserDocument,
   ObjectType,
   PermissionLevel,
+  UserProfileDocument,
 } from '@klicker-uzh/graphql/dist/ops'
 import {
   Button,
@@ -11,6 +12,7 @@ import {
   FormikSwitchField,
   SelectField,
   TextField,
+  toast,
 } from '@uzh-bf/design-system'
 import { Formik } from 'formik'
 import { useTranslations } from 'next-intl'
@@ -22,14 +24,10 @@ import usePermissionLevelSelection from '../../lib/hooks/usePermissionLevelSelec
 function DirectSharingForm({
   type,
   showPropagationSetting,
-  onSuccess,
-  onFailure,
   shareObjectCallback,
 }: {
   type: ObjectType
   showPropagationSetting: boolean
-  onSuccess: () => void
-  onFailure: () => void
   shareObjectCallback: ({
     shortnameOrEmail,
     userGroupId,
@@ -47,6 +45,18 @@ function DirectSharingForm({
   const { data, loading } = useQuery(GetUserGroupsUserDocument, {
     fetchPolicy: 'cache-and-network',
   })
+
+  // fetch own user to disable sharing with self
+  const { data: user } = useQuery(UserProfileDocument, {
+    fetchPolicy: 'cache-only',
+  })
+
+  const onFailure = () =>
+    toast({
+      type: 'error',
+      message: t('manage.sharing.sharingFailed'),
+      options: { duration: 3000 },
+    })
 
   return (
     <Formik
@@ -82,10 +92,6 @@ function DirectSharingForm({
 
           if (success) {
             resetForm()
-            onSuccess()
-            setSubmitting(false)
-          } else {
-            onFailure()
             setSubmitting(false)
           }
         } else {
@@ -94,14 +100,29 @@ function DirectSharingForm({
         }
       }}
       validationSchema={Yup.object().shape({
-        shortnameOrEmail: Yup.string().test(
-          'either-shortname-or-group',
-          t('manage.sharing.shortnameEmailOrGroupRequired'),
-          function (value) {
-            // if userGroupId exists in the parent, this field can be empty
-            return this.parent.userGroupId || (!!value && value !== '')
-          }
-        ),
+        shortnameOrEmail: Yup.string()
+          .test(
+            'either-shortname-or-group',
+            t('manage.sharing.shortnameEmailOrGroupRequired'),
+            function (value) {
+              // if userGroupId exists in the parent, this field can be empty
+              return this.parent.userGroupId || (!!value && value !== '')
+            }
+          )
+          .test(
+            'not-self',
+            t('manage.sharing.noSelfSharing'),
+            function (value) {
+              // check if the user is trying to share with themselves
+              if (value && user?.userProfile) {
+                return (
+                  value.toLowerCase() !==
+                  user.userProfile.shortname.toLowerCase()
+                )
+              }
+              return true
+            }
+          ),
         userGroupId: Yup.number().test(
           'either-group-or-shortname',
           t('manage.sharing.shortnameEmailOrGroupRequired'),
@@ -120,9 +141,12 @@ function DirectSharingForm({
     >
       {({
         values,
+        errors,
+        touched,
         isSubmitting,
         isValid,
         setFieldValue,
+        setFieldTouched,
         submitForm,
         validateForm,
       }) => (
@@ -130,9 +154,12 @@ function DirectSharingForm({
           <td className="px-4 py-3 text-sm text-gray-900">
             <TextField
               value={values.shortnameOrEmail || ''}
+              error={errors.shortnameOrEmail}
+              isTouched={touched.shortnameOrEmail}
               onChange={(newValue) => {
                 setFieldValue('shortnameOrEmail', newValue)
                 setFieldValue('userGroupId', undefined)
+                setFieldTouched('shortnameOrEmail', true)
 
                 // manually trigger form re-validation (otherwise lacks one step behind)
                 setTimeout(() => {

--- a/apps/frontend-manage/src/components/sharing/GrantedPermissionsTable.tsx
+++ b/apps/frontend-manage/src/components/sharing/GrantedPermissionsTable.tsx
@@ -19,8 +19,6 @@ function GrantedPermissionsTable({
   showPropagationSetting,
   onPermissionLevelChange,
   onPermissionRemoval,
-  onSharingSuccess,
-  onSharingFailure,
   onOwnershipTransfer,
   shareObjectCallback,
 }: {
@@ -40,8 +38,6 @@ function GrantedPermissionsTable({
     newPropagation: boolean
   }) => Promise<void>
   onPermissionRemoval: (permissionId: number) => Promise<void>
-  onSharingSuccess: () => void
-  onSharingFailure: () => void
   onOwnershipTransfer: () => void
   shareObjectCallback: ({
     shortnameOrEmail,
@@ -119,8 +115,6 @@ function GrantedPermissionsTable({
               <DirectSharingForm
                 type={type}
                 showPropagationSetting={showPropagationSetting}
-                onSuccess={onSharingSuccess}
-                onFailure={onSharingFailure}
                 shareObjectCallback={shareObjectCallback}
               />
             </>

--- a/apps/frontend-manage/src/components/sharing/ObjectSharingModal.tsx
+++ b/apps/frontend-manage/src/components/sharing/ObjectSharingModal.tsx
@@ -35,6 +35,13 @@ function ObjectSharingModal({
   const t = useTranslations()
   const [showDerivedPermissions, setShowDerivedPermissions] = useState(false)
 
+  const onSharingSuccess = () =>
+    toast({
+      type: 'success',
+      message: t('manage.sharing.sharingSuccessful'),
+      options: { duration: 3000 },
+    })
+
   const onSharingFailure = () =>
     toast({
       type: 'error',
@@ -90,10 +97,11 @@ function ObjectSharingModal({
     })
 
   // mutation to create new permission entry for answer collection
-  const { onShareObject, objectSharing } = useObjectSharing({
+  const { onShareObject } = useObjectSharing({
     objectId,
     objectType,
     catalogCollectionId,
+    onSuccess: () => onSharingSuccess(),
     onError: () => onSharingFailure(),
   })
 
@@ -157,14 +165,6 @@ function ObjectSharingModal({
             }
           }}
           shareObjectCallback={async (values) => await onShareObject(values)}
-          onSharingSuccess={() =>
-            toast({
-              type: 'success',
-              message: t('manage.sharing.sharingSuccessful'),
-              options: { duration: 3000 },
-            })
-          }
-          onSharingFailure={() => onSharingFailure()}
           onOwnershipTransfer={onOwnershipTransfer}
         />
       </div>

--- a/apps/frontend-manage/src/components/sharing/useObjectSharing.ts
+++ b/apps/frontend-manage/src/components/sharing/useObjectSharing.ts
@@ -15,11 +15,13 @@ function useObjectSharing({
   objectId,
   objectType,
   catalogCollectionId,
+  onSuccess,
   onError,
 }: {
   objectId: string | number
   objectType: ObjectType
   catalogCollectionId?: string
+  onSuccess?: () => void
   onError: () => void
 }): {
   onShareObject: ({
@@ -111,6 +113,7 @@ function useObjectSharing({
       })
 
       if (typeof res?.data?.shareObject?.permissionId !== 'undefined') {
+        onSuccess?.()
         return true
       } else {
         onError()

--- a/packages/graphql/src/services/sharing.ts
+++ b/packages/graphql/src/services/sharing.ts
@@ -3949,7 +3949,7 @@ export async function shareObject(
     })
 
     const userId = user?.id
-    if (!userId) {
+    if (!userId || userId === ctx.user.sub) {
       return null
     }
 

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -2914,6 +2914,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       noUserGroupsAvailable: 'Keine Nutzergruppen verfügbar',
       shortnameEmailOrGroupRequired:
         'Bitte geben Sie einen Kurznamen / E-Mail Adresse ein oder wählen Sie eine Nutzergruppe.',
+      noSelfSharing: 'Sie können keine Objekte mit sich selbst teilen.',
       infoTransferOwnershipCATALOG_COLLECTION:
         'Sie sind dabei, die Eigentumsrechte für die Katalog-Sammlung <b>{objectName}</b> an einen anderen Benutzer zu übertragen. Nach der Übertragung hat der neue Eigentümer die volle Kontrolle über diese Sammlung, während Sie automatisch einen Admin-Zugriff erhalten. Diese Aktion kann nicht rückgängig gemacht werden.',
       infoTransferOwnershipANSWER_COLLECTION:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -2883,6 +2883,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       noUserGroupsAvailable: 'No user groups available',
       shortnameEmailOrGroupRequired:
         'Please enter a shortname / email address or select a user group.',
+      noSelfSharing: 'You cannot share objects with yourself.',
       infoTransferOwnershipCATALOG_COLLECTION:
         'You are about to transfer all ownership rights of the catalog collection <b>{objectName}</b> to another user. After transferring the ownership, the new owner will have full control over this collection, while you will retain admin access. This action cannot be undone.',
       infoTransferOwnershipANSWER_COLLECTION:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent users from sharing objects with themselves, with immediate feedback in the sharing form.
  * Introduced new error messages notifying users when self-sharing is attempted, available in both English and German.

* **Improvements**
  * Success and error notifications for sharing actions are now handled internally, providing clearer and more consistent feedback to users. 

* **Bug Fixes**
  * Prevented accidental self-sharing of objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->