### PR TITLE
fix(packages/graphql): make sure that entire histogram bar is covered by case study likert criterion solution illustration

### DIFF
--- a/packages/graphql/src/services/stacks.ts
+++ b/packages/graphql/src/services/stacks.ts
@@ -3459,6 +3459,9 @@ function combineCaseStudyResults({
               // extract values from merged results
               const responses = Object.values(mergedResults)
 
+              // if the criterion is a liker criterion, make sure the entire valid bar is included in the solution interval
+              const isLikertCriterion = !!criterion.labels
+
               return {
                 criterionId: criterion.id,
                 name: criterion.name,
@@ -3468,8 +3471,16 @@ function combineCaseStudyResults({
                 unit: criterion.unit,
                 labels: criterion.labels,
 
-                solutionMin: criterionSolution?.min,
-                solutionMax: criterionSolution?.max,
+                solutionMin: criterionSolution?.min
+                  ? isLikertCriterion
+                    ? criterionSolution?.min - 0.5
+                    : criterionSolution?.min
+                  : undefined,
+                solutionMax: criterionSolution?.max
+                  ? isLikertCriterion
+                    ? criterionSolution?.max + 0.5
+                    : criterionSolution?.max
+                  : undefined,
 
                 statistics:
                   responses && responses.length > 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of Likert-scale criteria, preventing boundary off-by-one issues in computed solution ranges.
  - Solution minimums and maximums for Likert items are now slightly expanded to accurately reflect discrete label scales.
  - Other outputs and response data remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->