### PR TITLE
fix(packages/graphql): make sure lecturer join link displays shared and owned live quizzes

### DIFF
--- a/apps/frontend-pwa/src/pages/course/[courseId]/join.tsx
+++ b/apps/frontend-pwa/src/pages/course/[courseId]/join.tsx
@@ -28,13 +28,11 @@ function JoinCourse({
   courseId,
   displayName,
   color,
-  description,
   courseLoading,
 }: {
   courseId: string
   displayName: string
   color: string
-  description: string
   courseLoading: boolean
 }) {
   const t = useTranslations()

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -1055,21 +1055,38 @@ export async function getShortnameQuizzes(
   const user = await ctx.prisma.user.findUnique({
     where: { shortname: shortname.trim() },
     include: {
-      liveQuizzes: {
+      objects: {
         where: {
-          accessMode: DB.AccessMode.PUBLIC,
-          status: DB.PublicationStatus.PUBLISHED,
+          // the shared object must be a live quiz that is published and accessible
+          liveQuizId: { not: null },
+          liveQuiz: {
+            status: DB.PublicationStatus.PUBLISHED,
+            accessMode: DB.AccessMode.PUBLIC,
+          },
+          // only users with at least execution permissions can execute a live quiz
+          permissionLevel: {
+            in: [
+              DB.PermissionLevel.OWNER,
+              DB.PermissionLevel.ADMIN,
+              DB.PermissionLevel.WRITE,
+              DB.PermissionLevel.EXECUTE,
+            ],
+          },
         },
-        include: { course: true },
+        include: { liveQuiz: { include: { course: true } } },
       },
     },
   })
 
   return (
-    user?.liveQuizzes.map((quiz) => ({
-      ...quiz,
-      isPinProtected: !!quiz.pinCode,
-    })) ?? []
+    user?.objects.flatMap((obj) =>
+      obj.liveQuiz
+        ? {
+            ...obj.liveQuiz,
+            isPinProtected: !!obj.liveQuiz.pinCode,
+          }
+        : []
+    ) ?? []
   )
 }
 


### PR DESCRIPTION
Currently, the live quiz join link for a specific lecturer account only displays live quizzes owned by that specific user. In the case where a live quiz is shared with a user for execution, this could correspondingly result in issues. This pull request resolves this shortcoming, s.t. all shared live quizzes (with at least execution permissions - required for execution) are listed.

However, this implies the following potential issues:
- User A creates malicious live quiz
- User A shared malicious live quiz with user B with at least execution permissions
- User B executes another live quiz and presents the join link, showing both the correct and the malicious live quiz

-> for the current private testing phase, this behavior would probably not be too problematic. For a rollout in the public instance, we might have to introduce some kind of confirmation / acceptance for shared objects or at least a notification thereof, since shared objects might be automatically displayed in a user's account. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Live quizzes now indicate if they are PIN-protected.
  - Quiz listings include associated course details for clearer context.

- Bug Fixes
  - Improved accuracy of the “My Live Quizzes” list by showing only accessible, public, and published quizzes.
  - Reduced appearance of unavailable or invalid quizzes in results.

- Chores
  - Minor cleanup of unused UI props to streamline components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->