### PR TITLE
enhance(apps/frontend-pwa): add error page for invalid live quiz links instead of persistent loading circle

### DIFF
--- a/apps/frontend-control/src/pages/404.tsx
+++ b/apps/frontend-control/src/pages/404.tsx
@@ -8,7 +8,7 @@ function MissingPage() {
     <Layout title="KlickerUZH">
       <div className="mt-10 flex flex-col items-center gap-4 text-center">
         <div className="flex flex-row items-center gap-4 text-2xl text-red-600 sm:gap-6 sm:text-3xl md:gap-8 md:text-4xl">
-          <FontAwesomeIcon icon={faBan} className="sm:h-18 h-14 md:h-20" />
+          <FontAwesomeIcon icon={faBan} size="2x" />
           <div>404 Page not found</div>
         </div>
         <div className="md:max-w-140 max-w-[90%] sm:max-w-[70%]">

--- a/apps/frontend-manage/src/pages/404.tsx
+++ b/apps/frontend-manage/src/pages/404.tsx
@@ -12,7 +12,7 @@ function MissingPage() {
     <Layout displayName="KlickerUZH">
       <div className="mt-10 flex flex-col items-center gap-4 text-center">
         <div className="flex flex-row items-center gap-4 text-2xl text-red-600 sm:gap-6 sm:text-3xl md:gap-8 md:text-4xl">
-          <FontAwesomeIcon icon={faBan} className="sm:h-18 h-14 md:h-20" />
+          <FontAwesomeIcon icon={faBan} size="2x" />
           <div>{t('shared.error.404')}</div>
         </div>
         <div className="md:max-w-140 max-w-[90%] sm:max-w-[70%]">

--- a/apps/frontend-pwa/src/pages/404.tsx
+++ b/apps/frontend-pwa/src/pages/404.tsx
@@ -15,7 +15,7 @@ function MissingPage() {
     <Layout className={{ body: 'h-full' }}>
       <div className="mx-auto my-auto flex flex-col items-center gap-6 text-center">
         <div className="flex flex-row items-center gap-4 text-2xl text-red-600 sm:gap-6 sm:text-3xl md:gap-8 md:text-4xl">
-          <FontAwesomeIcon icon={faBan} className="sm:h-18 h-14 md:h-20" />
+          <FontAwesomeIcon icon={faBan} size="2x" />
           <div>{t('shared.error.404')}</div>
         </div>
         {!dataParticipant?.self ||

--- a/apps/frontend-pwa/src/pages/session/[id].tsx
+++ b/apps/frontend-pwa/src/pages/session/[id].tsx
@@ -1,5 +1,10 @@
 import { faCommentDots } from '@fortawesome/free-regular-svg-icons'
-import { faQuestion, faRankingStar } from '@fortawesome/free-solid-svg-icons'
+import {
+  faArrowsRotate,
+  faExclamationCircle,
+  faQuestion,
+  faRankingStar,
+} from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   ElementType,
@@ -16,7 +21,7 @@ import { useQuery } from '@apollo/client'
 import { Markdown } from '@klicker-uzh/markdown'
 import Loader from '@klicker-uzh/shared-components/src/Loader'
 import { addApolloState, initializeApollo } from '@lib/apollo'
-import { H2, UserNotification } from '@uzh-bf/design-system'
+import { Button, H1, H2, UserNotification } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
@@ -36,15 +41,38 @@ function Index({ id }: { id: string }) {
   const router = useRouter()
   const [activeMobilePage, setActiveMobilePage] = useState('questions')
 
-  const { data, subscribeToMore } = useQuery(GetRunningLiveQuizDocument, {
-    variables: { id },
-  })
+  const { data, loading, subscribeToMore } = useQuery(
+    GetRunningLiveQuizDocument,
+    {
+      variables: { id },
+    }
+  )
   const { data: selfData } = useQuery(SelfDocument)
+
+  if (loading) {
+    return (
+      <Layout>
+        <Loader />
+      </Layout>
+    )
+  }
 
   if (!data?.studentLiveQuiz) {
     return (
       <Layout>
-        <Loader />
+        <div className="flex h-full flex-col items-center justify-center text-center">
+          <div className="flex flex-row items-center gap-4 text-red-600">
+            <FontAwesomeIcon icon={faExclamationCircle} size="3x" />
+            <H1>{t('pwa.liveQuiz.noQuizTitle')}</H1>
+          </div>
+          <p className="my-4 max-w-96 text-gray-600">
+            {t('pwa.liveQuiz.noQuizDescription')}
+          </p>
+          <Button onClick={() => router.reload()} className={{ root: 'h-8' }}>
+            <Button.Icon icon={faArrowsRotate} />
+            <Button.Label>{t('pwa.liveQuiz.refreshPage')}</Button.Label>
+          </Button>
+        </div>
       </Layout>
     )
   }

--- a/apps/frontend-pwa/src/pages/session/[id].tsx
+++ b/apps/frontend-pwa/src/pages/session/[id].tsx
@@ -43,9 +43,7 @@ function Index({ id }: { id: string }) {
 
   const { data, loading, subscribeToMore } = useQuery(
     GetRunningLiveQuizDocument,
-    {
-      variables: { id },
-    }
+    { variables: { id } }
   )
   const { data: selfData } = useQuery(SelfDocument)
 
@@ -63,7 +61,9 @@ function Index({ id }: { id: string }) {
         <div className="flex h-full flex-col items-center justify-center text-center">
           <div className="flex flex-row items-center gap-4 text-red-600">
             <FontAwesomeIcon icon={faExclamationCircle} size="3x" />
-            <H1>{t('pwa.liveQuiz.noQuizTitle')}</H1>
+            <H1 className={{ root: 'mb-0' }}>
+              {t('pwa.liveQuiz.noQuizTitle')}
+            </H1>
           </div>
           <p className="my-4 max-w-96 text-gray-600">
             {t('pwa.liveQuiz.noQuizDescription')}

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -828,6 +828,10 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       pseudonymSelection: 'Pseudonym-Auswahl',
       avatarExplanation:
         'Falls sie möchten, können Sie hier Ihren <b>Avatar</b> für das Live-Quiz auswählen.',
+      noQuizTitle: 'Kein Live-Quiz verfügbar',
+      noQuizDescription:
+        'Unter diesem Link ist derzeit kein laufendes Live-Quiz verfügbar. Bitte überprüfen Sie Ihren Link oder wenden Sie sich an Ihren Dozierenden.',
+      refreshPage: 'Seite aktualisieren',
     },
     feedbacks: {
       title: 'Feedback-Kanal',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -825,6 +825,10 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       pseudonymSelection: 'Pseudonym Selection',
       avatarExplanation:
         'If you wish, you can select your <b>avatar</b> for the live quiz here.',
+      noQuizTitle: 'No Live Quiz Available',
+      noQuizDescription:
+        'There is currently no running live quiz available under this link. Please check your link or contact your instructor.',
+      refreshPage: 'Refresh Page',
     },
     feedbacks: {
       title: 'Feedback Channel',


### PR DESCRIPTION
<img width="450" height="775" alt="Screenshot 2025-07-14 at 20 37 11" src="https://github.com/user-attachments/assets/51a8bf47-1bcf-49c5-a48e-f1ec9cc1cfad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the 404 error pages across multiple apps to use a consistent icon size for improved visual consistency.
  * Improved the live quiz session page to display a clearer message and refresh option when no live quiz is available.

* **Localization**
  * Added new English and German translations for messages shown when no live quiz is available, including titles, descriptions, and a refresh button label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->