### PR TITLE
fix(apps/frontend-pwa): make sure lti-token is properly removed after setting participant token cookie

### DIFF
--- a/apps/frontend-pwa/src/lib/getParticipantToken.ts
+++ b/apps/frontend-pwa/src/lib/getParticipantToken.ts
@@ -110,6 +110,7 @@ export default async function getParticipantToken({
     participantToken = result?.data?.loginParticipantWithLti?.participantToken
 
     if (participantToken) {
+      // set a proper participant_token
       nookies.set(ctx, 'participant_token', participantToken, {
         domain: process.env.COOKIE_DOMAIN,
         path: '/',
@@ -123,6 +124,12 @@ export default async function getParticipantToken({
           process.env.COOKIE_DOMAIN === '127.0.0.1'
             ? 'lax'
             : 'none',
+      })
+
+      // remove the lti-token cookie since we now have a proper participant_token
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
       })
     }
 

--- a/packages/prisma/src/data/seedTEST.ts
+++ b/packages/prisma/src/data/seedTEST.ts
@@ -11,6 +11,7 @@ import {
   COURSE_ID_TEST,
   COURSE_ID_TEST2,
   COURSE_ID_TEST3,
+  USER_ID_TEST,
 } from './constants.js'
 import * as DATA_TEST from './data/TEST.js'
 import {
@@ -102,8 +103,6 @@ export const PARTICIPANT_GROUP_IDS = [
   '278057ff-f1c2-49a0-9ab1-bcbc4c6473b7',
   '11c06c89-0cb4-4d8e-b052-b711f327b8c4',
 ]
-
-const USER_ID_TEST = '73c018c2-d7ad-4844-84b0-814e33420423'
 
 async function seedTest(prisma: Prisma.PrismaClient) {
   if (process.env.ENV !== 'development') process.exit(1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie management to ensure temporary tokens are removed when a participant token is set.

* **Chores**
  * Centralized the definition of test user ID constants for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->