### PR TITLE
enhance(apps/frontend-manage): add possibility to see explanation and answer feedbacks in element preview

### DIFF
--- a/apps/frontend-manage/src/components/questions/manipulation/RecoveryPrompt.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/RecoveryPrompt.tsx
@@ -39,6 +39,7 @@ function RecoveryPrompt({
       primaryButtonStyle="primary"
       onPrimaryAction={onRecovery}
       dataPrimaryAction={{ cy: 'load-recovered-element-data' }}
+      className={{ content: 'max-w-2xl' }}
     >
       <UserNotification
         type="warning"

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -119,7 +119,7 @@ function StudentElementPreview({
                     case ElementType.Mc:
                     case ElementType.Kprim:
                       return {
-                        ['0']: {
+                        [artificialInstance.id]: {
                           evaluation: {
                             __typename: 'ChoicesInstanceEvaluation',
                             explanation,
@@ -132,7 +132,7 @@ function StudentElementPreview({
 
                     case ElementType.Numerical:
                       return {
-                        ['0']: {
+                        [artificialInstance.id]: {
                           evaluation: {
                             __typename: 'NumericalInstanceEvaluation',
                             explanation,
@@ -142,7 +142,7 @@ function StudentElementPreview({
 
                     case ElementType.FreeText:
                       return {
-                        ['0']: {
+                        [artificialInstance.id]: {
                           evaluation: {
                             __typename: 'FreeTextInstanceEvaluation',
                             explanation,
@@ -152,7 +152,7 @@ function StudentElementPreview({
 
                     case ElementType.Selection:
                       return {
-                        ['0']: {
+                        [artificialInstance.id]: {
                           evaluation: {
                             __typename: 'SelectionInstanceEvaluation',
                             explanation,
@@ -162,7 +162,7 @@ function StudentElementPreview({
 
                     case ElementType.CaseStudy:
                       return {
-                        ['0']: {
+                        [artificialInstance.id]: {
                           evaluation: {
                             __typename: 'CaseStudyInstanceEvaluation',
                             explanation,

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -7,7 +7,7 @@ import StudentElement, {
 } from '@klicker-uzh/shared-components/src/StudentElement'
 import { Checkbox, FormLabel } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { ElementFormTypes } from './types'
 import useArtificialElementInstance from './useArtificialElementInstance'
 
@@ -57,6 +57,89 @@ function StudentElementPreview({
     setStudentResponse,
   })
 
+  // memoized stack storage for evaluation components
+  const stackStorage = useMemo<StackStudentResponseType | undefined>(() => {
+    if (
+      !artificialInstance ||
+      !explanationOrFeedbacksDefined ||
+      !showFeedbacksExplanation
+    ) {
+      return undefined
+    }
+
+    const explanation =
+      values.explanation &&
+      !values.explanation.match(/^(<br>(\n)*)$/g) &&
+      values.explanation !== ''
+        ? values.explanation
+        : undefined
+
+    switch (values.type) {
+      case ElementType.Sc:
+      case ElementType.Mc:
+      case ElementType.Kprim:
+        return {
+          [artificialInstance.id]: {
+            evaluation: {
+              __typename: 'ChoicesInstanceEvaluation',
+              explanation,
+              feedbacks: values.options.hasAnswerFeedbacks
+                ? values.options.choices
+                : undefined,
+            },
+          },
+        } as StackStudentResponseType
+
+      case ElementType.Numerical:
+        return {
+          [artificialInstance.id]: {
+            evaluation: {
+              __typename: 'NumericalInstanceEvaluation',
+              explanation,
+            },
+          },
+        } as StackStudentResponseType
+
+      case ElementType.FreeText:
+        return {
+          [artificialInstance.id]: {
+            evaluation: {
+              __typename: 'FreeTextInstanceEvaluation',
+              explanation,
+            },
+          },
+        } as StackStudentResponseType
+
+      case ElementType.Selection:
+        return {
+          [artificialInstance.id]: {
+            evaluation: {
+              __typename: 'SelectionInstanceEvaluation',
+              explanation,
+            },
+          },
+        } as StackStudentResponseType
+
+      case ElementType.CaseStudy:
+        return {
+          [artificialInstance.id]: {
+            evaluation: {
+              __typename: 'CaseStudyInstanceEvaluation',
+              explanation,
+            },
+          },
+        } as StackStudentResponseType
+
+      default:
+        return undefined
+    }
+  }, [
+    values,
+    artificialInstance,
+    explanationOrFeedbacksDefined,
+    showFeedbacksExplanation,
+  ])
+
   if (!artificialInstance) {
     return <Loader />
   }
@@ -104,78 +187,7 @@ function StudentElementPreview({
           elementIx={0}
           singleStudentResponse={studentResponse}
           setSingleStudentResponse={setStudentResponse}
-          stackStorage={
-            showFeedbacksExplanation && explanationOrFeedbacksDefined
-              ? (() => {
-                  const explanation =
-                    values.explanation &&
-                    !values.explanation.match(/^(<br>(\n)*)$/g) &&
-                    values.explanation !== ''
-                      ? values.explanation
-                      : undefined
-
-                  switch (values.type) {
-                    case ElementType.Sc:
-                    case ElementType.Mc:
-                    case ElementType.Kprim:
-                      return {
-                        [artificialInstance.id]: {
-                          evaluation: {
-                            __typename: 'ChoicesInstanceEvaluation',
-                            explanation,
-                            feedbacks: values.options.hasAnswerFeedbacks
-                              ? values.options.choices
-                              : undefined,
-                          },
-                        },
-                      } as unknown as StackStudentResponseType
-
-                    case ElementType.Numerical:
-                      return {
-                        [artificialInstance.id]: {
-                          evaluation: {
-                            __typename: 'NumericalInstanceEvaluation',
-                            explanation,
-                          },
-                        },
-                      } as unknown as StackStudentResponseType
-
-                    case ElementType.FreeText:
-                      return {
-                        [artificialInstance.id]: {
-                          evaluation: {
-                            __typename: 'FreeTextInstanceEvaluation',
-                            explanation,
-                          },
-                        },
-                      } as unknown as StackStudentResponseType
-
-                    case ElementType.Selection:
-                      return {
-                        [artificialInstance.id]: {
-                          evaluation: {
-                            __typename: 'SelectionInstanceEvaluation',
-                            explanation,
-                          },
-                        },
-                      } as unknown as StackStudentResponseType
-
-                    case ElementType.CaseStudy:
-                      return {
-                        [artificialInstance.id]: {
-                          evaluation: {
-                            __typename: 'CaseStudyInstanceEvaluation',
-                            explanation,
-                          },
-                        },
-                      } as unknown as StackStudentResponseType
-
-                    default:
-                      return undefined
-                  }
-                })()
-              : undefined
-          }
+          stackStorage={stackStorage}
         />
       </div>
     </div>

--- a/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/StudentElementPreview.tsx
@@ -1,11 +1,11 @@
 import { ElementData, ElementType } from '@klicker-uzh/graphql/dist/ops'
-import { Markdown } from '@klicker-uzh/markdown'
 import useSingleStudentResponse from '@klicker-uzh/shared-components/src/hooks/useSingleStudentResponse'
 import Loader from '@klicker-uzh/shared-components/src/Loader'
 import StudentElement, {
   InstanceStackStudentResponseType,
+  StackStudentResponseType,
 } from '@klicker-uzh/shared-components/src/StudentElement'
-import { H3 } from '@uzh-bf/design-system'
+import { Checkbox, FormLabel } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import React, { useState } from 'react'
 import { ElementFormTypes } from './types'
@@ -23,6 +23,18 @@ function StudentElementPreview({
   answerCollectionEntries,
 }: StudentElementPreviewProps): React.ReactElement {
   const t = useTranslations()
+  const [showFeedbacksExplanation, setShowFeedbacksExplanation] =
+    useState(false)
+
+  const explanationOrFeedbacksDefined =
+    'explanation' in values &&
+    values.type !== ElementType.Flashcard &&
+    ((values.explanation &&
+      !values.explanation.match(/^(<br>(\n)*)$/g) &&
+      values.explanation !== '') ||
+      ('options' in values &&
+        'hasAnswerFeedbacks' in values.options &&
+        values.options.hasAnswerFeedbacks))
 
   // generate artificial instance from form content
   const artificialInstance = useArtificialElementInstance({
@@ -52,50 +64,120 @@ function StudentElementPreview({
   return (
     <div className="max-w-sm" data-cy="student-element-preview">
       <div className="rounded border p-4">
+        {explanationOrFeedbacksDefined && (
+          <div className="mb-2 flex flex-row items-center gap-2">
+            <Checkbox
+              checked={showFeedbacksExplanation}
+              onCheck={() =>
+                setShowFeedbacksExplanation(!showFeedbacksExplanation)
+              }
+            />
+            <FormLabel
+              required={false}
+              labelType="large"
+              label={
+                [ElementType.Sc, ElementType.Mc, ElementType.Kprim].includes(
+                  values.type
+                )
+                  ? t('manage.questionPool.showFeedbacksExplanation')
+                  : t('manage.questionPool.showExplanation')
+              }
+              tooltip={
+                [ElementType.Sc, ElementType.Mc, ElementType.Kprim].includes(
+                  values.type
+                )
+                  ? t.rich(
+                      'manage.questionPool.showFeedbacksExplanationTooltip',
+                      { b: (text) => <b>{text}</b> }
+                    )
+                  : t.rich('manage.questionPool.showExplanationTooltip', {
+                      b: (text) => <b>{text}</b>,
+                    })
+              }
+              className={{ label: 'font-normal' }}
+            />
+          </div>
+        )}
         <StudentElement
           preview
           element={artificialInstance}
           elementIx={0}
           singleStudentResponse={studentResponse}
           setSingleStudentResponse={setStudentResponse}
+          stackStorage={
+            showFeedbacksExplanation && explanationOrFeedbacksDefined
+              ? (() => {
+                  const explanation =
+                    values.explanation &&
+                    !values.explanation.match(/^(<br>(\n)*)$/g) &&
+                    values.explanation !== ''
+                      ? values.explanation
+                      : undefined
+
+                  switch (values.type) {
+                    case ElementType.Sc:
+                    case ElementType.Mc:
+                    case ElementType.Kprim:
+                      return {
+                        ['0']: {
+                          evaluation: {
+                            __typename: 'ChoicesInstanceEvaluation',
+                            explanation,
+                            feedbacks: values.options.hasAnswerFeedbacks
+                              ? values.options.choices
+                              : undefined,
+                          },
+                        },
+                      } as unknown as StackStudentResponseType
+
+                    case ElementType.Numerical:
+                      return {
+                        ['0']: {
+                          evaluation: {
+                            __typename: 'NumericalInstanceEvaluation',
+                            explanation,
+                          },
+                        },
+                      } as unknown as StackStudentResponseType
+
+                    case ElementType.FreeText:
+                      return {
+                        ['0']: {
+                          evaluation: {
+                            __typename: 'FreeTextInstanceEvaluation',
+                            explanation,
+                          },
+                        },
+                      } as unknown as StackStudentResponseType
+
+                    case ElementType.Selection:
+                      return {
+                        ['0']: {
+                          evaluation: {
+                            __typename: 'SelectionInstanceEvaluation',
+                            explanation,
+                          },
+                        },
+                      } as unknown as StackStudentResponseType
+
+                    case ElementType.CaseStudy:
+                      return {
+                        ['0']: {
+                          evaluation: {
+                            __typename: 'CaseStudyInstanceEvaluation',
+                            explanation,
+                          },
+                        },
+                      } as unknown as StackStudentResponseType
+
+                    default:
+                      return undefined
+                  }
+                })()
+              : undefined
+          }
         />
       </div>
-      {'explanation' in values && values.explanation ? (
-        <div className="mt-4">
-          <H3>{t('shared.generic.explanation')}</H3>
-          <Markdown
-            className={{
-              root: 'prose prose-p:m-0! prose-img:m-0! leading-6',
-            }}
-            content={values.explanation}
-          />
-        </div>
-      ) : null}
-      {(values.type === ElementType.Sc ||
-        values.type === ElementType.Mc ||
-        values.type === ElementType.Kprim) &&
-        values.options.hasAnswerFeedbacks && (
-          <div className="mt-4">
-            <H3>{t('shared.generic.feedbacks')}</H3>
-            {values.options.choices.map((choice) => (
-              <div
-                key={`choice-${choice.id}`}
-                className="border-b pb-1 pt-1 last:border-b-0"
-              >
-                {choice.feedback ? (
-                  <Markdown
-                    className={{
-                      root: 'prose prose-p:m-0! prose-img:m-0! leading-6',
-                    }}
-                    content={choice.feedback}
-                  />
-                ) : (
-                  t('manage.elements.noFeedbackDefined')
-                )}
-              </div>
-            ))}
-          </div>
-        )}
     </div>
   )
 }

--- a/apps/frontend-manage/src/components/questions/manipulation/types.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/types.ts
@@ -15,6 +15,7 @@ interface SharedQuestionFormProps {
 
 interface ElementFormTypesChoice {
   id: string
+  ix?: number
   value?: string | null
   correct?: boolean | null
   feedback?: string | null

--- a/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
+++ b/apps/frontend-manage/src/components/questions/manipulation/useElementFormInitialValues.ts
@@ -43,9 +43,10 @@ function useElementFormInitialValues({
           choices: [
             {
               id: nanoid(),
+              ix: 0,
               value: undefined,
               correct: false,
-              feedback: undefined,
+              feedback: '',
             },
           ],
         },

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1231,6 +1231,12 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Einige Elemente konnten erfolgreich aus dem Archiv wiederhergestellt werden. Bitte überprüfen Sie Ihre Berechtigungen (Admin-Rechte sind erforderlich für diese Operation) und versuchen Sie es erneut.',
       restoreFromArchiveFailed:
         'Keine Elemente konnten aus dem Archiv wiederhergestellt werden. Bitte überprüfen Sie Ihre Berechtigungen (Admin-Rechte sind erforderlich für diese Operation) und versuchen Sie es erneut.',
+      showFeedbacksExplanation: 'Antwort-Feedbacks & Erklärung anzeigen',
+      showExplanation: 'Erklärung anzeigen',
+      showFeedbacksExplanationTooltip:
+        'Eine Vorschau, wie die Erklärung und die Antwort-Feedbacks in <b>asynchronen Aktivitäten</b> angezeigt werden, nachdem ein Schüler auf das Element reagiert hat.',
+      showExplanationTooltip:
+        'Eine Vorschau, wie die Erklärung in <b>asynchronen Aktivitäten</b> angezeigt wird, nachdem ein Schüler auf das Element reagiert hat.',
     },
     tags: {
       deleteTag: 'Tag löschen',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1230,6 +1230,12 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         'Some elements could not be restored from the archive. Please check your permissions (admin rights are required for this operation) and try again.',
       restoreFromArchiveFailed:
         'No elements could be restored from the archive. Please check your permissions (admin rights are required for this operation) and try again.',
+      showFeedbacksExplanation: 'Show answer feedbacks & explanation',
+      showExplanation: 'Show explanation',
+      showFeedbacksExplanationTooltip:
+        'View a preview of how the explanation and answer feedbacks will be shown in <b>asynchronous activities</b> once a student has responded to the element.',
+      showExplanationTooltip:
+        'View a preview of how the explanation will be shown in <b>asynchronous activities</b> once a student has responded to the element.',
     },
     tags: {
       deleteTag: 'Delete tag',

--- a/packages/shared-components/src/CaseStudyQuestion.tsx
+++ b/packages/shared-components/src/CaseStudyQuestion.tsx
@@ -22,6 +22,7 @@ import type { CaseStudyStudentResponseType } from './StudentElement'
 import { validateCaseStudyResponse } from './utils/validateResponse'
 
 interface CaseStudyQuestionProps {
+  preview?: boolean
   sequential: boolean
   content: string
   options: CaseStudyElementOptions
@@ -32,10 +33,10 @@ interface CaseStudyQuestionProps {
   evaluation?: CaseStudyInstanceEvaluation
   noPoints: boolean
   disabled?: boolean
-  // preview: boolean
 }
 
 function CaseStudyQuestion({
+  preview = false,
   sequential,
   content,
   options,
@@ -46,7 +47,6 @@ function CaseStudyQuestion({
   evaluation,
   noPoints,
   disabled = false,
-  // preview,
 }: CaseStudyQuestionProps) {
   const t = useTranslations()
   const [caseIndex, setCaseIndex] = useState(0)
@@ -236,7 +236,7 @@ function CaseStudyQuestion({
         )}
       </div>
 
-      {evaluation && evaluation.studySolutions && solutions && (
+      {evaluation && evaluation.studySolutions && solutions && !preview ? (
         <div
           className="col-span-1 mr-2 rounded-md border border-solid bg-slate-50 px-2 py-4 md:ml-2 md:mr-0 md:w-64 md:px-0 lg:w-80"
           key={`evaluation-${elementIx}`}
@@ -252,7 +252,7 @@ function CaseStudyQuestion({
             />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/shared-components/src/ChoicesQuestion.tsx
+++ b/packages/shared-components/src/ChoicesQuestion.tsx
@@ -21,6 +21,7 @@ import {
 } from './utils/validateResponse'
 
 interface ChoicesQuestionProps {
+  preview?: boolean
   content: string
   type: ElementType.Sc | ElementType.Mc | ElementType.Kprim
   options: ChoiceElementOptions
@@ -34,6 +35,7 @@ interface ChoicesQuestionProps {
 }
 
 function ChoicesQuestion({
+  preview = false,
   content,
   type,
   options,
@@ -103,7 +105,7 @@ function ChoicesQuestion({
         )}
       </div>
 
-      {evaluation && (
+      {evaluation && !preview ? (
         <div
           className="col-span-1 mr-2 rounded-md border border-solid bg-slate-50 px-2 py-4 md:ml-2 md:mr-0 md:w-64 md:px-0 lg:w-80"
           key={`evaluation-${elementIx}`}
@@ -120,7 +122,7 @@ function ChoicesQuestion({
             )}
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/shared-components/src/FreeTextQuestion.tsx
+++ b/packages/shared-components/src/FreeTextQuestion.tsx
@@ -11,6 +11,7 @@ import FREETextAnswerOptions from './questions/FREETextAnswerOptions'
 import { validateFreeTextResponse } from './utils/validateResponse'
 
 interface FreeTextQuestionProps {
+  preview?: boolean
   content: string
   options: FreeTextElementOptions
   response?: string
@@ -24,6 +25,7 @@ interface FreeTextQuestionProps {
 }
 
 function FreeTextQuestion({
+  preview = false,
   content,
   options,
   response,
@@ -59,7 +61,7 @@ function FreeTextQuestion({
         />
       </div>
 
-      {evaluation && evaluation.solutions && (
+      {evaluation && evaluation.solutions && !preview ? (
         <div
           className="col-span-1 mr-2 rounded-md border border-solid bg-slate-50 px-2 py-4 md:ml-2 md:mr-0 md:w-64 md:px-0 lg:w-80"
           key={`evaluation-${elementIx}`}
@@ -85,7 +87,7 @@ function FreeTextQuestion({
             />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/shared-components/src/NumericalQuestion.tsx
+++ b/packages/shared-components/src/NumericalQuestion.tsx
@@ -11,6 +11,7 @@ import NUMERICALAnswerOptions from './questions/NUMERICALAnswerOptions'
 import { validateNumericalResponse } from './utils/validateResponse'
 
 interface NumericalQuestionProps {
+  preview?: boolean
   content: string
   options: NumericalElementOptions
   response?: string
@@ -24,6 +25,7 @@ interface NumericalQuestionProps {
 }
 
 function NumericalQuestion({
+  preview = false,
   content,
   options,
   response,
@@ -70,7 +72,7 @@ function NumericalQuestion({
         />
       </div>
 
-      {evaluation && (
+      {evaluation && !preview ? (
         <div
           className="col-span-1 mr-2 rounded-md border border-solid bg-slate-50 px-2 py-4 md:ml-2 md:mr-0 md:w-64 md:px-0 lg:w-80"
           key={`evaluation-${elementIx}`}
@@ -90,7 +92,7 @@ function NumericalQuestion({
             />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/shared-components/src/SelectionQuestion.tsx
+++ b/packages/shared-components/src/SelectionQuestion.tsx
@@ -38,7 +38,7 @@ function SelectionQuestion({
   evaluation,
   disabled,
   noPoints,
-  preview,
+  preview = false,
 }: SelectionQuestionProps) {
   const emptyResponses = useMemo(
     () =>
@@ -80,7 +80,7 @@ function SelectionQuestion({
         />
       </div>
 
-      {evaluation && evaluation.answerSolutionIds && (
+      {evaluation && evaluation.answerSolutionIds && !preview ? (
         <div
           className="col-span-1 mr-2 rounded-md border border-solid bg-slate-50 px-2 py-4 md:ml-2 md:mr-0 md:w-64 md:px-0 lg:w-80"
           key={`evaluation-${elementIx}`}
@@ -92,7 +92,7 @@ function SelectionQuestion({
             <SEEValuation evaluation={evaluation} options={options} />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/shared-components/src/StudentElement.tsx
+++ b/packages/shared-components/src/StudentElement.tsx
@@ -104,7 +104,7 @@ interface StudentElementStackProps extends StudentElementBaseProps {
 interface StudentElementSingleProps extends StudentElementBaseProps {
   studentResponse?: never
   setStudentResponse?: never
-  stackStorage?: never
+  stackStorage?: StackStudentResponseType
   singleStudentResponse: InstanceStackStudentResponseType
   setSingleStudentResponse: Dispatch<
     SetStateAction<InstanceStackStudentResponseType>
@@ -130,6 +130,7 @@ function StudentElement({
     return (
       <ChoicesQuestion
         key={element.id}
+        preview={preview}
         content={element.elementData.content}
         type={element.elementData.type as ElementChoicesType}
         options={element.elementData.options}
@@ -181,6 +182,7 @@ function StudentElement({
     return (
       <NumericalQuestion
         key={element.id}
+        preview={preview}
         content={element.elementData.content}
         options={element.elementData.options}
         response={
@@ -233,6 +235,7 @@ function StudentElement({
     return (
       <FreeTextQuestion
         key={element.id}
+        preview={preview}
         content={element.elementData.content}
         options={element.elementData.options}
         response={
@@ -285,6 +288,7 @@ function StudentElement({
     return (
       <SelectionQuestion
         key={element.id}
+        preview={preview}
         content={element.elementData.content}
         options={element.elementData.options}
         response={
@@ -334,13 +338,13 @@ function StudentElement({
           !element.elementData.options.hasSampleSolution
         }
         disabled={disabledInput}
-        preview={preview}
       />
     )
   } else if (element.elementData.__typename === 'CaseStudyElementData') {
     return (
       <CaseStudyQuestion
         key={element.id}
+        preview={preview}
         sequential={sequential}
         content={element.elementData.content}
         options={element.elementData.options}


### PR DESCRIPTION
<img width="404" height="480" alt="Screenshot 2025-07-14 at 15 23 08" src="https://github.com/user-attachments/assets/5cd1f345-7abe-48cb-bca1-9bb941e83686" />
<img width="401" height="668" alt="Screenshot 2025-07-14 at 15 23 13" src="https://github.com/user-attachments/assets/3d5bb83c-cdcd-45f9-ae90-eb11d6b695c9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to preview explanations and answer feedbacks within student element previews.
  * Introduced new labels and tooltips for explanation and feedback previews in both English and German.
  * Preview mode now hides evaluation panels in question components for a more accurate student-facing preview.

* **Enhancements**
  * Improved modal styling with a maximum width constraint for a better user experience.
  * Extended support for preview functionality across various question types.

* **Other Changes**
  * Minor updates to data structures to support new features and preview functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->