### PR TITLE
fix(packages/graphql): ensure that direct permissions of activities are revoked correctly on soft deletion

### DIFF
--- a/packages/graphql/src/services/groups.ts
+++ b/packages/graphql/src/services/groups.ts
@@ -1748,7 +1748,10 @@ export async function deleteGroupActivity(
       async (prisma) => {
         const updatedActivity = await prisma.groupActivity.update({
           where: { id },
-          data: { isDeleted: true },
+          data: {
+            isDeleted: true,
+            directPermissions: { deleteMany: {} }, // delete all direct permissions on the activity
+          },
         })
 
         // update derived permissions for this group activity (after soft deletion)

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -2440,7 +2440,10 @@ export async function deleteLiveQuiz(
       async (prisma) => {
         const quiz = await prisma.liveQuiz.update({
           where: { id, status: DB.PublicationStatus.ENDED },
-          data: { isDeleted: true },
+          data: {
+            isDeleted: true,
+            directPermissions: { deleteMany: {} }, // delete all direct permissions on the activity
+          },
         })
 
         // update derived permissions for this live quiz (after soft deletion)

--- a/packages/graphql/src/services/microLearning.ts
+++ b/packages/graphql/src/services/microLearning.ts
@@ -659,7 +659,10 @@ export async function deleteMicroLearning(
       async (prisma) => {
         const updated = await prisma.microLearning.update({
           where: { id },
-          data: { isDeleted: true },
+          data: {
+            isDeleted: true,
+            directPermissions: { deleteMany: {} }, // delete all direct permissions on the activity
+          },
         })
 
         // update derived permissions for this microlearning (after soft deletion)

--- a/packages/graphql/src/services/practiceQuizzes.ts
+++ b/packages/graphql/src/services/practiceQuizzes.ts
@@ -635,7 +635,10 @@ export async function deletePracticeQuiz(
       async (prisma) => {
         const quiz = await prisma.practiceQuiz.update({
           where: { id },
-          data: { isDeleted: true },
+          data: {
+            isDeleted: true,
+            directPermissions: { deleteMany: {} }, // delete all direct permissions on the activity
+          },
           include: { stacks: true },
         })
 

--- a/packages/graphql/src/services/resources.ts
+++ b/packages/graphql/src/services/resources.ts
@@ -538,7 +538,10 @@ export async function deleteAnswerCollection(
       // ? Soft-delete the answer collection
       const updatedAnswerCollection = await prisma.answerCollection.update({
         where: { id: collectionId },
-        data: { isDeleted: true },
+        data: {
+          isDeleted: true,
+          directPermissions: { deleteMany: {} }, // delete all direct permissions on the activity
+        },
       })
 
       // trigger recomputation of all derived permissions for this answer collection object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Soft-deleting content now also clears any direct permissions, preventing unintended access to deleted items. This applies to groups, live quizzes, micro-learning, practice quizzes, and answer collections.
  * Ensures deleted content is fully inaccessible to all users, aligning behavior across activity types.
  * No changes to hard-delete behavior; permission recalculation still occurs after deletion.
  * No UI or API changes; existing workflows continue to function while improving access consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->