### PR TITLE
chore(packages/graphql): add unit tests for element batch operations

### DIFF
--- a/apps/frontend-manage/src/components/elements/manipulation/ElementBatchOperationsModal.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/ElementBatchOperationsModal.tsx
@@ -8,7 +8,7 @@ import {
 } from '@klicker-uzh/graphql/dist/ops'
 import { Button, Modal, toast } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { isShallowEqual, omit } from 'remeda'
 import { twMerge } from 'tailwind-merge'
 import ElementArchiveCard from './batchOperations/ElementArchiveCard'
@@ -36,7 +36,11 @@ function ElementBatchOperationsModal({
 }) {
   const t = useTranslations()
   const [affectedElements, setAffectedElements] = useState(
-    selectedElements.map((element) => element.id)
+    selectedElements.map((element) => ({
+      ...element,
+      actionsApplied: true,
+      reasons: [] as string[],
+    }))
   )
   const [selectedActions, setSelectedActions] = useState<BatchOperationActions>(
     INITIAL_ELEMENT_BATCH_OPERATIONS
@@ -49,37 +53,93 @@ function ElementBatchOperationsModal({
 
   // whenever the applied filters change, update the affected elements
   useEffect(() => {
-    let filtered = [...selectedElements]
+    let mapped = [
+      ...affectedElements.map((element) => ({
+        ...element,
+        actionsApplied: true,
+        reasons: [] as string[],
+      })),
+    ]
 
     if (selectedActions.unarchive) {
-      filtered = filtered.filter(
-        (element) => element.isArchived && element.isManager
-      )
+      mapped = mapped.map((element) => ({
+        ...element,
+        actionsApplied:
+          element.actionsApplied && !!element.isArchived && !!element.isManager,
+        reasons: [
+          ...element.reasons,
+          ...(!element.isArchived
+            ? [t('manage.questionPool.batchUnarchiveOnlyArchivedElements')]
+            : []),
+          ...(element.isArchived && !element.isManager
+            ? [t('manage.questionPool.batchUnarchiveOnlyManagerElements')]
+            : []),
+        ],
+      }))
     } else if (selectedActions.archive) {
-      filtered = filtered.filter(
-        (element) => !element.isArchived && element.isManager
-      )
+      mapped = mapped.map((element) => ({
+        ...element,
+        actionsApplied:
+          element.actionsApplied && !element.isArchived && !!element.isManager,
+        reasons: [
+          ...element.reasons,
+          ...(element.isArchived
+            ? [t('manage.questionPool.batchArchiveOnlyUnarchivedElements')]
+            : []),
+          ...(!element.isManager
+            ? [t('manage.questionPool.batchArchiveOnlyManagerElements')]
+            : []),
+        ],
+      }))
     }
     if (selectedActions.multiplier) {
-      filtered = filtered.filter(
-        (element) =>
-          element.isEditor &&
-          'options' in element &&
-          element.options.hasSampleSolution
-      )
+      mapped = mapped.map((element) => ({
+        ...element,
+        actionsApplied:
+          element.actionsApplied &&
+          !!element.isEditor &&
+          !!('options' in element && element.options.hasSampleSolution),
+        reasons: [
+          ...element.reasons,
+          ...(!element.isEditor
+            ? [t('manage.questionPool.batchMultiplierOnlyEditorElements')]
+            : []),
+          ...(!('options' in element && element.options.hasSampleSolution)
+            ? [t('manage.questionPool.batchMultiplierOnlySampleSolution')]
+            : []),
+        ],
+      }))
     }
     if (typeof selectedActions.basePoints !== 'undefined') {
-      filtered = filtered.filter(
-        (element) =>
-          element.isEditor &&
-          element.type !== ElementType.Flashcard &&
-          element.type !== ElementType.Content
-      )
+      mapped = mapped.map((element) => ({
+        ...element,
+        actionsApplied:
+          element.actionsApplied &&
+          !!element.isEditor &&
+          !(
+            element.type === ElementType.Flashcard ||
+            element.type === ElementType.Content
+          ),
+        reasons: [
+          ...element.reasons,
+          ...(!element.isEditor
+            ? [t('manage.questionPool.batchBasePointsOnlyEditorElements')]
+            : []),
+          ...(element.type === ElementType.Flashcard ||
+          element.type === ElementType.Content
+            ? [t('manage.questionPool.batchBasePointsOnlyQuestions')]
+            : []),
+        ],
+      }))
     }
 
-    // return the filtered and mapped elements (unfiltered if no relevant action applied)
-    setAffectedElements(filtered.map((element) => element.id))
+    // set the updated element list
+    setAffectedElements(mapped)
   }, [selectedElements, selectedActions])
+
+  const numOfUpdatedElements = useMemo(() => {
+    return affectedElements.filter((element) => element.actionsApplied).length
+  }, [affectedElements])
 
   return (
     <Modal
@@ -137,24 +197,24 @@ function ElementBatchOperationsModal({
               <span
                 className={twMerge(
                   'text-sm text-green-600',
-                  affectedElements.length === 0 && 'text-red-600'
+                  numOfUpdatedElements === 0 && 'text-red-600'
                 )}
               >
                 <FontAwesomeIcon
-                  icon={affectedElements.length === 0 ? faX : faCheck}
+                  icon={numOfUpdatedElements === 0 ? faX : faCheck}
                   className="mr-1.5"
                 />
-                {affectedElements.length === 0
+                {numOfUpdatedElements === 0
                   ? t('manage.questionPool.noElementsWillBeUpdated')
                   : t('manage.questionPool.nElementsWillBeUpdated', {
-                      number: affectedElements.length,
+                      number: numOfUpdatedElements,
                     })}
               </span>
               <Button
                 primary
                 disabled={
                   applying ||
-                  affectedElements.length === 0 ||
+                  numOfUpdatedElements === 0 ||
                   isShallowEqual(
                     omit(selectedActions, [
                       'updateInstances',
@@ -171,7 +231,9 @@ function ElementBatchOperationsModal({
                     // submit the batch operations
                     const { data: res } = await applyElementBatchOperations({
                       variables: {
-                        elementIds: affectedElements,
+                        elementIds: affectedElements
+                          .filter((element) => element.actionsApplied)
+                          .map((element) => element.id),
                         archive: selectedActions.archive,
                         unarchive: selectedActions.unarchive,
                         status: selectedActions.status ?? undefined,

--- a/apps/frontend-manage/src/components/elements/manipulation/batchOperations/SelectedElementsList.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/batchOperations/SelectedElementsList.tsx
@@ -6,7 +6,9 @@ import {
   ShadcnTableBody,
   ShadcnTableCell,
   ShadcnTableRow,
+  Tooltip,
 } from '@uzh-bf/design-system'
+import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 import ObjectPermissionLevel from '../../../sharing/ObjectPermissionLevel'
@@ -16,8 +18,13 @@ function SelectedElementsList({
   affectedElements,
 }: {
   selectedElements: Element[]
-  affectedElements: number[]
+  affectedElements: (Element & {
+    actionsApplied: boolean
+    reasons: string[]
+  })[]
 }) {
+  const t = useTranslations()
+
   // check if user has owner / admin permissions on all elements
   const allAdminPermissions = useMemo(
     () => selectedElements.every((element) => element.isManager),
@@ -28,8 +35,11 @@ function SelectedElementsList({
     <div className="min-h-0 flex-1 overflow-auto">
       <ShadcnTable className="mt-2">
         <ShadcnTableBody>
-          {selectedElements.map((element) => {
-            const isAffected = affectedElements.includes(element.id)
+          {affectedElements.map((element) => {
+            const isAffected =
+              affectedElements.find(
+                (affectedElement) => affectedElement.id === element.id
+              )?.actionsApplied ?? false
 
             return (
               <ShadcnTableRow
@@ -65,11 +75,30 @@ function SelectedElementsList({
                       data-cy={`element-batch-check-${element.name}`}
                     />
                   ) : (
-                    <FontAwesomeIcon
-                      icon={faX}
-                      className="text-red-600"
-                      data-cy={`element-batch-x-${element.name}`}
-                    />
+                    <Tooltip
+                      tooltip={
+                        <>
+                          <div>
+                            {t(
+                              'manage.questionPool.batchNotApplicableExplanation'
+                            )}
+                          </div>
+                          <ul className="list-disc pl-4">
+                            {element.reasons.map((reason, idx) => (
+                              <li key={idx} className="mt-0.5">
+                                {reason}
+                              </li>
+                            ))}
+                          </ul>
+                        </>
+                      }
+                    >
+                      <FontAwesomeIcon
+                        icon={faX}
+                        className="text-red-600"
+                        data-cy={`element-batch-x-${element.name}`}
+                      />
+                    </Tooltip>
                   )}
                 </ShadcnTableCell>
               </ShadcnTableRow>

--- a/packages/graphql/src/services/elements.ts
+++ b/packages/graphql/src/services/elements.ts
@@ -763,53 +763,49 @@ export async function applyElementBatchOperations(
   }
 
   // execute the required element updates and, if enabled, update the corresponding linked instances
-  const updatedElements = await Promise.allSettled(
-    dbElements.map(
-      async (element) =>
-        await ctx.prisma.$transaction(async (tx) => {
-          // execute the element update
-          const updatedElement = await tx.element.update({
-            where: { id: element.id },
-            data: {
-              version: { increment: 1 },
-              isArchived: archive ? true : unarchive ? false : undefined,
-              status: status ?? undefined,
-              pointsMultiplier:
-                typeof multiplier !== 'undefined' && multiplier !== null
-                  ? multiplier
-                  : undefined,
-              basePoints:
-                typeof basePoints !== 'undefined' && basePoints !== null
-                  ? basePoints
-                  : undefined,
-            },
-          })
-
-          // if enabled, update the corresponding element instances
-          if (updateInstances) {
-            await updateElementInstances(
-              {
-                elementId: updatedElement.id,
-                includeTemplates: updateTemplateInstances,
-              },
-              tx,
-              ctx.emitter,
-              ctx.user.sub
-            )
-          }
-
-          return updatedElement
+  // needs to be sequential since element instance updates potentially include derived permission updates
+  const updatedElements: DB.Element[] = []
+  for (const element of dbElements) {
+    updatedElements.push(
+      await ctx.prisma.$transaction(async (tx) => {
+        // execute the element update
+        const updatedElement = await tx.element.update({
+          where: { id: element.id },
+          data: {
+            version: { increment: 1 },
+            isArchived: archive ? true : unarchive ? false : undefined,
+            status: status ?? undefined,
+            pointsMultiplier:
+              typeof multiplier !== 'undefined' && multiplier !== null
+                ? multiplier
+                : undefined,
+            basePoints:
+              typeof basePoints !== 'undefined' && basePoints !== null
+                ? basePoints
+                : undefined,
+          },
         })
-    )
-  )
 
-  // filter out the elements that were successfully updated
-  const successfullyUpdatedElements = updatedElements
-    .filter((result) => result.status === 'fulfilled')
-    .map((result) => result.value)
+        // if enabled, update the corresponding element instances
+        if (updateInstances) {
+          await updateElementInstances(
+            {
+              elementId: updatedElement.id,
+              includeTemplates: updateTemplateInstances,
+            },
+            tx,
+            ctx.emitter,
+            ctx.user.sub
+          )
+        }
+
+        return updatedElement
+      })
+    )
+  }
 
   // return the number of successfully updated elements
-  return successfullyUpdatedElements.length
+  return updatedElements.length
 }
 
 export async function changeElementStatus(

--- a/packages/graphql/src/services/elements.ts
+++ b/packages/graphql/src/services/elements.ts
@@ -535,9 +535,7 @@ export async function manipulateElement(
       explanation: typeof explanation === 'undefined' ? undefined : explanation,
       basePoints: basePoints!,
       pointsMultiplier: pointsMultiplier ?? 1,
-      version: {
-        increment: 1,
-      },
+      version: { increment: 1 },
       options: options ? processedOptions : undefined,
       // connect or create new tags and disconnect previous ones if they are selected anymore
       tags: {
@@ -720,6 +718,7 @@ export async function applyElementBatchOperations(
       DB.PermissionLevel.OWNER,
       DB.PermissionLevel.ADMIN,
       DB.PermissionLevel.WRITE,
+      DB.PermissionLevel.EXECUTE,
       DB.PermissionLevel.READ,
     ]
   } else {
@@ -772,6 +771,7 @@ export async function applyElementBatchOperations(
           const updatedElement = await tx.element.update({
             where: { id: element.id },
             data: {
+              version: { increment: 1 },
               isArchived: archive ? true : unarchive ? false : undefined,
               status: status ?? undefined,
               pointsMultiplier:
@@ -1511,72 +1511,49 @@ export async function updateElementInstances(
             include: {
               microLearning: {
                 where: {
-                  status: {
-                    in: acceptedStatusValues,
-                  },
+                  status: { in: acceptedStatusValues },
                   // only activities where the user has at least WRITE permissions should be updated
                   permissions: {
                     some: {
                       userId,
-                      permissionLevel: {
-                        in: requiredActivityAccess,
-                      },
+                      permissionLevel: { in: requiredActivityAccess },
                     },
                   },
                 },
-                include: {
-                  templateInfo: true,
-                },
+                include: { templateInfo: true },
               },
               practiceQuiz: {
                 where: {
-                  status: {
-                    in: acceptedStatusValues,
-                  },
+                  status: { in: acceptedStatusValues },
                   // only activities where the user has at least WRITE permissions should be updated
                   permissions: {
                     some: {
                       userId,
-                      permissionLevel: {
-                        in: requiredActivityAccess,
-                      },
+                      permissionLevel: { in: requiredActivityAccess },
                     },
                   },
                 },
-                include: {
-                  templateInfo: true,
-                },
+                include: { templateInfo: true },
               },
               groupActivity: {
                 where: {
-                  status: {
-                    in: acceptedStatusValues,
-                  },
+                  status: { in: acceptedStatusValues },
                   // only activities where the user has at least WRITE permissions should be updated
                   permissions: {
                     some: {
                       userId,
-                      permissionLevel: {
-                        in: requiredActivityAccess,
-                      },
+                      permissionLevel: { in: requiredActivityAccess },
                     },
                   },
                 },
-                include: {
-                  templateInfo: true,
-                },
+                include: { templateInfo: true },
               },
             },
           },
           elementBlock: {
             include: {
               // ? where clause is not accepted by prisma for unknown reasons
-              liveQuiz: {
-                include: {
-                  templateInfo: true,
-                  permissions: true,
-                },
-              },
+              liveQuiz: { include: { templateInfo: true, permissions: true } },
             },
           },
         },

--- a/packages/graphql/test/elementBatchOperations.test.ts
+++ b/packages/graphql/test/elementBatchOperations.test.ts
@@ -1,0 +1,1116 @@
+import {
+  ElementInstanceType,
+  ElementStatus,
+  ElementType,
+  PermissionLevel,
+  PrismaClient,
+} from '@klicker-uzh/prisma'
+import { ElementInstanceOptions, ElementOptions } from '@klicker-uzh/types'
+import {
+  getInitialInstanceResults,
+  processElementData,
+  recomputeDerivedPermissions,
+} from '@klicker-uzh/util'
+import { EventEmitter } from 'events'
+import { v4 as uuid } from 'uuid'
+import type { ContextWithUser } from '../src/lib/context.js'
+import { applyElementBatchOperations } from '../src/services/elements.js'
+import { initializePrisma, testCleanup, testInitialization } from './helpers.js'
+
+describe('Unit tests for sharing functionalities of courses', () => {
+  // shared resources used across tests
+  let prisma: PrismaClient
+  let emitter: EventEmitter
+  let userOneCtx: ContextWithUser
+  let userTwoCtx: ContextWithUser
+
+  beforeAll(async () => {
+    const { prisma: newPrisma, emitter: newEmitter } = await initializePrisma()
+    prisma = newPrisma
+    emitter = newEmitter
+  })
+
+  afterAll(async () => {
+    await testCleanup(prisma)
+    await prisma.$disconnect()
+  })
+
+  beforeEach(async () => {
+    const { userOneCtx: ctx1, userTwoCtx: ctx2 } = await testInitialization(
+      prisma,
+      emitter
+    )
+    userOneCtx = ctx1
+    userTwoCtx = ctx2
+  })
+
+  afterEach(async () => {
+    await testCleanup(prisma)
+  })
+
+  async function seedElement(args: { [x: string]: any }, prisma: PrismaClient) {
+    // Randomly choose one of the values of ElementType
+    const elementTypes = Object.values(ElementType)
+    const randomType =
+      elementTypes[Math.floor(Math.random() * elementTypes.length)]!
+
+    const element = await prisma.element.create({
+      data: {
+        name: uuid(),
+        content: uuid(),
+        type: randomType,
+        options: {} as ElementOptions,
+        ownerId: userOneCtx.user.sub,
+        ...args,
+      },
+    })
+
+    await recomputeDerivedPermissions(
+      { elementId: element.id, userId: userOneCtx.user.sub },
+      prisma
+    )
+
+    return element.id
+  }
+
+  async function seedElementPermissions(
+    prisma: PrismaClient,
+    args: { [x: string]: any } = {}
+  ) {
+    const readElement = await seedElement(
+      {
+        ...args,
+        ownerId: userTwoCtx.user.sub,
+        directPermissions: {
+          create: {
+            userId: userOneCtx.user.sub,
+            permissionLevel: PermissionLevel.READ,
+          },
+        },
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions({ elementId: readElement }, prisma)
+
+    const executeElement = await seedElement(
+      {
+        ...args,
+        ownerId: userTwoCtx.user.sub,
+        directPermissions: {
+          create: {
+            userId: userOneCtx.user.sub,
+            permissionLevel: PermissionLevel.EXECUTE,
+          },
+        },
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions({ elementId: executeElement }, prisma)
+
+    const writeElement = await seedElement(
+      {
+        ...args,
+        ownerId: userTwoCtx.user.sub,
+        directPermissions: {
+          create: {
+            userId: userOneCtx.user.sub,
+            permissionLevel: PermissionLevel.WRITE,
+          },
+        },
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions({ elementId: writeElement }, prisma)
+
+    const adminElement = await seedElement(
+      {
+        ...args,
+        ownerId: userTwoCtx.user.sub,
+        directPermissions: {
+          create: {
+            userId: userOneCtx.user.sub,
+            permissionLevel: PermissionLevel.ADMIN,
+          },
+        },
+      },
+      prisma
+    )
+    await recomputeDerivedPermissions({ elementId: adminElement }, prisma)
+
+    return { readElement, executeElement, writeElement, adminElement }
+  }
+
+  async function seedElementsDifferentTypes(prisma: PrismaClient) {
+    const SCWithSampleSolution = await seedElement(
+      {
+        type: ElementType.SC,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const SCWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.SC,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const MCWithSampleSolution = await seedElement(
+      {
+        type: ElementType.MC,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const MCWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.MC,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const KPWithSampleSolution = await seedElement(
+      {
+        type: ElementType.KPRIM,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const KPWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.KPRIM,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const NRWithSampleSolution = await seedElement(
+      {
+        type: ElementType.NUMERICAL,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const NRWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.NUMERICAL,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const FTWithSampleSolution = await seedElement(
+      {
+        type: ElementType.FREE_TEXT,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const FTWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.FREE_TEXT,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const SEWithSampleSolution = await seedElement(
+      {
+        type: ElementType.SELECTION,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const SEWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.SELECTION,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const CSWithSampleSolution = await seedElement(
+      {
+        type: ElementType.CASE_STUDY,
+        options: { hasSampleSolution: true },
+      },
+      prisma
+    )
+    const CSWithoutSampleSolution = await seedElement(
+      {
+        type: ElementType.CASE_STUDY,
+        options: { hasSampleSolution: false },
+      },
+      prisma
+    )
+
+    const FC = await seedElement(
+      {
+        type: ElementType.FLASHCARD,
+        options: {},
+      },
+      prisma
+    )
+
+    const content = await seedElement(
+      {
+        type: ElementType.CONTENT,
+        options: {},
+      },
+      prisma
+    )
+
+    return {
+      SCWithSampleSolution,
+      SCWithoutSampleSolution,
+      MCWithSampleSolution,
+      MCWithoutSampleSolution,
+      KPWithSampleSolution,
+      KPWithoutSampleSolution,
+      NRWithSampleSolution,
+      NRWithoutSampleSolution,
+      FTWithSampleSolution,
+      FTWithoutSampleSolution,
+      SEWithSampleSolution,
+      SEWithoutSampleSolution,
+      CSWithSampleSolution,
+      CSWithoutSampleSolution,
+      FC,
+      content,
+    }
+  }
+
+  it('Verify that only either the archive or unarchive flags can be set', async () => {
+    // verify that if no instances are provided, the operation will return 0
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [],
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+    expect(res).toEqual(0)
+
+    // verify that if both archive and unarchive are set, the operation will return 0
+    const resBoth = await applyElementBatchOperations(
+      {
+        elementIds: [1, 2],
+        archive: true,
+        unarchive: true,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+    expect(resBoth).toEqual(0)
+  })
+
+  it('Verify that only non-archived elements can be archived', async () => {
+    const archivedElements = await Promise.all(
+      Array.from(
+        { length: 5 },
+        async () => await seedElement({ isArchived: true }, prisma)
+      )
+    )
+    const nonArchivedElements = await Promise.all(
+      Array.from(
+        { length: 5 },
+        async () => await seedElement({ isArchived: false }, prisma)
+      )
+    )
+
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [...archivedElements, ...nonArchivedElements],
+        archive: true,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only non-archived elements were archived
+    expect(res).toEqual(nonArchivedElements.length)
+
+    // verify that the archived elements are still archived
+    const archivedCheck = await prisma.element.findMany({
+      where: {
+        id: { in: archivedElements },
+        isArchived: true,
+      },
+    })
+    expect(archivedCheck.length).toEqual(archivedElements.length)
+
+    // verify that the non-archived elements are now archived
+    const nonArchivedCheck = await prisma.element.findMany({
+      where: {
+        id: { in: nonArchivedElements },
+        isArchived: true,
+      },
+    })
+    expect(nonArchivedCheck.length).toEqual(nonArchivedElements.length)
+  })
+
+  it('Verify that only archived elements can be unarchived', async () => {
+    const archivedElements = await Promise.all(
+      Array.from(
+        { length: 5 },
+        async () => await seedElement({ isArchived: true }, prisma)
+      )
+    )
+    const nonArchivedElements = await Promise.all(
+      Array.from(
+        { length: 5 },
+        async () => await seedElement({ isArchived: false }, prisma)
+      )
+    )
+
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [...archivedElements, ...nonArchivedElements],
+        archive: false,
+        unarchive: true,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only archived elements were unarchived
+    expect(res).toEqual(archivedElements.length)
+
+    // verify that the non-archived elements are still non-archived
+    const nonArchivedCheck = await prisma.element.findMany({
+      where: {
+        id: { in: nonArchivedElements },
+        isArchived: false,
+      },
+    })
+    expect(nonArchivedCheck.length).toEqual(nonArchivedElements.length)
+
+    // verify that the archived elements are now non-archived
+    const archivedCheck = await prisma.element.findMany({
+      where: {
+        id: { in: archivedElements },
+        isArchived: false,
+      },
+    })
+    expect(archivedCheck.length).toEqual(archivedElements.length)
+  })
+
+  it('Verify that admin permissions are required for elements to be archived / unarchived', async () => {
+    const { readElement, executeElement, writeElement, adminElement } =
+      await seedElementPermissions(prisma)
+
+    // try to archive all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        archive: true,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only the admin element was archived
+    expect(res).toEqual(1)
+
+    // verify that the other elements are still non-archived
+    const nonArchivedCheck = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement] },
+        isArchived: false,
+      },
+    })
+    expect(nonArchivedCheck.length).toEqual(3)
+
+    // verify that the admin element is now archived
+    const archivedCheck = await prisma.element.findMany({
+      where: {
+        id: adminElement,
+        isArchived: true,
+      },
+    })
+    expect(archivedCheck.length).toEqual(1)
+
+    // archive all directly through the prisma client
+    await prisma.element.updateMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement, adminElement] },
+      },
+      data: { isArchived: true },
+    })
+
+    // try to unarchive all elements
+    const resUnarchive = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        archive: false,
+        unarchive: true,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only the admin element was unarchived
+    expect(resUnarchive).toEqual(1)
+
+    // verify that the other elements are still archived
+    const archivedCheckAfterUnarchive = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement] },
+        isArchived: true,
+      },
+    })
+    expect(archivedCheckAfterUnarchive.length).toEqual(3)
+
+    // verify that the admin element is now non-archived
+    const nonArchivedCheckAfterUnarchive = await prisma.element.findMany({
+      where: {
+        id: adminElement,
+        isArchived: false,
+      },
+    })
+    expect(nonArchivedCheckAfterUnarchive.length).toEqual(1)
+  })
+
+  it('Verify that status changes can be performed by all users that have some level of access to an element', async () => {
+    const { readElement, executeElement, writeElement, adminElement } =
+      await seedElementPermissions(prisma)
+
+    // try to change the status of all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        archive: false,
+        unarchive: false,
+        status: ElementStatus.REVIEW,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that all elements were updated
+    expect(res).toEqual(4)
+
+    // verify that the status of all elements was changed to REVIEW
+    const updatedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement, adminElement] },
+        status: ElementStatus.REVIEW,
+      },
+    })
+    expect(updatedElements.length).toEqual(4)
+
+    // try to change the status of all elements to DRAFT
+    const resDraft = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        archive: false,
+        unarchive: false,
+        status: ElementStatus.DRAFT,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that all elements were updated
+    expect(resDraft).toEqual(4)
+
+    // verify that the status of all elements was changed to DRAFT
+    const updatedElementsDraft = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement, adminElement] },
+        status: ElementStatus.DRAFT,
+      },
+    })
+    expect(updatedElementsDraft.length).toEqual(4)
+  })
+
+  it('Verify that multiplier changes can only be made on elements with a well-defined sample solution', async () => {
+    const {
+      SCWithSampleSolution,
+      SCWithoutSampleSolution,
+      MCWithSampleSolution,
+      MCWithoutSampleSolution,
+      KPWithSampleSolution,
+      KPWithoutSampleSolution,
+      NRWithSampleSolution,
+      NRWithoutSampleSolution,
+      FTWithSampleSolution,
+      FTWithoutSampleSolution,
+      SEWithSampleSolution,
+      SEWithoutSampleSolution,
+      CSWithSampleSolution,
+      CSWithoutSampleSolution,
+      FC,
+      content,
+    } = await seedElementsDifferentTypes(prisma)
+
+    // try to apply multiplier changes on all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [
+          SCWithSampleSolution,
+          SCWithoutSampleSolution,
+          MCWithSampleSolution,
+          MCWithoutSampleSolution,
+          KPWithSampleSolution,
+          KPWithoutSampleSolution,
+          NRWithSampleSolution,
+          NRWithoutSampleSolution,
+          FTWithSampleSolution,
+          FTWithoutSampleSolution,
+          SEWithSampleSolution,
+          SEWithoutSampleSolution,
+          CSWithSampleSolution,
+          CSWithoutSampleSolution,
+          FC,
+          content,
+        ],
+        multiplier: 2,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only elements with a sample solution were updated
+    expect(res).toEqual(7)
+
+    // verify that the elements with a sample solution have the multiplier set to 2
+    const updatedElements = await prisma.element.findMany({
+      where: { pointsMultiplier: 2 },
+    })
+    expect(updatedElements.length).toEqual(7)
+
+    // verify that the elements are the correct ones
+    const updatedElementIds = updatedElements.map((el) => el.id)
+    expect(new Set(updatedElementIds)).toEqual(
+      new Set([
+        SCWithSampleSolution,
+        MCWithSampleSolution,
+        KPWithSampleSolution,
+        NRWithSampleSolution,
+        FTWithSampleSolution,
+        SEWithSampleSolution,
+        CSWithSampleSolution,
+      ])
+    )
+  })
+
+  it('Verify that multiplier changes can be performed by all users that have at least write access to an element', async () => {
+    const { readElement, executeElement, writeElement, adminElement } =
+      await seedElementPermissions(prisma, {
+        type: ElementType.SC,
+        options: { hasSampleSolution: true },
+      })
+
+    // try to change the multiplier of all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        multiplier: 2,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only the write and admin elements were updated
+    expect(res).toEqual(2)
+
+    // verify that the multiplier of the write and admin elements was changed to 2
+    const updatedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [writeElement, adminElement] },
+        pointsMultiplier: 2,
+      },
+    })
+    expect(updatedElements.length).toEqual(2)
+
+    // verify that the read and execute elements are still unchanged
+    const unchangedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement] },
+        pointsMultiplier: 1,
+      },
+    })
+    expect(unchangedElements.length).toEqual(2)
+  })
+
+  it('Verify that base points can only be set on questions (not flashcards or content elements)', async () => {
+    const {
+      SCWithSampleSolution,
+      SCWithoutSampleSolution,
+      MCWithSampleSolution,
+      MCWithoutSampleSolution,
+      KPWithSampleSolution,
+      KPWithoutSampleSolution,
+      NRWithSampleSolution,
+      NRWithoutSampleSolution,
+      FTWithSampleSolution,
+      FTWithoutSampleSolution,
+      SEWithSampleSolution,
+      SEWithoutSampleSolution,
+      CSWithSampleSolution,
+      CSWithoutSampleSolution,
+      FC,
+      content,
+    } = await seedElementsDifferentTypes(prisma)
+
+    // try to disable base points on all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [
+          SCWithSampleSolution,
+          SCWithoutSampleSolution,
+          MCWithSampleSolution,
+          MCWithoutSampleSolution,
+          KPWithSampleSolution,
+          KPWithoutSampleSolution,
+          NRWithSampleSolution,
+          NRWithoutSampleSolution,
+          FTWithSampleSolution,
+          FTWithoutSampleSolution,
+          SEWithSampleSolution,
+          SEWithoutSampleSolution,
+          CSWithSampleSolution,
+          CSWithoutSampleSolution,
+          FC,
+          content,
+        ],
+        basePoints: false,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that all elements have base points disabled now (14 / 16 modified)
+    expect(res).toEqual(14)
+
+    // verify that all elements in the database now have base points disabled
+    const updatedElements = await prisma.element.findMany({
+      where: { basePoints: false },
+    })
+    expect(updatedElements.length).toEqual(14)
+
+    // enable base points on all elements
+    const resEnable = await applyElementBatchOperations(
+      {
+        elementIds: [
+          SCWithSampleSolution,
+          SCWithoutSampleSolution,
+          MCWithSampleSolution,
+          MCWithoutSampleSolution,
+          KPWithSampleSolution,
+          KPWithoutSampleSolution,
+          NRWithSampleSolution,
+          NRWithoutSampleSolution,
+          FTWithSampleSolution,
+          FTWithoutSampleSolution,
+          SEWithSampleSolution,
+          SEWithoutSampleSolution,
+          CSWithSampleSolution,
+          CSWithoutSampleSolution,
+          FC,
+          content,
+        ],
+        basePoints: true,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that all elements have base points enabled now (14 / 16 modified)
+    expect(resEnable).toEqual(14)
+
+    // verify that all elements in the database now have base points enabled (default for FC / CT)
+    const updatedElementsEnable = await prisma.element.findMany({
+      where: { basePoints: true },
+    })
+    expect(updatedElementsEnable.length).toEqual(16)
+  })
+
+  it('Verify that base points can only be set by users that have at least write access to an element', async () => {
+    const { readElement, executeElement, writeElement, adminElement } =
+      await seedElementPermissions(prisma, {
+        type: ElementType.SC,
+        basePoints: true,
+      })
+
+    // try to unset base points on all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        basePoints: false,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only the write and admin elements were updated
+    expect(res).toEqual(2)
+
+    // verify that the base points of the write and admin elements were changed to false
+    const updatedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [writeElement, adminElement] },
+        basePoints: false,
+      },
+    })
+    expect(updatedElements.length).toEqual(2)
+
+    // verify that the read and execute elements are still unchanged
+    const unchangedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement] },
+        basePoints: true,
+      },
+    })
+    expect(unchangedElements.length).toEqual(2)
+
+    // disable the base points on all elements through the prisma client
+    await prisma.element.updateMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement, adminElement] },
+      },
+      data: { basePoints: false },
+    })
+
+    // try to enable base points on all elements
+    const resEnable = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        basePoints: true,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that only the write and admin elements were updated
+    expect(resEnable).toEqual(2)
+
+    // verify that the base points of the write and admin elements were changed to true
+    const updatedElementsEnable = await prisma.element.findMany({
+      where: {
+        id: { in: [writeElement, adminElement] },
+        basePoints: true,
+      },
+    })
+    expect(updatedElementsEnable.length).toEqual(2)
+
+    // verify that the read and execute elements are still unchanged
+    const unchangedElementsEnable = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement] },
+        basePoints: false,
+      },
+    })
+    expect(unchangedElementsEnable.length).toEqual(2)
+  })
+
+  it('Verify that combinations of the batch operations are applied correctly (e.g. multiplier and base points, multiplier and status, etc.)', async () => {
+    const { readElement, executeElement, writeElement, adminElement } =
+      await seedElementPermissions(prisma, {
+        type: ElementType.SC,
+        status: ElementStatus.DRAFT,
+        pointsMultiplier: 1,
+        options: { hasSampleSolution: true },
+      })
+
+    // try to change the status and multiplier of all elements
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        status: ElementStatus.REVIEW,
+        multiplier: 2,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // verify that the changes only went into effect for the write and admin elements
+    expect(res).toEqual(2)
+
+    // verify that the status of the write and admin elements was changed to REVIEW
+    // and the multiplier was set to 2
+    const updatedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [writeElement, adminElement] },
+        status: ElementStatus.REVIEW,
+        pointsMultiplier: 2,
+      },
+    })
+    expect(updatedElements.length).toEqual(2)
+
+    // verify that the read and execute elements are still unchanged
+    const unchangedElements = await prisma.element.findMany({
+      where: {
+        id: { in: [readElement, executeElement] },
+        status: ElementStatus.DRAFT,
+        pointsMultiplier: 1,
+      },
+    })
+    expect(unchangedElements.length).toEqual(2)
+
+    // reset status and points multiplier,
+    await prisma.element.updateMany({
+      where: {
+        id: { in: [readElement, executeElement, writeElement, adminElement] },
+      },
+      data: { status: ElementStatus.DRAFT, pointsMultiplier: 1 },
+    })
+
+    // unset the sample solution on the read and write elements
+    await prisma.element.updateMany({
+      where: { id: { in: [readElement, writeElement] } },
+      data: { options: { hasSampleSolution: false } },
+    })
+
+    // try to change the multiplier and the base points of all elements
+    const resMultiplierBasePoints = await applyElementBatchOperations(
+      {
+        elementIds: [readElement, executeElement, writeElement, adminElement],
+        multiplier: 2,
+        basePoints: false,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+
+    // make sure that higher requiremenet of sample solution and write access was deciding -> only admin element was updated
+    expect(resMultiplierBasePoints).toEqual(1)
+
+    // verify that the multiplier of the admin element was changed to 2 and base points were disabled
+    const updatedElementsMultiplierBasePoints = await prisma.element.findMany({
+      where: {
+        id: adminElement,
+        pointsMultiplier: 2,
+        basePoints: false,
+      },
+    })
+    expect(updatedElementsMultiplierBasePoints.length).toEqual(1)
+
+    // verify that the read, execute and write elements are still unchanged
+    const unchangedElementsMultiplierBasePoints = await prisma.element.findMany(
+      {
+        where: {
+          id: { in: [readElement, executeElement, writeElement] },
+          pointsMultiplier: 1,
+          basePoints: true,
+        },
+      }
+    )
+    expect(unchangedElementsMultiplierBasePoints.length).toEqual(3)
+  })
+
+  it('Verify that element instance updates are correctly executed when corresponding flag is set', async () => {
+    const SCUpdated = await prisma.element.create({
+      data: {
+        name: 'Sample SC',
+        content: 'Sample content',
+        type: ElementType.SC,
+        options: { hasSampleSolution: true, choices: [] },
+        ownerId: userOneCtx.user.sub,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { elementId: SCUpdated.id, userId: userOneCtx.user.sub },
+      prisma
+    )
+    expect(SCUpdated).not.toBeNull()
+
+    const SCNotUpdated = await prisma.element.create({
+      data: {
+        name: 'Sample SC',
+        content: 'Sample content',
+        type: ElementType.SC,
+        options: { hasSampleSolution: false, choices: [] },
+        ownerId: userOneCtx.user.sub,
+      },
+    })
+    await recomputeDerivedPermissions(
+      { elementId: SCNotUpdated.id, userId: userOneCtx.user.sub },
+      prisma
+    )
+    expect(SCNotUpdated).not.toBeNull()
+
+    // include both elements in a live quiz
+    const liveQuiz = await prisma.liveQuiz.create({
+      data: {
+        name: 'Live Quiz',
+        displayName: 'Live Quiz',
+        ownerId: userOneCtx.user.sub,
+        pointsMultiplier: 2,
+        blocks: {
+          create: [
+            {
+              order: 0,
+              elements: {
+                create: [
+                  {
+                    type: ElementInstanceType.LIVE_QUIZ,
+                    elementId: SCUpdated.id,
+                    elementType: ElementType.SC,
+                    order: 0,
+                    options: { pointsMultiplier: 2 } as ElementInstanceOptions,
+                    elementData: processElementData(SCUpdated),
+                    results: getInitialInstanceResults(
+                      processElementData(SCUpdated)
+                    ),
+                    anonymousResults: getInitialInstanceResults(
+                      processElementData(SCUpdated)
+                    ),
+                    ownerId: userOneCtx.user.sub,
+                  },
+                  {
+                    type: ElementInstanceType.LIVE_QUIZ,
+                    elementId: SCNotUpdated.id,
+                    elementType: ElementType.SC,
+                    order: 1,
+                    options: { pointsMultiplier: 1 } as ElementInstanceOptions,
+                    elementData: processElementData(SCNotUpdated),
+                    results: getInitialInstanceResults(
+                      processElementData(SCNotUpdated)
+                    ),
+                    anonymousResults: getInitialInstanceResults(
+                      processElementData(SCNotUpdated)
+                    ),
+                    ownerId: userOneCtx.user.sub,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+    await recomputeDerivedPermissions(
+      { liveQuizId: liveQuiz.id, userId: userOneCtx.user.sub },
+      prisma
+    )
+    expect(liveQuiz).not.toBeNull()
+
+    // trigger an update of the mulitplier with the instance update flag disabled
+    const res = await applyElementBatchOperations(
+      {
+        elementIds: [SCUpdated.id, SCNotUpdated.id],
+        multiplier: 2,
+        archive: false,
+        unarchive: false,
+        updateInstances: false,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+    expect(res).toEqual(1)
+
+    // verify that only the multiplier of the SCUpdated element was changed
+    const updatedElements = await prisma.element.findMany({
+      where: {
+        id: SCUpdated.id,
+        pointsMultiplier: 2,
+      },
+    })
+    expect(updatedElements.length).toEqual(1)
+
+    // verify that the multiplier of the SCNotUpdated element is still 1
+    const unchangedElements = await prisma.element.findMany({
+      where: {
+        id: SCNotUpdated.id,
+        pointsMultiplier: 1,
+      },
+    })
+    expect(unchangedElements.length).toEqual(1)
+
+    // verify that the instance of the SCUpdated element was not updated
+    const updatedInstance = await prisma.elementInstance.findFirst({
+      where: {
+        elementId: SCUpdated.id,
+        type: ElementInstanceType.LIVE_QUIZ,
+      },
+    })
+    expect(updatedInstance?.elementData.id).toEqual(`${SCUpdated.id}-v1`)
+    expect(updatedInstance?.elementData.pointsMultiplier).toEqual(1)
+    expect(updatedInstance?.options.pointsMultiplier).toEqual(2)
+
+    // change the muliplier to 3 with the instance update flag enabled
+    const resWithUpdate = await applyElementBatchOperations(
+      {
+        elementIds: [SCUpdated.id, SCNotUpdated.id],
+        multiplier: 3,
+        archive: false,
+        unarchive: false,
+        updateInstances: true,
+        updateTemplateInstances: false,
+      },
+      userOneCtx
+    )
+    expect(resWithUpdate).toEqual(1)
+
+    // verify that the multiplier of the SCUpdated element was changed to 3
+    const updatedElementsWithUpdate = await prisma.element.findMany({
+      where: {
+        id: { in: [SCUpdated.id] },
+        pointsMultiplier: 3,
+      },
+    })
+    expect(updatedElementsWithUpdate.length).toEqual(1)
+
+    // verify that the multiplier of the SCNotUpdated element is still 1
+    const unchangedElementsWithUpdate = await prisma.element.findMany({
+      where: {
+        id: { in: [SCNotUpdated.id] },
+        pointsMultiplier: 1,
+      },
+    })
+    expect(unchangedElementsWithUpdate.length).toEqual(1)
+
+    // verify that the instance of the SCUpdated element was updated
+    const updatedInstanceWithUpdate = await prisma.elementInstance.findFirst({
+      where: {
+        elementId: SCUpdated.id,
+        type: ElementInstanceType.LIVE_QUIZ,
+      },
+    })
+    expect(updatedInstanceWithUpdate?.elementData.id).toEqual(
+      `${SCUpdated.id}-v3`
+    )
+    expect(updatedInstanceWithUpdate?.elementData.pointsMultiplier).toEqual(3)
+    expect(updatedInstanceWithUpdate?.options.pointsMultiplier).toEqual(6)
+  })
+})

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1306,7 +1306,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       batchOperations: 'Batch-Operationen ({numElements} Elemente)',
       batchOperationsElements: 'Batch-Operationen (Elemente)',
       selectedElementsDescription:
-        'Sie haben die folgenden Elemente ausgewählt. Alle Elemente, die von den gewählten Aktionen betroffen sind, sind markiert. Bitte beachten Sie: Einige Aktionen können nur einzeln durchgeführt werden oder erfordern bestimmte Zugriffsrechte (siehe Tooltip). Überprüfen Sie die ausgewählten Aktionen sorgfältig, bevor Sie diese anwenden.',
+        'Sie haben die folgenden Elemente ausgewählt. Alle Elemente, die von den gewählten Aktionen betroffen sind, sind markiert. Hovern Sie über dem Symbol für nicht betroffene Elemente für mehr Informationen. Bitte beachten Sie: Einige Aktionen können nur einzeln durchgeführt werden oder erfordern bestimmte Zugriffsrechte (siehe Tooltip). Überprüfen Sie die ausgewählten Aktionen sorgfältig, bevor Sie diese anwenden.',
       actionApplies: 'Aktion wird angewendet',
       modifyStatus: 'Status ändern',
       modifyMultiplier: 'Multiplikator ändern',
@@ -1326,13 +1326,31 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Wählen Sie hier, ob die Änderungen, die an den ausgewählten Elementen vorgenommen werden, auch auf alle Aktivitäten im Entwurf- und Planungsstatus angewendet werden sollen. Optional können Sie auch Aktivitätsvorlagen mit diesem Element in das Update einbeziehen.',
       activityUpdates: 'Aktivitäts-Updates',
       draftScheduledActivities: 'Entwurfs- und geplante Aktivitäten',
-      templateUpdates: 'Vorlagen-Updates',
+      templateUpdates: 'Aktivitätsvorlagen-Updates',
       batchOperationSuccess:
         'Ihre Batch-Operation wurde erfolgreich durchgeführt.',
       batchOperationPartialSuccess:
         'Nur ein Teil Ihrer Batch-Operation konnte erfolgreich angewendet werden. Bitte überprüfen Sie die betroffenen Elemente und Ihre Berechtigungen.',
       batchOperationFailed:
         'Beim Anwenden der Batch-Operation ist ein Fehler aufgetreten. Bitte überprüfen Sie Ihre Berechtigungen und versuchen Sie es erneut.',
+      batchNotApplicableExplanation:
+        'Die ausgewählten Batch-Operationen können aus den folgenden Gründen nicht auf dieses Element angewendet werden:',
+      batchUnarchiveOnlyArchivedElements:
+        'Die Wiederherstellung von Elementen aus dem Archiv ist nur für archivierte Elemente möglich',
+      batchUnarchiveOnlyManagerElements:
+        'Die Wiederherstellung von Elementen aus dem Archiv erfordert mindestens Adminrechte',
+      batchArchiveOnlyUnarchivedElements:
+        'Das Archivieren von Elementen ist nur für nicht archivierte Elemente möglich',
+      batchArchiveOnlyManagerElements:
+        'Das Archivieren von Elementen erfordert mindestens Adminrechte',
+      batchMultiplierOnlyEditorElements:
+        'Das Verändern von Multiplikatoren erfordert mindestens Schreibrechte.',
+      batchMultiplierOnlySampleSolution:
+        'Das Verändern von Multiplikatoren ist nur für Fragen mit einer definierten Musterlösung möglich.',
+      batchBasePointsOnlyEditorElements:
+        'Das Verändern von Basispunkten erfordert mindestens Schreibrechte.',
+      batchBasePointsOnlyQuestions:
+        'Basispunkte können nur für Fragen (nicht für Lernkarten oder Inhaltselemente) aktiviert / deaktiviert werden.',
     },
     tags: {
       deleteTag: 'Tag löschen',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1303,7 +1303,7 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       batchOperations: 'Batch operations ({numElements} elements)',
       batchOperationsElements: 'Batch Operations (Elements)',
       selectedElementsDescription:
-        'You have selected the following elements. All elements, which are affected by the selected actions, are marked. Please note: Some actions can only be performed separately or require specific permissions (see tooltip). Carefully review the selected actions and affected elements before applying them.',
+        'You have selected the following elements. All elements, which are affected by the selected actions, are marked. Hover over the icon for unaffected elements for more information. Please note: Some actions can only be performed separately or require specific permissions (see tooltip). Carefully review the selected actions and affected elements before applying them.',
       actionApplies: 'Action applies',
       modifyStatus: 'Modify status',
       modifyMultiplier: 'Modify multiplier',
@@ -1323,13 +1323,30 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         'Choose here if the modifications made to the selected elements should also be applied to all activities in draft and scheduled state. Optionally, you can also include activity templates with this element in the update.',
       activityUpdates: 'Activity updates',
       draftScheduledActivities: 'Draft and scheduled activities',
-      templateUpdates: 'Template updates',
-      batchOperationSuccess:
-        'Ihre Batch-Operation wurde erfolgreich durchgeführt.',
+      templateUpdates: 'Activity template updates',
+      batchOperationSuccess: 'Your batch operation was successfully applied.',
       batchOperationPartialSuccess:
-        'Nur ein Teil Ihrer Batch-Operation konnte erfolgreich angewendet werden. Bitte überprüfen Sie die betroffenen Elemente und Ihre Berechtigungen.',
+        'Only a part of your batch operation could be applied successfully. Please check the affected elements and your permissions.',
       batchOperationFailed:
-        'Beim Anwenden der Batch-Operation ist ein Fehler aufgetreten. Bitte überprüfen Sie Ihre Berechtigungen und versuchen Sie es erneut.',
+        'An error occurred while applying the batch operation. Please check your permissions and try again.',
+      batchNotApplicableExplanation:
+        'The selected batch operations cannot be applied to this element for the following reasons:',
+      batchUnarchiveOnlyArchivedElements:
+        'Restoring elements from the archive is only possible for archived elements',
+      batchUnarchiveOnlyManagerElements:
+        'Restoring elements from the archive requires at least admin permissions',
+      batchArchiveOnlyUnarchivedElements:
+        'Archiving elements is only possible for non-archived elements',
+      batchArchiveOnlyManagerElements:
+        'Archiving elements requires at least admin permissions',
+      batchMultiplierOnlyEditorElements:
+        'Changing the element multiplier requires at least write permissions.',
+      batchMultiplierOnlySampleSolution:
+        'Changing the element multiplier is only possible for questions with a defined sample solution.',
+      batchBasePointsOnlyEditorElements:
+        'Changing the element base points requires at least write permissions.',
+      batchBasePointsOnlyQuestions:
+        'Base points can only be enabled / disabled for questions (not flashcards or content elements).',
     },
     tags: {
       deleteTag: 'Delete tag',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks for batch element status changes (EXECUTE added) and ensured element versions increment during batch updates.
  * Switched batch processing to a sequential update flow to provide accurate update counts.

* **New Features**
  * UI now shows per-element eligibility with reasons and a hover tooltip; counts and messages reflect only applicable elements.
  * Apply action sends only eligible element IDs.

* **Tests**
  * Added comprehensive unit tests covering permissions, state rules, and instance update propagation.

* **Localization**
  * Added and updated English and German messages for batch-operation guidance and tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->