### PR TITLE
enhance: add dedicated error page that handles server side errors and fix errors on activity overviews

### DIFF
--- a/apps/frontend-pwa/src/lib/getParticipantToken.ts
+++ b/apps/frontend-pwa/src/lib/getParticipantToken.ts
@@ -15,7 +15,6 @@ export default async function getParticipantToken({
   ctx: GetServerSidePropsContext
 }) {
   const { req, res, query } = ctx
-
   const cookies = nookies.get(ctx)
 
   // if the user already has a participant token, skip registration

--- a/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
@@ -89,7 +89,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/docs`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/docs`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
@@ -4,6 +4,7 @@ import getParticipantToken from '@lib/getParticipantToken'
 import useParticipantToken from '@lib/useParticipantToken'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import DocsLayout from '../../../../components/docs/DocsLayout'
 
 interface Props {
@@ -74,6 +75,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on course docs:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
@@ -78,7 +78,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/docs`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/docs`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/docs/index.tsx
@@ -35,42 +35,54 @@ function Landing({ participantToken, cookiesAvailable }: Props) {
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.courseId !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.courseId !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo()
 
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      courseId: ctx.params.courseId,
+      ctx,
+    })
 
-  if (participantToken) {
-    return {
+    if (participantToken) {
+      return {
+        props: {
+          cookiesAvailable,
+          participantToken,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
       props: {
-        cookiesAvailable,
-        participantToken,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on course docs:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/docs`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default Landing

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -613,42 +613,57 @@ function CourseOverview({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.courseId !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.courseId !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
+    // TODO: REMOVE FAKE ERROR
+    throw new Error('Test error')
 
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
+    const apolloClient = initializeApollo()
 
-  if (participantToken) {
-    return {
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      courseId: ctx.params.courseId,
+      ctx,
+    })
+
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
-        cookiesAvailable,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on course overview:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default CourseOverview

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -667,7 +667,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -624,9 +624,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       }
     }
 
-    // TODO: REMOVE FAKE ERROR
-    throw new Error('Test error')
-
     const apolloClient = initializeApollo()
 
     const { participantToken, cookiesAvailable } = await getParticipantToken({
@@ -656,25 +653,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on course overview:', error)
-
-    // TODO: remove setting of fake cookie to test removal
-    nookies.set(ctx, 'lti-token', 'asdf', {
-      domain: process.env.COOKIE_DOMAIN,
-      path: '/',
-      httpOnly: true,
-      maxAge: 60 * 2, // valid for 2 min
-      secure:
-        process.env.NODE_ENV === 'production' &&
-        process.env.COOKIE_DOMAIN !== '127.0.0.1',
-      sameSite:
-        process.env.NODE_ENV === 'development' ||
-        process.env.COOKIE_DOMAIN === '127.0.0.1'
-          ? 'lax'
-          : 'none',
-    })
-
-    // wait for 10 seconds
-    await new Promise((resolve) => setTimeout(resolve, 10000)) // TODO: REMOVE
 
     // remove the lti-token, if it is defined
     try {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -662,7 +662,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       domain: process.env.COOKIE_DOMAIN,
       path: '/',
       httpOnly: true,
-      maxAge: 1000 * 60 * 2, // valid for 2 min
+      maxAge: 60 * 2, // valid for 2 min
       secure:
         process.env.NODE_ENV === 'production' &&
         process.env.COOKIE_DOMAIN !== '127.0.0.1',
@@ -676,8 +676,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}`,
-        // destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`, // TODO: re-introduce correct URL
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -673,6 +673,19 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
           : 'none',
     })
 
+    // wait for 10 seconds
+    await new Promise((resolve) => setTimeout(resolve, 10000)) // TODO: REMOVE
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
+
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -30,6 +30,7 @@ import dayjs from 'dayjs'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
+import nookies from 'nookies'
 import Rank1Img from 'public/rank1.svg'
 import Rank2Img from 'public/rank2.svg'
 import Rank3Img from 'public/rank3.svg'
@@ -655,6 +656,22 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on course overview:', error)
+
+    // TODO: remove setting of fake cookie to test removal
+    nookies.set(ctx, 'lti-tokenv2', 'asdf', {
+      domain: process.env.COOKIE_DOMAIN,
+      path: '/',
+      httpOnly: true,
+      maxAge: 1000 * 60 * 2, // valid for 2 min
+      secure:
+        process.env.NODE_ENV === 'production' &&
+        process.env.COOKIE_DOMAIN !== '127.0.0.1',
+      sameSite:
+        process.env.NODE_ENV === 'development' ||
+        process.env.COOKIE_DOMAIN === '127.0.0.1'
+          ? 'lax'
+          : 'none',
+    })
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -676,7 +676,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -658,7 +658,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     console.error('Error in getServerSideProps on course overview:', error)
 
     // TODO: remove setting of fake cookie to test removal
-    nookies.set(ctx, 'lti-tokenv2', 'asdf', {
+    nookies.set(ctx, 'lti-token', 'asdf', {
       domain: process.env.COOKIE_DOMAIN,
       path: '/',
       httpOnly: true,
@@ -677,6 +677,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     return {
       redirect: {
         destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}`,
+        // destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`, // TODO: re-introduce correct URL
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/index.tsx
@@ -659,7 +659,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
@@ -161,7 +161,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/liveQuizzes/overview`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/liveQuizzes/overview`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
@@ -172,7 +172,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/liveQuizzes/overview`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/liveQuizzes/overview`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
@@ -90,71 +90,82 @@ function LiveQuizOverview({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.courseId !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.courseId !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo()
+    const result = await apolloClient.query({
+      query: GetCourseRunningLiveQuizzesDocument,
+      variables: {
+        courseId: ctx.params.courseId,
+      },
+    })
 
-  const result = await apolloClient.query({
-    query: GetCourseRunningLiveQuizzesDocument,
-    variables: {
+    // if there is no result (e.g., the shortname is not valid)
+    if (!result?.data?.getCourseRunningLiveQuizzes) {
+      return {
+        props: {
+          isInactive: true,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    // if only a single live quiz is running, redirect directly to the corresponding quiz page
+    // or if linkTo is set, redirect to the specified link
+    if (result.data.getCourseRunningLiveQuizzes.length === 1) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/session/${result.data.getCourseRunningLiveQuizzes[0].id}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
       courseId: ctx.params.courseId,
-    },
-  })
+      ctx,
+    })
 
-  // if there is no result (e.g., the shortname is not valid)
-  if (!result?.data?.getCourseRunningLiveQuizzes) {
-    return {
-      props: {
-        isInactive: true,
-        messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-          .default,
-      },
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
     }
-  }
 
-  // if only a single live quiz is running, redirect directly to the corresponding quiz page
-  // or if linkTo is set, redirect to the specified link
-  if (result.data.getCourseRunningLiveQuizzes.length === 1) {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/session/${result.data.getCourseRunningLiveQuizzes[0].id}`,
-        permanent: false,
-      },
-    }
-  }
-
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
-
-  if (participantToken) {
-    return {
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
-        cookiesAvailable,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on live quiz overview:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/liveQuizzes/overview`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default LiveQuizOverview

--- a/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/liveQuizzes/overview.tsx
@@ -8,6 +8,7 @@ import useParticipantToken from '@lib/useParticipantToken'
 import { H2, UserNotification } from '@uzh-bf/design-system'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import Layout from '../../../../components/Layout'
 import LinkButton from '../../../../components/common/LinkButton'
 
@@ -157,6 +158,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on live quiz overview:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
@@ -250,7 +250,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings/${ctx.params?.id}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings/${ctx.params?.id}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
@@ -261,7 +261,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings/${ctx.params?.id}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings/${ctx.params?.id}`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
@@ -21,6 +21,7 @@ import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import nookies from 'nookies'
 import Layout from '../../../../../components/Layout'
 import PreviewMessage from '../../../../../components/common/PreviewMessage'
 import MicroLearningSubscriber from '../../../../../components/microLearning/MicroLearningSubscriber'
@@ -246,6 +247,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on microlearning:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/[id]/index.tsx
@@ -203,46 +203,58 @@ function MicrolearningIntroduction({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (
-    typeof ctx.params?.courseId !== 'string' ||
-    typeof ctx.params?.id !== 'string'
-  ) {
+  try {
+    if (
+      typeof ctx.params?.courseId !== 'string' ||
+      typeof ctx.params?.id !== 'string'
+    ) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          permanent: false,
+        },
+      }
+    }
+
+    const apolloClient = initializeApollo()
+
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      courseId: ctx.params.courseId,
+      ctx,
+    })
+
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          id: ctx.params.id,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
+      props: {
+        id: ctx.params.id,
+        courseId: ctx.params.courseId,
+        messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+          .default,
+      },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on microlearning:', error)
+
+    // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings/${ctx.params?.id}`,
         permanent: false,
       },
     }
   }
-
-  const apolloClient = initializeApollo()
-
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
-
-  if (participantToken) {
-    return {
-      props: {
-        participantToken,
-        cookiesAvailable,
-        id: ctx.params.id,
-        messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-          .default,
-      },
-    }
-  }
-
-  return addApolloState(apolloClient, {
-    props: {
-      id: ctx.params.id,
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default MicrolearningIntroduction

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
@@ -184,7 +184,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
@@ -173,7 +173,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
@@ -98,71 +98,86 @@ function MicroLearningsOverview({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.courseId !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.courseId !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
-  const result = await apolloClient.query({
-    query: GetCoursePublishedMicroLearningsDocument,
-    variables: {
+    const apolloClient = initializeApollo()
+    const result = await apolloClient.query({
+      query: GetCoursePublishedMicroLearningsDocument,
+      variables: {
+        courseId: ctx.params.courseId,
+      },
+    })
+
+    // if there is no result (e.g., the shortname is not valid)
+    const course = result.data.getCoursePublishedMicroLearnings?.[0]?.course
+    if (!result?.data?.getCoursePublishedMicroLearnings || !course) {
+      return {
+        props: {
+          isInactive: true,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    // if only a single live quiz is running, redirect directly to the corresponding quiz page
+    // or if linkTo is set, redirect to the specified link
+    if (result.data.getCoursePublishedMicroLearnings.length === 1) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/course/${course.id}/microLearnings/${result.data.getCoursePublishedMicroLearnings[0].id}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
       courseId: ctx.params.courseId,
-    },
-  })
+      ctx,
+    })
 
-  // if there is no result (e.g., the shortname is not valid)
-  const course = result.data.getCoursePublishedMicroLearnings?.[0]?.course
-  if (!result?.data?.getCoursePublishedMicroLearnings || !course) {
-    return {
-      props: {
-        isInactive: true,
-        messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-          .default,
-      },
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
     }
-  }
 
-  // if only a single live quiz is running, redirect directly to the corresponding quiz page
-  // or if linkTo is set, redirect to the specified link
-  if (result.data.getCoursePublishedMicroLearnings.length === 1) {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/course/${course.id}/microLearnings/${result.data.getCoursePublishedMicroLearnings[0].id}`,
-        permanent: false,
-      },
-    }
-  }
-
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
-
-  if (participantToken) {
-    return {
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
-        cookiesAvailable,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error(
+      'Error in getServerSideProps on microlearnings overview page:',
+      error
+    )
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/microLearnings`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default MicroLearningsOverview

--- a/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/microLearnings/overview.tsx
@@ -9,6 +9,7 @@ import { H2, UserNotification } from '@uzh-bf/design-system'
 import dayjs from 'dayjs'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import Layout from '../../../../components/Layout'
 import LinkButton from '../../../../components/common/LinkButton'
 
@@ -169,6 +170,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       'Error in getServerSideProps on microlearnings overview page:',
       error
     )
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
@@ -125,7 +125,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practice`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practice`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
@@ -83,41 +83,53 @@ function PracticePool({ courseId, participantToken, cookiesAvailable }: Props) {
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.courseId !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.courseId !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
+    const apolloClient = initializeApollo()
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      courseId: ctx.params.courseId,
+      ctx,
+    })
 
-  if (participantToken) {
-    return {
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
-        cookiesAvailable,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on practice:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practice`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default PracticePool

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
@@ -136,7 +136,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practice`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/practice`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practice.tsx
@@ -7,6 +7,7 @@ import useParticipantToken from '@lib/useParticipantToken'
 import { UserNotification } from '@uzh-bf/design-system'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import { useState } from 'react'
 import Layout from '../../../components/Layout'
 import Footer from '../../../components/common/Footer'
@@ -121,6 +122,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on practice:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
@@ -113,47 +113,59 @@ function PracticeQuizPage({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (
-    typeof ctx.params?.courseId !== 'string' ||
-    typeof ctx.params?.id !== 'string'
-  ) {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (
+      typeof ctx.params?.courseId !== 'string' ||
+      typeof ctx.params?.id !== 'string'
+    ) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo()
 
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      courseId: ctx.params.courseId,
+      ctx,
+    })
 
-  if (participantToken) {
-    return {
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          id: ctx.params.id,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
-        cookiesAvailable,
         id: ctx.params.id,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on practice quiz:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      id: ctx.params.id,
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default PracticeQuizPage

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
@@ -161,7 +161,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
@@ -172,7 +172,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/[id].tsx
@@ -11,6 +11,7 @@ import { UserNotification } from '@uzh-bf/design-system'
 import dayjs from 'dayjs'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import { useState } from 'react'
 import Layout from '../../../../components/Layout'
 import Footer from '../../../../components/common/Footer'
@@ -157,6 +158,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on practice quiz:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
@@ -182,7 +182,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
@@ -8,6 +8,7 @@ import useParticipantToken from '@lib/useParticipantToken'
 import { H2, UserNotification } from '@uzh-bf/design-system'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import Layout from '../../../../components/Layout'
 import LinkButton from '../../../../components/common/LinkButton'
 
@@ -167,6 +168,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       'Error in getServerSideProps on practice quiz overview:',
       error
     )
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
@@ -171,7 +171,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/practiceQuizzes/overview.tsx
@@ -95,73 +95,87 @@ function PracticeQuizOverview({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.courseId !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.courseId !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo()
+    const result = await apolloClient.query({
+      query: GetCoursePublishedPracticeQuizzesDocument,
+      variables: {
+        courseId: ctx.params.courseId,
+      },
+    })
 
-  const result = await apolloClient.query({
-    query: GetCoursePublishedPracticeQuizzesDocument,
-    variables: {
+    // if there is no result (e.g., the shortname is not valid)
+    const quizzes = result.data.getCoursePublishedPracticeQuizzes
+    const course = quizzes?.[0]?.course
+    if (!result?.data?.getCoursePublishedPracticeQuizzes || !course) {
+      return {
+        props: {
+          isInactive: true,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    // if only a single practice quiz is running, redirect directly to the corresponding quiz page
+    // or if linkTo is set, redirect to the specified link
+    if (quizzes.length === 1) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/course/${course.id}/practiceQuizzes/${quizzes[0].id}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
       courseId: ctx.params.courseId,
-    },
-  })
+      ctx,
+    })
 
-  // if there is no result (e.g., the shortname is not valid)
-  const quizzes = result.data.getCoursePublishedPracticeQuizzes
-  const course = quizzes?.[0]?.course
-  if (!result?.data?.getCoursePublishedPracticeQuizzes || !course) {
-    return {
-      props: {
-        isInactive: true,
-        messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-          .default,
-      },
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          courseId: ctx.params.courseId,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
     }
-  }
 
-  // if only a single practice quiz is running, redirect directly to the corresponding quiz page
-  // or if linkTo is set, redirect to the specified link
-  if (quizzes.length === 1) {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/course/${course.id}/practiceQuizzes/${quizzes[0].id}`,
-        permanent: false,
-      },
-    }
-  }
-
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    courseId: ctx.params.courseId,
-    ctx,
-  })
-
-  if (participantToken) {
-    return {
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
-        cookiesAvailable,
         courseId: ctx.params.courseId,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error(
+      'Error in getServerSideProps on practice quiz overview:',
+      error
+    )
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/course/${ctx.params?.courseId}/practiceQuizzes/${ctx.params?.id}`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      courseId: ctx.params.courseId,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default PracticeQuizOverview

--- a/apps/frontend-pwa/src/pages/createAccount.tsx
+++ b/apps/frontend-pwa/src/pages/createAccount.tsx
@@ -196,7 +196,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/createAccount`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/createAccount`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/createAccount.tsx
+++ b/apps/frontend-pwa/src/pages/createAccount.tsx
@@ -206,7 +206,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/createAccount`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/createAccount`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/createAccount.tsx
+++ b/apps/frontend-pwa/src/pages/createAccount.tsx
@@ -193,6 +193,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   } catch (error) {
     console.error('Error in getServerSideProps on createAccount:', error)
 
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
+
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {

--- a/apps/frontend-pwa/src/pages/createAccount.tsx
+++ b/apps/frontend-pwa/src/pages/createAccount.tsx
@@ -83,92 +83,103 @@ function CreateAccount({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  const { req, res, query } = ctx
+  try {
+    const { req, res, query } = ctx
+    const apolloClient = initializeApollo()
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      ctx,
+    })
 
-  const apolloClient = initializeApollo()
+    if (participantToken) {
+      if (!cookiesAvailable) {
+        return {
+          redirect: {
+            destination: `${ctx.locale ? `/${ctx.locale}` : ''}/editProfile?participantToken=${participantToken}`,
+            permanent: false,
+            query: { participantToken },
+          },
+        }
+      }
 
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    ctx,
-  })
-
-  if (participantToken) {
-    if (!cookiesAvailable) {
       return {
         redirect: {
-          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/editProfile?participantToken=${participantToken}`,
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/editProfile`,
           permanent: false,
-          query: { participantToken },
         },
       }
     }
 
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/editProfile`,
-        permanent: false,
-      },
+    const cookies = nookies.get(ctx)
+    const signedLtiData = { token: '', ssoId: '', email: '' }
+
+    // LTI 1.3 authentication flow
+    if (cookies['lti-token'] || query.jwt) {
+      const token = cookies['lti-token'] ?? query.jwt
+
+      const parsedToken = JWT.verify(
+        token,
+        process.env.APP_SECRET as string
+      ) as {
+        sub: string
+        email: string
+        scope: string
+      }
+
+      if (parsedToken.scope === 'LTI1.3') {
+        signedLtiData.token = token
+        signedLtiData.ssoId = parsedToken.sub
+        signedLtiData.email = parsedToken.email
+      }
     }
-  }
-
-  const cookies = nookies.get(ctx)
-
-  const signedLtiData = {
-    token: '',
-    ssoId: '',
-    email: '',
-  }
-
-  // LTI 1.3 authentication flow
-  if (cookies['lti-token'] || query.jwt) {
-    const token = cookies['lti-token'] ?? query.jwt
-
-    const parsedToken = JWT.verify(token, process.env.APP_SECRET as string) as {
-      sub: string
-      email: string
-      scope: string
-    }
-
-    if (parsedToken.scope === 'LTI1.3') {
-      signedLtiData.token = token
-      signedLtiData.ssoId = parsedToken.sub
-      signedLtiData.email = parsedToken.email
-    }
-  }
-  // LTI 1.1 authentication flow
-  else if (req.method === 'POST') {
-    const { request }: any = await new Promise((resolve) => {
-      bodyParser.urlencoded({ extended: true })(req, res, () => {
-        bodyParser.json()(req, res, () => {
-          resolve({ request: req })
+    // LTI 1.1 authentication flow
+    else if (req.method === 'POST') {
+      const { request }: any = await new Promise((resolve) => {
+        bodyParser.urlencoded({ extended: true })(req, res, () => {
+          bodyParser.json()(req, res, () => {
+            resolve({ request: req })
+          })
         })
       })
-    })
 
-    if (request?.body?.lis_person_sourcedid) {
-      signedLtiData.token = JWT.sign(
-        {
-          sub: request.body.lis_person_sourcedid,
-          email: request.body.lis_person_contact_email_primary,
-          scope: 'LTI1.1',
-        },
-        process.env.APP_SECRET as string,
-        {
-          algorithm: 'HS256',
-          expiresIn: '5m',
-        }
-      )
-      signedLtiData.ssoId = request.body.lis_person_sourcedid
-      signedLtiData.email = request.body.lis_person_contact_email_primary
+      if (request?.body?.lis_person_sourcedid) {
+        signedLtiData.token = JWT.sign(
+          {
+            sub: request.body.lis_person_sourcedid,
+            email: request.body.lis_person_contact_email_primary,
+            scope: 'LTI1.1',
+          },
+          process.env.APP_SECRET as string,
+          {
+            algorithm: 'HS256',
+            expiresIn: '5m',
+          }
+        )
+        signedLtiData.ssoId = request.body.lis_person_sourcedid
+        signedLtiData.email = request.body.lis_person_contact_email_primary
+      }
     }
-  }
 
-  if (!query?.disableLti && signedLtiData.token !== '') {
-    return addApolloState(apolloClient, {
+    if (!query?.disableLti && signedLtiData.token !== '') {
+      return addApolloState(apolloClient, {
+        props: {
+          signedLtiData: signedLtiData.token,
+          ssoId: signedLtiData.ssoId,
+          email: signedLtiData.email,
+          username: generatePassword.generate({
+            length: 10,
+            uppercase: true,
+            symbols: false,
+            numbers: true,
+          }),
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      })
+    }
+
+    return {
       props: {
-        signedLtiData: signedLtiData.token,
-        ssoId: signedLtiData.ssoId,
-        email: signedLtiData.email,
         username: generatePassword.generate({
           length: 10,
           uppercase: true,
@@ -178,20 +189,17 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
-    })
-  }
+    }
+  } catch (error) {
+    console.error('Error in getServerSideProps on createAccount:', error)
 
-  return {
-    props: {
-      username: generatePassword.generate({
-        length: 10,
-        uppercase: true,
-        symbols: false,
-        numbers: true,
-      }),
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/createAccount`,
+        permanent: false,
+      },
+    }
   }
 }
 

--- a/apps/frontend-pwa/src/pages/editProfile.tsx
+++ b/apps/frontend-pwa/src/pages/editProfile.tsx
@@ -7,6 +7,7 @@ import useParticipantToken from '@lib/useParticipantToken'
 import { toast } from '@uzh-bf/design-system'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import Layout from '../components/Layout'
 import AccountDeletionForm from '../components/forms/AccountDeletionForm'
 import AvatarUpdateForm from '../components/forms/AvatarUpdateForm'
@@ -118,6 +119,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on editProfile:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/editProfile.tsx
+++ b/apps/frontend-pwa/src/pages/editProfile.tsx
@@ -133,7 +133,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/editProfile`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/editProfile`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/editProfile.tsx
+++ b/apps/frontend-pwa/src/pages/editProfile.tsx
@@ -82,40 +82,51 @@ function EditProfile({ participantToken, cookiesAvailable }: Props) {
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  const apolloClient = initializeApollo()
+  try {
+    const apolloClient = initializeApollo()
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      ctx,
+    })
 
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    ctx,
-  })
-
-  if (!participantToken) {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/createAccount`,
-        permanent: false,
-      },
+    if (!participantToken) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/createAccount`,
+          permanent: false,
+        },
+      }
     }
-  }
 
-  if (participantToken) {
-    return {
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
       props: {
-        participantToken,
         cookiesAvailable,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on editProfile:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/editProfile`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      cookiesAvailable,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default EditProfile

--- a/apps/frontend-pwa/src/pages/editProfile.tsx
+++ b/apps/frontend-pwa/src/pages/editProfile.tsx
@@ -122,7 +122,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/editProfile`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/editProfile`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/join/[shortname].tsx
+++ b/apps/frontend-pwa/src/pages/join/[shortname].tsx
@@ -7,6 +7,7 @@ import useParticipantToken from '@lib/useParticipantToken'
 import { H2, UserNotification } from '@uzh-bf/design-system'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
+import nookies from 'nookies'
 import Layout from '../../components/Layout'
 import LinkButton from '../../components/common/LinkButton'
 
@@ -152,6 +153,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     })
   } catch (error) {
     console.error('Error in getServerSideProps on join page:', error)
+
+    // remove the lti-token, if it is defined
+    try {
+      nookies.destroy(ctx, 'lti-token', {
+        domain: process.env.COOKIE_DOMAIN,
+        path: '/',
+      })
+    } catch (nookiesError) {
+      console.error(nookiesError)
+    }
 
     // redirect to lti error page with redirect back to this page
     return {

--- a/apps/frontend-pwa/src/pages/join/[shortname].tsx
+++ b/apps/frontend-pwa/src/pages/join/[shortname].tsx
@@ -156,7 +156,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/join/${ctx.params?.shortname}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/join/${ctx.params?.shortname}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/join/[shortname].tsx
+++ b/apps/frontend-pwa/src/pages/join/[shortname].tsx
@@ -167,7 +167,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // redirect to lti error page with redirect back to this page
     return {
       redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/join/${ctx.params?.shortname}`,
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/serverError?redirectTo=${encodeURIComponent(`/${ctx.locale}/join/${ctx.params?.shortname}`)}`,
         permanent: false,
       },
     }

--- a/apps/frontend-pwa/src/pages/join/[shortname].tsx
+++ b/apps/frontend-pwa/src/pages/join/[shortname].tsx
@@ -86,70 +86,81 @@ function Join({
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  if (typeof ctx.params?.shortname !== 'string') {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
-        statusCode: 302,
-      },
+  try {
+    if (typeof ctx.params?.shortname !== 'string') {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/404`,
+          statusCode: 302,
+        },
+      }
     }
-  }
 
-  const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo()
+    const result = await apolloClient.query({
+      query: GetShortnameQuizzesDocument,
+      variables: {
+        shortname: ctx.params.shortname,
+      },
+    })
 
-  const result = await apolloClient.query({
-    query: GetShortnameQuizzesDocument,
-    variables: {
-      shortname: ctx.params.shortname,
-    },
-  })
+    // if there is no result (e.g., the shortname is not valid)
+    if (!result?.data?.shortnameQuizzes) {
+      return {
+        props: {
+          isInactive: true,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
 
-  // if there is no result (e.g., the shortname is not valid)
-  if (!result?.data?.shortnameQuizzes) {
-    return {
+    // if only a single live quiz is running, redirect directly to the corresponding quiz page
+    // or if linkTo is set, redirect to the specified link
+    if (result.data.shortnameQuizzes.length === 1) {
+      return {
+        redirect: {
+          destination: `${ctx.locale ? `/${ctx.locale}` : ''}/session/${result.data.shortnameQuizzes[0].id}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const { participantToken, cookiesAvailable } = await getParticipantToken({
+      apolloClient,
+      ctx,
+    })
+
+    if (participantToken) {
+      return {
+        props: {
+          participantToken,
+          cookiesAvailable,
+          shortname: ctx.params.shortname,
+          messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
+            .default,
+        },
+      }
+    }
+
+    return addApolloState(apolloClient, {
       props: {
-        isInactive: true,
-        messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-          .default,
-      },
-    }
-  }
-
-  // if only a single live quiz is running, redirect directly to the corresponding quiz page
-  // or if linkTo is set, redirect to the specified link
-  if (result.data.shortnameQuizzes.length === 1) {
-    return {
-      redirect: {
-        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/session/${result.data.shortnameQuizzes[0].id}`,
-        permanent: false,
-      },
-    }
-  }
-
-  const { participantToken, cookiesAvailable } = await getParticipantToken({
-    apolloClient,
-    ctx,
-  })
-
-  if (participantToken) {
-    return {
-      props: {
-        participantToken,
-        cookiesAvailable,
         shortname: ctx.params.shortname,
         messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
           .default,
       },
+    })
+  } catch (error) {
+    console.error('Error in getServerSideProps on join page:', error)
+
+    // redirect to lti error page with redirect back to this page
+    return {
+      redirect: {
+        destination: `${ctx.locale ? `/${ctx.locale}` : ''}/ltiError?redirectTo=${process.env.NEXT_PUBLIC_PWA_URL}/${ctx.locale}/join/${ctx.params?.shortname}`,
+        permanent: false,
+      },
     }
   }
-
-  return addApolloState(apolloClient, {
-    props: {
-      shortname: ctx.params.shortname,
-      messages: (await import(`@klicker-uzh/i18n/messages/${ctx.locale}`))
-        .default,
-    },
-  })
 }
 
 export default Join

--- a/apps/frontend-pwa/src/pages/ltiError.tsx
+++ b/apps/frontend-pwa/src/pages/ltiError.tsx
@@ -1,0 +1,65 @@
+import {
+  faArrowsRotate,
+  faExclamationCircle,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Button, H1 } from '@uzh-bf/design-system'
+import { GetStaticPropsContext } from 'next'
+import { useTranslations } from 'next-intl'
+import { useRouter } from 'next/router'
+import nookies from 'nookies'
+import Layout from '../components/Layout'
+
+function Index() {
+  const t = useTranslations()
+  const router = useRouter()
+
+  return (
+    <Layout displayName={t('shared.generic.title')}>
+      <div className="flex h-full flex-col items-center justify-center text-center">
+        <div className="flex flex-row items-center gap-4 text-red-600">
+          <FontAwesomeIcon icon={faExclamationCircle} size="3x" />
+          <H1 className={{ root: 'mb-0' }}>{t('pwa.lti.loginFailedTitle')}</H1>
+        </div>
+        <p className="max-w-120 my-4 text-gray-600">
+          {t('pwa.lti.loginFailedDescription')}
+        </p>
+        <Button
+          onClick={() => {
+            // TODO: remove this branch before merging, if the approach does not work to reset the lti token cookie
+            // reset cookies
+            nookies.destroy(null, 'lti-token', {
+              domain: process.env.COOKIE_DOMAIN,
+              path: '/',
+            })
+
+            // redirect to page in query parameter, if defined
+            if (
+              router.query.redirectTo &&
+              typeof router.query.redirectTo === 'string'
+            ) {
+              router.push(router.query.redirectTo)
+            }
+          }}
+          className={{ root: 'h-8' }}
+        >
+          <Button.Icon icon={faArrowsRotate} />
+          <Button.Label>{t('pwa.lti.tryAgain')}</Button.Label>
+        </Button>
+      </div>
+    </Layout>
+  )
+}
+
+export async function getStaticProps({ locale }: GetStaticPropsContext) {
+  return {
+    props: {
+      messages: (await import(`@klicker-uzh/i18n/messages/${locale}`)).default,
+    },
+  }
+}
+
+export default Index
+
+// TODO: remove
+// https://pwa.klicker.com/ltiError?redirectTo=https://pwa.klicker.com/createAccount

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -26,11 +26,18 @@ function Index() {
         <Button
           onClick={() => {
             // redirect to page in query parameter, if defined
+            const redirectTo = router.query.redirectTo
             if (
-              router.query.redirectTo &&
-              typeof router.query.redirectTo === 'string'
+              redirectTo &&
+              typeof redirectTo === 'string' &&
+              redirectTo.startsWith('/') &&
+              !redirectTo.startsWith('//') && // prevent protocol-relative
+              !redirectTo.includes('://') // prevent absolute URLs
             ) {
-              router.push(router.query.redirectTo)
+              router.push(redirectTo)
+            } else {
+              // fallback, navigate to home page
+              router.push('/')
             }
           }}
           className={{ root: 'h-8' }}

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -25,9 +25,14 @@ function Index() {
         </p>
         <Button
           onClick={() => {
-            // remove lti-token cookie by setting it to expire in the past
-            document.cookie =
-              'lti-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+            // remove the lti token cookie
+            if (process.env.NEXT_PUBLIC_COOKIE_DOMAIN) {
+              document.cookie = `lti-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${process.env.NEXT_PUBLIC_COOKIE_DOMAIN}; secure; samesite=none`
+            } else {
+              // fallback without domain if env var not available
+              document.cookie =
+                'lti-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; secure; samesite=none'
+            }
 
             // redirect to page in query parameter, if defined
             if (

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -52,6 +52,3 @@ export async function getStaticProps({ locale }: GetStaticPropsContext) {
 }
 
 export default Index
-
-// TODO: remove
-// https://pwa.klicker.com/serverError?redirectTo=https://pwa.klicker.com/createAccount

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -26,9 +26,15 @@ function Index() {
         </p>
         <Button
           onClick={() => {
-            // TODO: remove this branch before merging, if the approach does not work to reset the lti token cookie
-            // reset cookies
+            // TODO: remove this, if it does not work as desired
+            // reset lti-token cookie that can create issues with authentication
             nookies.destroy(null, 'lti-token', {
+              domain: process.env.COOKIE_DOMAIN,
+              path: '/',
+            })
+
+            // TODO: remove - test code to determine if cookies can be removed through client
+            nookies.destroy(null, 'lti-tokenv2', {
               domain: process.env.COOKIE_DOMAIN,
               path: '/',
             })

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -26,15 +26,8 @@ function Index() {
         </p>
         <Button
           onClick={() => {
-            // TODO: remove this, if it does not work as desired
             // reset lti-token cookie that can create issues with authentication
             nookies.destroy(null, 'lti-token', {
-              domain: process.env.COOKIE_DOMAIN,
-              path: '/',
-            })
-
-            // TODO: remove - test code to determine if cookies can be removed through client
-            nookies.destroy(null, 'lti-tokenv2', {
               domain: process.env.COOKIE_DOMAIN,
               path: '/',
             })

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -7,7 +7,6 @@ import { Button, H1 } from '@uzh-bf/design-system'
 import { GetStaticPropsContext } from 'next'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
-import nookies from 'nookies'
 import Layout from '../components/Layout'
 
 function Index() {
@@ -26,11 +25,9 @@ function Index() {
         </p>
         <Button
           onClick={() => {
-            // reset lti-token cookie that can create issues with authentication
-            nookies.destroy(null, 'lti-token', {
-              domain: process.env.COOKIE_DOMAIN,
-              path: '/',
-            })
+            // remove lti-token cookie by setting it to expire in the past
+            document.cookie =
+              'lti-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
 
             // redirect to page in query parameter, if defined
             if (

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -25,15 +25,6 @@ function Index() {
         </p>
         <Button
           onClick={() => {
-            // remove the lti token cookie
-            if (process.env.NEXT_PUBLIC_COOKIE_DOMAIN) {
-              document.cookie = `lti-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${process.env.NEXT_PUBLIC_COOKIE_DOMAIN}; secure; samesite=none`
-            } else {
-              // fallback without domain if env var not available
-              document.cookie =
-                'lti-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; secure; samesite=none'
-            }
-
             // redirect to page in query parameter, if defined
             if (
               router.query.redirectTo &&

--- a/apps/frontend-pwa/src/pages/serverError.tsx
+++ b/apps/frontend-pwa/src/pages/serverError.tsx
@@ -19,10 +19,10 @@ function Index() {
       <div className="flex h-full flex-col items-center justify-center text-center">
         <div className="flex flex-row items-center gap-4 text-red-600">
           <FontAwesomeIcon icon={faExclamationCircle} size="3x" />
-          <H1 className={{ root: 'mb-0' }}>{t('pwa.lti.loginFailedTitle')}</H1>
+          <H1 className={{ root: 'mb-0' }}>{t('pwa.serverError.warning')}</H1>
         </div>
-        <p className="max-w-120 my-4 text-gray-600">
-          {t('pwa.lti.loginFailedDescription')}
+        <p className="max-w-140 my-4 text-gray-600">
+          {t('pwa.serverError.serverSideError')}
         </p>
         <Button
           onClick={() => {
@@ -44,7 +44,7 @@ function Index() {
           className={{ root: 'h-8' }}
         >
           <Button.Icon icon={faArrowsRotate} />
-          <Button.Label>{t('pwa.lti.tryAgain')}</Button.Label>
+          <Button.Label>{t('pwa.serverError.tryAgain')}</Button.Label>
         </Button>
       </div>
     </Layout>
@@ -62,4 +62,4 @@ export async function getStaticProps({ locale }: GetStaticPropsContext) {
 export default Index
 
 // TODO: remove
-// https://pwa.klicker.com/ltiError?redirectTo=https://pwa.klicker.com/createAccount
+// https://pwa.klicker.com/serverError?redirectTo=https://pwa.klicker.com/createAccount

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -921,10 +921,10 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       loggedInAs: 'Angemeldet als',
       temporaryPseudonym: 'temporäres Pseudonym',
     },
-    lti: {
-      loginFailedTitle: 'Fehler bei Anmeldung aufgetreten',
-      loginFailedDescription:
-        'Beim Anmeldeprozess ist ein Fehler aufgetreten. Bitte setzen Sie Ihre Cookies zurück und versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wenden Sie sich an Ihren Kursleiter.',
+    serverError: {
+      warning: 'Ein unerwarteter Fehler ist aufgetreten',
+      serverSideError:
+        'Ein unerwarteter Fehler ist bei Ihrer Anfrage aufgetreten. Bitte setzen Sie Ihre Cookies zurück und versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wenden Sie sich an Ihren Kursleiter.',
       tryAgain: 'Erneut versuchen',
     },
     avatar: {

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -921,6 +921,12 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       loggedInAs: 'Angemeldet als',
       temporaryPseudonym: 'temporäres Pseudonym',
     },
+    lti: {
+      loginFailedTitle: 'Fehler bei Anmeldung aufgetreten',
+      loginFailedDescription:
+        'Beim Anmeldeprozess ist ein Fehler aufgetreten. Bitte setzen Sie Ihre Cookies zurück und versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wenden Sie sich an Ihren Kursleiter.',
+      tryAgain: 'Erneut versuchen',
+    },
     avatar: {
       hair: 'Frisur',
       hairColor: 'Haarfarbe',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -922,6 +922,12 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       loggedInAs: 'Logged in as',
       temporaryPseudonym: 'temporary pseudonym',
     },
+    lti: {
+      loginFailedTitle: 'Error during login',
+      loginFailedDescription:
+        'An error occurred during the login process. Please reset your cookies and try again. If the problem persists, contact your course instructor.',
+      tryAgain: 'Try Again',
+    },
     avatar: {
       hair: 'Hair',
       hairColor: 'Hair Color',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -922,10 +922,10 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
       loggedInAs: 'Logged in as',
       temporaryPseudonym: 'temporary pseudonym',
     },
-    lti: {
-      loginFailedTitle: 'Error during login',
-      loginFailedDescription:
-        'An error occurred during the login process. Please reset your cookies and try again. If the problem persists, contact your course instructor.',
+    serverError: {
+      warning: 'An unexpected error has occurred',
+      serverSideError:
+        'An unexpected error occurred while processing your request. Please reset your cookies and try again. If the problem persists, contact your course instructor.',
       tryAgain: 'Try Again',
     },
     avatar: {


### PR DESCRIPTION

<img width="944" height="666" alt="Screenshot 2025-08-27 at 16 44 10" src="https://github.com/user-attachments/assets/af0f140b-1bef-4077-ad00-e43690c6bd8d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Localized server error page with retry button and safe return-path handling.
  - English and German server-error translations.

- **Behavior Changes**
  - Server-side errors now redirect to the server error page and attempt cookie cleanup.
  - Pages respect participant token and cookie availability for redirects/props; single available quiz or micro-learning now auto-redirects; inactive state shown when none exist.

- **Refactor**
  - Centralized SSR error handling with locale-aware redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->