### PR TITLE
fix(apps/frontend-manage): make sure to show element edit content recovery modal also on title click

### DIFF
--- a/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivitySettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivitySettingsStep.tsx
@@ -48,7 +48,7 @@ function GroupActivitySettingsStep({
       innerRef={formRef}
       validationSchema={validationSchema}
     >
-      {({ values, touched, isValid, isSubmitting, setTouched, setValues }) => (
+      {({ values, isValid, isSubmitting, setTouched, setValues }) => (
         <Form className="h-full w-full">
           <CreationFormValidator
             isValid={isValid}
@@ -66,7 +66,7 @@ function GroupActivitySettingsStep({
             <div className="flex flex-col justify-center gap-4 md:flex-row">
               <div
                 className={twMerge(
-                  'border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-72',
+                  'border-border w-full rounded-md border border-solid p-2 shadow-md md:w-72',
                   typeof values.courseId !== 'undefined' && 'border-orange-400'
                 )}
               >
@@ -99,7 +99,7 @@ function GroupActivitySettingsStep({
                   <MultiplierSelector />
                 )}
               </div>
-              <div className="border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-72">
+              <div className="border-border w-full rounded-md border border-solid p-2 shadow-md md:w-72">
                 <div className="flex flex-row items-center justify-center gap-2">
                   <FontAwesomeIcon icon={faClock} />
                   <div

--- a/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivityStackClues.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivityStackClues.tsx
@@ -183,7 +183,7 @@ function GroupActivityStackClues({
                                 errors.clues.length > ix &&
                                 errors.clues[ix]
                                 ? 'border-red-600'
-                                : 'border-uzh-grey-40'
+                                : 'border-border'
                             )}
                             data-cy={`groupActivity-clue-${clue.name}`}
                           >

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
@@ -63,7 +63,7 @@ function LiveQuizSettingsStep({
             <div className="flex flex-col justify-center gap-4 md:flex-row">
               <div
                 className={twMerge(
-                  'border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-64',
+                  'border-border w-full rounded-md border border-solid p-2 shadow-md md:w-64',
                   values.isGamificationEnabled && 'border-orange-400'
                 )}
               >
@@ -116,7 +116,7 @@ function LiveQuizSettingsStep({
                   />
                 )}
               </div>
-              <div className="border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-64">
+              <div className="border-border w-full rounded-md border border-solid p-2 shadow-md md:w-64">
                 <div className="mb-4 flex flex-row items-center justify-center gap-2">
                   <FontAwesomeIcon icon={faUsers} />
                   <div className="text-lg font-bold">

--- a/apps/frontend-manage/src/components/activities/creation/microLearning/MicroLearningSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/microLearning/MicroLearningSettingsStep.tsx
@@ -68,7 +68,7 @@ function MicroLearningSettingsStep({
             <div className="flex flex-col justify-center gap-4 md:flex-row">
               <div
                 className={twMerge(
-                  'border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-72',
+                  'border-border w-full rounded-md border border-solid p-2 shadow-md md:w-72',
                   courseGamified && 'border-orange-400'
                 )}
               >
@@ -109,7 +109,7 @@ function MicroLearningSettingsStep({
                   />
                 )}
               </div>
-              <div className="border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-72">
+              <div className="border-border w-full rounded-md border border-solid p-2 shadow-md md:w-72">
                 <div className="flex flex-row items-center justify-center gap-2">
                   <FontAwesomeIcon icon={faClock} />
                   <div

--- a/apps/frontend-manage/src/components/activities/creation/practiceQuiz/PracticeQuizSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/practiceQuiz/PracticeQuizSettingsStep.tsx
@@ -66,7 +66,7 @@ function PracticeQuizSettingsStep({
             <div className="flex flex-col justify-center gap-4 md:flex-row">
               <div
                 className={twMerge(
-                  'border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-72',
+                  'border-border w-full rounded-md border border-solid p-2 shadow-md md:w-72',
                   courseGamified && 'border-orange-400'
                 )}
               >
@@ -107,7 +107,7 @@ function PracticeQuizSettingsStep({
                   />
                 )}
               </div>
-              <div className="border-uzh-grey-40 w-full rounded-md border border-solid p-2 shadow-md md:w-72">
+              <div className="border-border w-full rounded-md border border-solid p-2 shadow-md md:w-72">
                 <div className="flex flex-row items-center justify-center gap-2">
                   <FontAwesomeIcon icon={faGears} />
                   <div className="text-lg font-bold">

--- a/apps/frontend-manage/src/components/evaluation/feedbacks/SingleFeedback.tsx
+++ b/apps/frontend-manage/src/components/evaluation/feedbacks/SingleFeedback.tsx
@@ -14,7 +14,7 @@ function SingleFeedback({ feedback }: SingleFeedbackProps) {
 
   return (
     <div key={feedback.content} className="break-inside-avoid">
-      <div className="border-uzh-grey-40 w-full rounded-md border border-solid p-2">
+      <div className="border-border w-full rounded-md border border-solid p-2">
         <div className="flex flex-row justify-between">
           <div>{feedback.content}</div>
           <div className="flex flex-row items-center text-gray-500">
@@ -34,7 +34,7 @@ function SingleFeedback({ feedback }: SingleFeedbackProps) {
       </div>
       {feedback.responses?.map((response) => (
         <div key={response?.content} className="mt-1 w-full pl-12 text-base">
-          <div className="border-uzh-grey-40 bg-primary-20 rounded border border-solid bg-opacity-50 p-1.5">
+          <div className="border-border bg-primary-20 rounded border border-solid bg-opacity-50 p-1.5">
             {response?.content}
           </div>
         </div>

--- a/apps/frontend-manage/src/components/questions/Element.tsx
+++ b/apps/frontend-manage/src/components/questions/Element.tsx
@@ -172,7 +172,15 @@ function Element({
                   type="button"
                   onClick={() => {
                     if (!disabled) {
-                      setModificationModalOpen(true)
+                      const value = localStorage.getItem(
+                        `autosave-element-${element.id}`
+                      )
+
+                      if (value) {
+                        setShowRecoveryPrompt(true)
+                      } else {
+                        setModificationModalOpen(true)
+                      }
                     }
                   }}
                   data-cy={`element-title-${element.name}`}

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCasesFields.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyCasesFields.tsx
@@ -232,7 +232,7 @@ function CaseStudyCasesFields({
                   </div>
                 )}
 
-                <hr className="border-uzh-grey-40 mt-4 w-full border-2" />
+                <hr className="border-border mt-4 w-full border-2" />
               </div>
             ))}
             {!inputsDisabled ? (

--- a/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyOptions.tsx
+++ b/apps/frontend-manage/src/components/questions/manipulation/options/CaseStudyOptions.tsx
@@ -76,9 +76,9 @@ function CaseStudyOptions({
           setSelectedItems={setSelectedItems}
         />
       )}
-      <hr className="border-uzh-grey-40 my-2 w-full border-2" />
+      <hr className="border-border my-2 w-full border-2" />
       <CaseStudyCriteriaFields disabled={inputsDisabled} />
-      <hr className="border-uzh-grey-40 my-2 w-full border-2" />
+      <hr className="border-border my-2 w-full border-2" />
       <CaseStudyCasesFields
         inputsDisabled={inputsDisabled}
         setFieldTouched={setFieldTouched}

--- a/packages/prisma/src/data/seedTEST.ts
+++ b/packages/prisma/src/data/seedTEST.ts
@@ -660,14 +660,18 @@ async function seedTest(prisma: Prisma.PrismaClient) {
                   {
                     order: 0,
                     type: Prisma.ElementInstanceType.LIVE_QUIZ,
-                    elementType: Prisma.ElementType.SC,
+                    elementType: questionsTest[0]!.type,
                     elementData: processElementData(questionsTest[0]!),
                     options: {
                       basePoints: true,
                       pointsMultiplier: quizData.pointsMultiplier,
                     },
-                    results: { choices: Array(4).fill(0), total: 0 },
-                    anonymousResults: { choices: Array(4).fill(0), total: 0 },
+                    results: getInitialInstanceResults(
+                      processElementData(questionsTest[0]!)
+                    ),
+                    anonymousResults: getInitialInstanceResults(
+                      processElementData(questionsTest[0]!)
+                    ),
                     instanceStatistics: {
                       create: getInitialInstanceStatistics(
                         Prisma.ElementInstanceType.LIVE_QUIZ


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When editing a question element, users are now prompted to recover autosaved drafts if available, enhancing data recovery and editing experience.

* **Style**
  * Updated border color styling across various settings, feedback, and question components for a more consistent appearance.

* **Chores**
  * Improved internal logic for generating initial results in test data, ensuring better alignment with actual element data. (No user-facing impact)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->