### PR TITLE
fix: make sure that activity batch operations respect constraints for activity removal from assessment courses

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -5,14 +5,13 @@ on:
     # paths:
     #   - apps/**
     #   - packages/**
-  # TODO: re-introduce this before merging
-  # pull_request:
-  #   branches: ['v3', 'v3*']
-  #   types: [opened, synchronize, reopened]
-  #   paths:
-  #     - apps/**
-  #     - packages/**
-  #     - cypress/**
+  pull_request:
+    branches: ['v3', 'v3*']
+    types: [opened, synchronize, reopened]
+    paths:
+      - apps/**
+      - packages/**
+      - cypress/**
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -5,13 +5,14 @@ on:
     # paths:
     #   - apps/**
     #   - packages/**
-  pull_request:
-    branches: ['v3', 'v3*']
-    types: [opened, synchronize, reopened]
-    paths:
-      - apps/**
-      - packages/**
-      - cypress/**
+  # TODO: re-introduce this before merging
+  # pull_request:
+  #   branches: ['v3', 'v3*']
+  #   types: [opened, synchronize, reopened]
+  #   paths:
+  #     - apps/**
+  #     - packages/**
+  #     - cypress/**
 
 env:
   REGISTRY: ghcr.io

--- a/apps/frontend-manage/src/components/activities/overview/ActivityBatchOperationsModal.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityBatchOperationsModal.tsx
@@ -58,7 +58,7 @@ function ActivityBatchOperationsModal({
 
   const { loading: loadingCourses, data: dataCourses } = useQuery(
     GetActiveUserCoursesDocument,
-    { fetchPolicy: 'cache-and-network' }
+    { fetchPolicy: 'network-only' }
   )
 
   // whenever the applied filters change, update the affected activities
@@ -112,6 +112,12 @@ function ActivityBatchOperationsModal({
 
       // course assignment change
       if (selectedActions.course?.id) {
+        // assessment activities can only be removed from assessment courses by course admins
+        if (activity.isAssessmentEnabled && !activity.isActivityReviewer) {
+          actionsApplied = false
+          reasons.push(t('manage.activities.batchAssessmentRemovalAdminOnly'))
+        }
+
         // group activities can only be assigned to courses with groups enabled
         if (
           activity.type === ActivityType.GroupActivity &&

--- a/apps/frontend-manage/src/components/activities/overview/ActivityBatchOperationsModal.tsx
+++ b/apps/frontend-manage/src/components/activities/overview/ActivityBatchOperationsModal.tsx
@@ -113,7 +113,11 @@ function ActivityBatchOperationsModal({
       // course assignment change
       if (selectedActions.course?.id) {
         // assessment activities can only be removed from assessment courses by course admins
-        if (activity.isAssessmentEnabled && !activity.isActivityReviewer) {
+        if (
+          activity.isAssessmentEnabled &&
+          !activity.isActivityReviewer &&
+          selectedActions.course.id !== activity.courseId
+        ) {
           actionsApplied = false
           reasons.push(t('manage.activities.batchAssessmentRemovalAdminOnly'))
         }

--- a/packages/graphql/src/services/activities.ts
+++ b/packages/graphql/src/services/activities.ts
@@ -441,11 +441,35 @@ export async function applyActivityBatchOperations(
         },
       },
       status: { in: allowedActivityStatus },
-      // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
-      OR:
-        (setMultiplier && !newCourse) || setLiveQuizPoints
-          ? [{ isGamificationEnabled: true }, { isAssessmentEnabled: true }]
-          : undefined,
+      AND: [
+        // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
+        {
+          OR:
+            (setMultiplier && !newCourse) || setLiveQuizPoints
+              ? [{ isGamificationEnabled: true }, { isAssessmentEnabled: true }]
+              : undefined,
+        },
+        // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
+        {
+          OR: [
+            { courseId: null },
+            { isAssessmentEnabled: false },
+            {
+              isAssessmentEnabled: true,
+              course: {
+                permissions: {
+                  some: {
+                    userId: ctx.user.sub,
+                    permissionLevel: {
+                      in: [DB.PermissionLevel.OWNER, DB.PermissionLevel.ADMIN],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
     },
     include: { blocks: { include: { elements: true } } },
   })
@@ -490,6 +514,28 @@ export async function applyActivityBatchOperations(
                   },
                 ]
               : []),
+            // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
+            {
+              OR: [
+                { isAssessmentEnabled: false },
+                {
+                  isAssessmentEnabled: true,
+                  course: {
+                    permissions: {
+                      some: {
+                        userId: ctx.user.sub,
+                        permissionLevel: {
+                          in: [
+                            DB.PermissionLevel.OWNER,
+                            DB.PermissionLevel.ADMIN,
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
           ],
         },
         include: { stacks: { include: { elements: true } } },
@@ -508,16 +554,46 @@ export async function applyActivityBatchOperations(
             },
           },
           status: { in: allowedActivityStatus },
-          // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
-          OR:
-            setMultiplier && !newCourse
-              ? [{ isGamificationEnabled: true }, { isAssessmentEnabled: true }]
-              : undefined,
           // if a new course is assigned, the entire availability interval of the activity should lie inside the course duration
           scheduledStartAt: newCourse
             ? { gte: newCourse.startDate }
             : undefined,
           scheduledEndAt: newCourse ? { lte: newCourse.endDate } : undefined,
+          AND: [
+            // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
+            ...(setMultiplier && !newCourse
+              ? [
+                  {
+                    OR: [
+                      { isGamificationEnabled: true },
+                      { isAssessmentEnabled: true },
+                    ],
+                  },
+                ]
+              : []),
+            // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
+            {
+              OR: [
+                { isAssessmentEnabled: false },
+                {
+                  isAssessmentEnabled: true,
+                  course: {
+                    permissions: {
+                      some: {
+                        userId: ctx.user.sub,
+                        permissionLevel: {
+                          in: [
+                            DB.PermissionLevel.OWNER,
+                            DB.PermissionLevel.ADMIN,
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
         },
         include: { stacks: { include: { elements: true } } },
       })
@@ -536,14 +612,6 @@ export async function applyActivityBatchOperations(
               },
             },
             status: { in: allowedActivityStatus },
-            // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
-            OR:
-              setMultiplier && !newCourse
-                ? [
-                    { isGamificationEnabled: true },
-                    { isAssessmentEnabled: true },
-                  ]
-                : undefined,
             // if a new course is assigned, the group formation deadline should be before the start of the group activity
             // (start date of course does not need to be verified, since group formation deadline is always after start date)
             scheduledStartAt: newCourse
@@ -551,6 +619,41 @@ export async function applyActivityBatchOperations(
               : undefined,
             // if a new course is assigned, the group activity should end before the end of the course
             scheduledEndAt: newCourse ? { lte: newCourse.endDate } : undefined,
+            AND: [
+              // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
+              ...(setMultiplier && !newCourse
+                ? [
+                    {
+                      OR: [
+                        { isGamificationEnabled: true },
+                        { isAssessmentEnabled: true },
+                      ],
+                    },
+                  ]
+                : []),
+              // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
+              {
+                OR: [
+                  { isAssessmentEnabled: false },
+                  {
+                    isAssessmentEnabled: true,
+                    course: {
+                      permissions: {
+                        some: {
+                          userId: ctx.user.sub,
+                          permissionLevel: {
+                            in: [
+                              DB.PermissionLevel.OWNER,
+                              DB.PermissionLevel.ADMIN,
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
           },
           include: { stacks: { include: { elements: true } } },
         })

--- a/packages/graphql/src/services/activities.ts
+++ b/packages/graphql/src/services/activities.ts
@@ -443,12 +443,16 @@ export async function applyActivityBatchOperations(
       status: { in: allowedActivityStatus },
       AND: [
         // if no new course is assigned, but the multiplier is updated, the activity needs to be already gamified / in assessment mode
-        {
-          OR:
-            (setMultiplier && !newCourse) || setLiveQuizPoints
-              ? [{ isGamificationEnabled: true }, { isAssessmentEnabled: true }]
-              : undefined,
-        },
+        ...((setMultiplier && !newCourse) || setLiveQuizPoints
+          ? [
+              {
+                OR: [
+                  { isGamificationEnabled: true },
+                  { isAssessmentEnabled: true },
+                ],
+              },
+            ]
+          : []),
         // activities in assessment mode can only be assigned to another course (and thereby removed from it) by an admin of the assessment course
         {
           OR: [

--- a/packages/graphql/test/activityBatchOperations.test.ts
+++ b/packages/graphql/test/activityBatchOperations.test.ts
@@ -1531,6 +1531,26 @@ describe('Integration tests for batch operations on activities', () => {
           userId: userFourCtx.user.sub,
           permissionLevel: PermissionLevel.ADMIN,
         },
+        {
+          courseId: gamified.id,
+          userId: userTwoCtx.user.sub,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          courseId: gamified.id,
+          userId: userThreeCtx.user.sub,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          courseId: gamified.id,
+          userId: userFourCtx.user.sub,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          courseId: gamified.id,
+          userId: userFiveCtx.user.sub,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
       ],
     })
     await recomputeDerivedPermissions({ courseId: assessment.id }, prisma)
@@ -1560,6 +1580,10 @@ describe('Integration tests for batch operations on activities', () => {
         },
       ],
     })
+    await recomputeDerivedPermissions({ liveQuizId: lq.id }, prisma)
+    await recomputeDerivedPermissions({ practiceQuizId: pq.id }, prisma)
+    await recomputeDerivedPermissions({ microLearningId: ml.id }, prisma)
+    await recomputeDerivedPermissions({ groupActivityId: ga.id }, prisma)
 
     // verify that triggering a course re-assignment is only successful for users one and four
     for (const userCtx of [userTwoCtx, userThreeCtx, userFiveCtx]) {

--- a/packages/graphql/test/activityBatchOperations.test.ts
+++ b/packages/graphql/test/activityBatchOperations.test.ts
@@ -26,6 +26,8 @@ describe('Integration tests for batch operations on activities', () => {
   let userOneCtx: ContextWithUser
   let userTwoCtx: ContextWithUser
   let userThreeCtx: ContextWithUser
+  let userFourCtx: ContextWithUser
+  let userFiveCtx: ContextWithUser
 
   beforeAll(async () => {
     const { prisma: newPrisma, emitter: newEmitter } = await initializePrisma()
@@ -43,10 +45,14 @@ describe('Integration tests for batch operations on activities', () => {
       userOneCtx: ctx1,
       userTwoCtx: ctx2,
       userThreeCtx: ctx3,
+      userFourCtx: ctx4,
+      userFiveCtx: ctx5,
     } = await testInitialization(prisma, emitter)
     userOneCtx = ctx1
     userTwoCtx = ctx2
     userThreeCtx = ctx3
+    userFourCtx = ctx4
+    userFiveCtx = ctx5
   })
 
   afterEach(async () => {
@@ -1433,6 +1439,244 @@ describe('Integration tests for batch operations on activities', () => {
     })
     expect(permission16).not.toBeNull()
     expect(permission16!.permissionLevel).toEqual(PermissionLevel.ADMIN)
+  })
+
+  it('Verify that course re-assignments for activities in an assessment course are only accepted from assessment course admins / owner', async () => {
+    // seed an assessment course and a normal gamified course
+    const assessment = await seedCourse({ isAssessmentEnabled: true }, prisma)
+    const gamified = await seedCourse({ isGamificationEnabled: true }, prisma)
+
+    // seed activities that are assigned to the assessment course
+    const lq = await seedLiveQuiz(
+      {
+        courseId: assessment.id,
+        reviewStatus: ReviewStatus.REVIEWED,
+        isGamificationEnabled: true,
+        isAssessmentEnabled: true,
+      },
+      prisma
+    )
+    const pq = await seedPracticeQuiz(
+      {
+        courseId: assessment.id,
+        reviewStatus: ReviewStatus.REVIEWED,
+        isGamificationEnabled: true,
+        isAssessmentEnabled: true,
+      },
+      prisma
+    )
+    const ml = await seedMicroLearning(
+      {
+        courseId: assessment.id,
+        reviewStatus: ReviewStatus.REVIEWED,
+        isGamificationEnabled: true,
+        isAssessmentEnabled: true,
+      },
+      prisma
+    )
+    const ga = await seedGroupActivity(
+      {
+        courseId: assessment.id,
+        reviewStatus: ReviewStatus.REVIEWED,
+        isGamificationEnabled: true,
+        isAssessmentEnabled: true,
+      },
+      prisma
+    )
+
+    // verify that all activities have assessment enabled and are assigned to the assessment course
+    const verification1 = await prisma.liveQuiz.findUnique({
+      where: { id: lq.id },
+    })
+    expect(verification1).not.toBeNull()
+    expect(verification1!.isAssessmentEnabled).toBe(true)
+    expect(verification1!.courseId).toBe(assessment.id)
+
+    const verification2 = await prisma.practiceQuiz.findUnique({
+      where: { id: pq.id },
+    })
+    expect(verification2).not.toBeNull()
+    expect(verification2!.isAssessmentEnabled).toBe(true)
+    expect(verification2!.courseId).toBe(assessment.id)
+
+    const verification3 = await prisma.microLearning.findUnique({
+      where: { id: ml.id },
+    })
+    expect(verification3).not.toBeNull()
+    expect(verification3!.isAssessmentEnabled).toBe(true)
+    expect(verification3!.courseId).toBe(assessment.id)
+
+    const verification4 = await prisma.groupActivity.findUnique({
+      where: { id: ga.id },
+    })
+    expect(verification4).not.toBeNull()
+    expect(verification4!.isAssessmentEnabled).toBe(true)
+    expect(verification4!.courseId).toBe(assessment.id)
+
+    // share both courses with read, write and admin permissions with users two, three and four
+    await prisma.permission.createMany({
+      data: [
+        {
+          courseId: assessment.id,
+          userId: userTwoCtx.user.sub,
+          permissionLevel: PermissionLevel.READ,
+        },
+        {
+          courseId: assessment.id,
+          userId: userThreeCtx.user.sub,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          courseId: assessment.id,
+          userId: userFourCtx.user.sub,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+      ],
+    })
+    await recomputeDerivedPermissions({ courseId: assessment.id }, prisma)
+
+    // share the activities directly with user five
+    await prisma.permission.createMany({
+      data: [
+        {
+          liveQuizId: lq.id,
+          userId: userFiveCtx.user.sub,
+          permissionLevel: PermissionLevel.ADMIN,
+        },
+        {
+          practiceQuizId: pq.id,
+          userId: userFiveCtx.user.sub,
+          permissionLevel: PermissionLevel.WRITE,
+        },
+        {
+          microLearningId: ml.id,
+          userId: userFiveCtx.user.sub,
+          permissionLevel: PermissionLevel.EXECUTE,
+        },
+        {
+          groupActivityId: ga.id,
+          userId: userFiveCtx.user.sub,
+          permissionLevel: PermissionLevel.READ,
+        },
+      ],
+    })
+
+    // verify that triggering a course re-assignment is only successful for users one and four
+    for (const userCtx of [userTwoCtx, userThreeCtx, userFiveCtx]) {
+      const res = await applyActivityBatchOperations(
+        {
+          activityIds: [lq.id, pq.id, ml.id, ga.id],
+          courseId: gamified.id,
+        },
+        userCtx
+      )
+      expect(res).toBe(0)
+
+      const verification1 = await prisma.liveQuiz.findUnique({
+        where: { id: lq.id },
+      })
+      expect(verification1).not.toBeNull()
+      expect(verification1!.isAssessmentEnabled).toBe(true)
+      expect(verification1!.courseId).toBe(assessment.id)
+
+      const verification2 = await prisma.practiceQuiz.findUnique({
+        where: { id: pq.id },
+      })
+      expect(verification2).not.toBeNull()
+      expect(verification2!.isAssessmentEnabled).toBe(true)
+      expect(verification2!.courseId).toBe(assessment.id)
+
+      const verification3 = await prisma.microLearning.findUnique({
+        where: { id: ml.id },
+      })
+      expect(verification3).not.toBeNull()
+      expect(verification3!.isAssessmentEnabled).toBe(true)
+      expect(verification3!.courseId).toBe(assessment.id)
+
+      const verification4 = await prisma.groupActivity.findUnique({
+        where: { id: ga.id },
+      })
+      expect(verification4).not.toBeNull()
+      expect(verification4!.isAssessmentEnabled).toBe(true)
+      expect(verification4!.courseId).toBe(assessment.id)
+    }
+
+    for (const userCtx of [userOneCtx, userFourCtx]) {
+      const res = await applyActivityBatchOperations(
+        {
+          activityIds: [lq.id, pq.id, ml.id, ga.id],
+          courseId: gamified.id,
+        },
+        userCtx
+      )
+      expect(res).toBe(4)
+
+      const verification1 = await prisma.liveQuiz.findUnique({
+        where: { id: lq.id },
+      })
+      expect(verification1).not.toBeNull()
+      expect(verification1!.isAssessmentEnabled).toBe(false)
+      expect(verification1!.courseId).toBe(gamified.id)
+
+      const verification2 = await prisma.practiceQuiz.findUnique({
+        where: { id: pq.id },
+      })
+      expect(verification2).not.toBeNull()
+      expect(verification2!.isAssessmentEnabled).toBe(false)
+      expect(verification2!.courseId).toBe(gamified.id)
+
+      const verification3 = await prisma.microLearning.findUnique({
+        where: { id: ml.id },
+      })
+      expect(verification3).not.toBeNull()
+      expect(verification3!.isAssessmentEnabled).toBe(false)
+      expect(verification3!.courseId).toBe(gamified.id)
+
+      const verification4 = await prisma.groupActivity.findUnique({
+        where: { id: ga.id },
+      })
+      expect(verification4).not.toBeNull()
+      expect(verification4!.isAssessmentEnabled).toBe(false)
+      expect(verification4!.courseId).toBe(gamified.id)
+
+      // assign the activities back to the assessment course to be ready for another transfer
+      const res5 = await applyActivityBatchOperations(
+        {
+          activityIds: [lq.id, pq.id, ml.id, ga.id],
+          courseId: assessment.id,
+        },
+        userCtx
+      )
+      expect(res5).toBe(4)
+
+      const verification5 = await prisma.liveQuiz.findUnique({
+        where: { id: lq.id },
+      })
+      expect(verification5).not.toBeNull()
+      expect(verification5!.isAssessmentEnabled).toBe(true)
+      expect(verification5!.courseId).toBe(assessment.id)
+
+      const verification6 = await prisma.practiceQuiz.findUnique({
+        where: { id: pq.id },
+      })
+      expect(verification6).not.toBeNull()
+      expect(verification6!.isAssessmentEnabled).toBe(true)
+      expect(verification6!.courseId).toBe(assessment.id)
+
+      const verification7 = await prisma.microLearning.findUnique({
+        where: { id: ml.id },
+      })
+      expect(verification7).not.toBeNull()
+      expect(verification7!.isAssessmentEnabled).toBe(true)
+      expect(verification7!.courseId).toBe(assessment.id)
+
+      const verification8 = await prisma.groupActivity.findUnique({
+        where: { id: ga.id },
+      })
+      expect(verification8).not.toBeNull()
+      expect(verification8!.isAssessmentEnabled).toBe(true)
+      expect(verification8!.courseId).toBe(assessment.id)
+    }
   })
 
   it('Verify that the course assignment, multiplier and points can be updated simultaneously and that the review status is updated correctly', async () => {

--- a/packages/graphql/test/activityBatchOperations.test.ts
+++ b/packages/graphql/test/activityBatchOperations.test.ts
@@ -1665,42 +1665,45 @@ describe('Integration tests for batch operations on activities', () => {
       expect(verification4!.courseId).toBe(gamified.id)
 
       // assign the activities back to the assessment course to be ready for another transfer
-      const res5 = await applyActivityBatchOperations(
-        {
-          activityIds: [lq.id, pq.id, ml.id, ga.id],
-          courseId: assessment.id,
-        },
-        userCtx
-      )
-      expect(res5).toBe(4)
+      if (userCtx.user.sub === userOneCtx.user.sub) {
+        // backwards assignment only works for user one (user four has not sufficient permissions, on purpose)
+        const res2 = await applyActivityBatchOperations(
+          {
+            activityIds: [lq.id, pq.id, ml.id, ga.id],
+            courseId: assessment.id,
+          },
+          userCtx
+        )
+        expect(res2).toBe(4)
 
-      const verification5 = await prisma.liveQuiz.findUnique({
-        where: { id: lq.id },
-      })
-      expect(verification5).not.toBeNull()
-      expect(verification5!.isAssessmentEnabled).toBe(true)
-      expect(verification5!.courseId).toBe(assessment.id)
+        const verification5 = await prisma.liveQuiz.findUnique({
+          where: { id: lq.id },
+        })
+        expect(verification5).not.toBeNull()
+        expect(verification5!.isAssessmentEnabled).toBe(true)
+        expect(verification5!.courseId).toBe(assessment.id)
 
-      const verification6 = await prisma.practiceQuiz.findUnique({
-        where: { id: pq.id },
-      })
-      expect(verification6).not.toBeNull()
-      expect(verification6!.isAssessmentEnabled).toBe(true)
-      expect(verification6!.courseId).toBe(assessment.id)
+        const verification6 = await prisma.practiceQuiz.findUnique({
+          where: { id: pq.id },
+        })
+        expect(verification6).not.toBeNull()
+        expect(verification6!.isAssessmentEnabled).toBe(true)
+        expect(verification6!.courseId).toBe(assessment.id)
 
-      const verification7 = await prisma.microLearning.findUnique({
-        where: { id: ml.id },
-      })
-      expect(verification7).not.toBeNull()
-      expect(verification7!.isAssessmentEnabled).toBe(true)
-      expect(verification7!.courseId).toBe(assessment.id)
+        const verification7 = await prisma.microLearning.findUnique({
+          where: { id: ml.id },
+        })
+        expect(verification7).not.toBeNull()
+        expect(verification7!.isAssessmentEnabled).toBe(true)
+        expect(verification7!.courseId).toBe(assessment.id)
 
-      const verification8 = await prisma.groupActivity.findUnique({
-        where: { id: ga.id },
-      })
-      expect(verification8).not.toBeNull()
-      expect(verification8!.isAssessmentEnabled).toBe(true)
-      expect(verification8!.courseId).toBe(assessment.id)
+        const verification8 = await prisma.groupActivity.findUnique({
+          where: { id: ga.id },
+        })
+        expect(verification8).not.toBeNull()
+        expect(verification8!.isAssessmentEnabled).toBe(true)
+        expect(verification8!.courseId).toBe(assessment.id)
+      }
     }
   })
 

--- a/packages/graphql/test/activityBatchOperations.test.ts
+++ b/packages/graphql/test/activityBatchOperations.test.ts
@@ -1554,6 +1554,7 @@ describe('Integration tests for batch operations on activities', () => {
       ],
     })
     await recomputeDerivedPermissions({ courseId: assessment.id }, prisma)
+    await recomputeDerivedPermissions({ courseId: gamified.id }, prisma)
 
     // share the activities directly with user five
     await prisma.permission.createMany({

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1203,6 +1203,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Eine Veränderung des Multiplikators ist nur für gamifizierte Aktivitäten oder Aktivitäten mit Assessment-Kurs Zuweisung möglich.',
       batchGroupActivityRequiresGroupsEnabled:
         'Gruppenaktivitäten können nur Kursen zugewiesen werden, in welchen die Gruppenbildung aktiviert ist.',
+      batchAssessmentRemovalAdminOnly:
+        'Aktivitäten, welche sich im Assessment-Modus (mit Zuweisung zu einem Assessment-Kurs) befinden, können nur von Administratoren des entsprechenden Kurses aus diesem entfernt werden.',
       batchActivityDatesOutsideCourse:
         'Das Verfügbarkeitsintervall von Gruppenaktivtäten und Microlearnings muss vollständig innerhalb der Kurslaufzeit liegen.',
       batchGroupActivityRequiresFinalizedGroups:

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1201,6 +1201,8 @@ Since the KlickerUZH app is not yet available on the iOS App Store, follow these
         'A multiplier can only be set for gamified activities or activities in assessment courses, as points can only be collected in these courses.',
       batchGroupActivityRequiresGroupsEnabled:
         'Group activities can only be assigned to courses where group formation is enabled.',
+      batchAssessmentRemovalAdminOnly:
+        'Activities that are in assessment mode (assigned to an assessment course) can only be removed from it by administrators of the corresponding course.',
       batchActivityDatesOutsideCourse:
         'The availability interval of group activities and microlearnings must be fully within the course duration.',
       batchGroupActivityRequiresFinalizedGroups:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added in-app messaging (EN/DE) explaining admin-only removal of assessment-mode activities.

- Bug Fixes
  - Enforced stricter permissions: only course admins/owners can reassign or remove activities from assessment-mode courses.
  - Ensures batch operations fetch up-to-date course data from the network.

- Tests
  - Added integration tests validating reassignment rules for assessment-mode activities across user roles (duplicate test entry present).

- Chores
  - Removed the pull_request trigger from the Cypress workflow (placeholder left for re-introduction).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->