### PR TITLE
fix(apps/frontend-manage): ensure that element edit modal is not closed on element status change

### DIFF
--- a/apps/frontend-manage/src/components/elements/manipulation/ElementEditModal.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/ElementEditModal.tsx
@@ -143,8 +143,14 @@ function ElementEditModal({
         Object.keys(formikInitialValues).length === 0
       }
       initialValues={formikInitialValues}
-      onClose={() => {
+      onClose={async () => {
+        // close the modal
         handleSetIsOpen(false)
+
+        // refetch elements here, since element status might have changed and refetch cannot be used there to avoid closing modal
+        await refetchElements?.()
+
+        // remove potential query parameters that open element edit modal on reload
         const {
           editElementId,
           contextActivityId,

--- a/apps/frontend-manage/src/components/elements/manipulation/ElementInformationFields.tsx
+++ b/apps/frontend-manage/src/components/elements/manipulation/ElementInformationFields.tsx
@@ -96,7 +96,6 @@ function ElementInformationFields({
                 })
               }
 
-              await refetchElements?.()
               setFieldValue('status', newValue as ElementStatus)
               setStatusSaving(false)
             }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Elements list now refreshes automatically after closing the edit modal, and any temporary edit-related URL parameters are cleared.
- Bug Fixes
  - Ensures edited element changes are visible immediately upon closing the modal, reducing stale data.
- Refactor
  - Streamlined status updates to rely on local cache, removing unnecessary list refreshes for faster, smoother interactions.
- Chores
  - Updated internal handler behavior to support asynchronous close operations for consistent post-edit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->