### PR TITLE
enhance(apps/hatchet-worker-response-processor): add student response validation to processors

### DIFF
--- a/.github/workflows/test-grading.yml
+++ b/.github/workflows/test-grading.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           version: 9.15.4
           run_install: true
+      - name: Build types package
+        shell: bash
+        run: |
+          cd packages/types
+          pnpm run build
       - name: Test functions
         shell: bash
         run: |

--- a/apps/frontend-pwa/src/components/liveQuiz/QuestionArea.tsx
+++ b/apps/frontend-pwa/src/components/liveQuiz/QuestionArea.tsx
@@ -285,12 +285,10 @@ function QuestionArea({
         liveQuizId: quizId,
         instanceId,
         type,
-        answer: Object.entries(input.response)
-          .filter(([, value]) => value)
-          .map(([key, value]) => ({
-            ix: parseInt(key),
-            selected: value,
-          })),
+        answer: Object.entries(input.response).map(([key, value]) => ({
+          ix: parseInt(key),
+          selected: typeof value === 'boolean' ? value : false,
+        })),
         correlationKey,
       })
 

--- a/apps/frontend-pwa/src/pages/index.tsx
+++ b/apps/frontend-pwa/src/pages/index.tsx
@@ -326,6 +326,11 @@ function Index() {
               : t('pwa.general.myCourses')}
           </H1>
           <div className="flex flex-col gap-2">
+            {process.env.NEXT_PUBLIC_IS_ASSESSMENT && courses.length === 0 ? (
+              <UserNotification type="warning">
+                {t('pwa.general.noAssessmentCourseAssignments')}
+              </UserNotification>
+            ) : null}
             {courses.map((course) => (
               <CourseElement
                 key={course.id}

--- a/apps/hatchet-worker-response-processor/src/assessmentProcessor.ts
+++ b/apps/hatchet-worker-response-processor/src/assessmentProcessor.ts
@@ -11,7 +11,7 @@ import {
   ResponseCorrectness,
   UserRole,
 } from '@klicker-uzh/prisma/client'
-import type { ResponseInput } from '@klicker-uzh/types'
+import type { LiveQuizResponseInput } from '@klicker-uzh/types'
 import { strict as assert } from 'assert'
 import { createHash } from 'crypto'
 import { DEFAULT_POINTS } from './constants.js'
@@ -22,6 +22,7 @@ import {
   getNumericalQuestionPointsDetails,
   getSelectionQuestionPointsDetails,
   updateLeaderboards,
+  validateStudentResponse,
 } from './helpers.js'
 import getRedis from './redis.js'
 
@@ -36,7 +37,7 @@ export async function processAssessmentResponse(
     participantId: string
     liveQuizId: string
     instanceId: string
-    response: ResponseInput
+    response: LiveQuizResponseInput
     cookie?: string
     responseTimestamp: number
   },
@@ -103,6 +104,7 @@ export async function processAssessmentResponse(
   const {
     type,
     solutions,
+    restrictions,
     firstResponseReceivedAt,
     sessionBlockId,
     choiceCount,
@@ -119,8 +121,24 @@ export async function processAssessmentResponse(
     )
   }
 
-  // ! Step 2: Switch between different types, validate response and compute awarded points and XP
+  // ! Step 1.2 Validation of response format
+  const { valid, message: validationError } = validateStudentResponse({
+    type: type as any,
+    response,
+    restrictions: restrictions
+      ? typeof restrictions === 'string'
+        ? JSON.parse(restrictions)
+        : restrictions
+      : undefined,
+  })
 
+  if (!valid) {
+    throw new NonRetryableError(
+      `Response to question instance ${message.instanceId} is not valid: ${validationError}`
+    )
+  }
+
+  // ! Step 2: Switch between different types, validate response and compute awarded points and XP
   let parsedSolutions = undefined
   try {
     if (solutions) {
@@ -374,7 +392,7 @@ export async function aggregateAssessmentResponses(
     isGamificationEnabled: boolean
     pointsAwarded: number
     xpAwarded: number
-    response: ResponseInput
+    response: LiveQuizResponseInput
   },
   ctx: Context<JsonObject, {}> | DurableContext<JsonObject, {}>
 ) {

--- a/apps/hatchet-worker-response-processor/src/assessmentProcessor.ts
+++ b/apps/hatchet-worker-response-processor/src/assessmentProcessor.ts
@@ -11,7 +11,11 @@ import {
   ResponseCorrectness,
   UserRole,
 } from '@klicker-uzh/prisma/client'
-import type { LiveQuizResponseInput } from '@klicker-uzh/types'
+import type {
+  FreeTextRestrictions,
+  LiveQuizResponseInput,
+  NumericalRestrictions,
+} from '@klicker-uzh/types'
 import { strict as assert } from 'assert'
 import { createHash } from 'crypto'
 import { DEFAULT_POINTS } from './constants.js'
@@ -122,14 +126,28 @@ export async function processAssessmentResponse(
   }
 
   // ! Step 1.2 Validation of response format
+  let parsedRestrictions:
+    | NumericalRestrictions
+    | FreeTextRestrictions
+    | undefined
+  try {
+    if (restrictions) {
+      parsedRestrictions = restrictions
+        ? typeof restrictions === 'string'
+          ? JSON.parse(restrictions)
+          : restrictions
+        : undefined
+    }
+  } catch (e) {
+    throw new NonRetryableError(
+      `Error ${String(e)} occurred when parsing restrictions: ${restrictions}`
+    )
+  }
+
   const { valid, message: validationError } = validateStudentResponse({
     type: type as any,
     response,
-    restrictions: restrictions
-      ? typeof restrictions === 'string'
-        ? JSON.parse(restrictions)
-        : restrictions
-      : undefined,
+    restrictions: parsedRestrictions,
   })
 
   if (!valid) {

--- a/apps/hatchet-worker-response-processor/src/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/helpers.ts
@@ -10,7 +10,11 @@ import {
   gradeQuestionSC,
   gradeQuestionSelection,
 } from '@klicker-uzh/grading'
-import type { ResponseInput } from '@klicker-uzh/types'
+import type {
+  FreeTextRestrictions,
+  LiveQuizResponseInput,
+  NumericalRestrictions,
+} from '@klicker-uzh/types'
 import type { ChainableCommander } from 'ioredis'
 import {
   DEFAULT_CORRECT_POINTS,
@@ -95,8 +99,188 @@ function getPointsWithDefaults(instanceInfo: Record<string, string>) {
   }
 }
 
+export function validateStudentResponse({
+  type,
+  response,
+  restrictions,
+}: {
+  type:
+    | 'SC'
+    | 'MC'
+    | 'KPRIM'
+    | 'NUMERICAL'
+    | 'FREE_TEXT'
+    | 'SELECTION'
+    | 'CASE_STUDY'
+    | 'CONTENT'
+  response: LiveQuizResponseInput
+  restrictions?: NumericalRestrictions | FreeTextRestrictions
+}): { valid: boolean; message?: string } {
+  if (type === 'SC' || type === 'MC' || type === 'KPRIM') {
+    // response should be of format { ix: number, selected: boolean | undefined }[]
+    if (
+      !Array.isArray(response.choices) ||
+      response.choices.length === 0 ||
+      !response.choices.every(
+        (r) =>
+          typeof r.ix === 'number' &&
+          (typeof r.selected === 'boolean' || typeof r.selected === 'undefined')
+      )
+    ) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for choices question ${JSON.stringify(response)}`,
+      }
+    }
+
+    // for single choice questions, only exactly one choice should be selected
+    if (
+      type === 'SC' &&
+      response.choices.filter((r) => r.selected).length !== 1
+    ) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for single choice question ${JSON.stringify(response)}`,
+      }
+    }
+
+    // for multiple choice questions, at least one choice should be selected
+    if (
+      type === 'MC' &&
+      response.choices.filter((r) => r.selected).length === 0
+    ) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for multiple choice question ${JSON.stringify(response)}`,
+      }
+    }
+
+    // for KPRIM questions, exactly four choices should be provided
+    if (type === 'KPRIM' && response.choices.length !== 4) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for KPRIM question ${JSON.stringify(response)}`,
+      }
+    }
+
+    // if all cases are passed, choices response is considered to be valid
+    return { valid: true }
+  } else if (type === 'NUMERICAL') {
+    // response should be a string and be parseable as a number
+    if (
+      typeof response.value !== 'string' ||
+      !response.value ||
+      isNaN(parseFloat(response.value))
+    ) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for numerical question ${JSON.stringify(response)}`,
+      }
+    }
+
+    // if restrictions are defined, check that the parsed number is within the defined bounds
+    const parsedResponse = parseFloat(response.value)
+    if (
+      restrictions &&
+      (('min' in restrictions &&
+        typeof restrictions.min === 'number' &&
+        parsedResponse < restrictions.min) ||
+        ('max' in restrictions &&
+          typeof restrictions.max === 'number' &&
+          parsedResponse > restrictions.max))
+    ) {
+      return {
+        valid: false,
+        message: `Numerical response ${parsedResponse} out of bounds for numerical question with restrictions ${JSON.stringify(restrictions)}`,
+      }
+    }
+
+    return { valid: true }
+  } else if (type === 'FREE_TEXT') {
+    // response should be a string
+    if (!response.value || typeof response.value !== 'string') {
+      return {
+        valid: false,
+        message: `Invalid response submitted for free text question ${JSON.stringify(response)}`,
+      }
+    }
+
+    // if restrictions are defined, check that the response satisfies them
+    if (
+      restrictions &&
+      'maxLength' in restrictions &&
+      typeof restrictions.maxLength === 'number' &&
+      response.value.length > restrictions.maxLength
+    ) {
+      return {
+        valid: false,
+        message: `Free text response exceeds maximum length of ${restrictions.maxLength} characters for free text question`,
+      }
+    }
+
+    return { valid: true }
+  } else if (type === 'SELECTION') {
+    // response should be an array of numbers
+    if (
+      !Array.isArray(response.selection) ||
+      response.selection.length === 0 ||
+      !response.selection.every((r) => typeof r === 'number')
+    ) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for selection question ${JSON.stringify(response)}`,
+      }
+    }
+
+    return { valid: true }
+  } else if (type === 'CASE_STUDY') {
+    // response should be of the format { [caseId: string]: { [itemId: number]: { [criterionId: string]: number } } }
+    if (
+      !response.assessment ||
+      Object.keys(response.assessment).length === 0 ||
+      !Object.values(response.assessment).every(
+        (caseObj) =>
+          typeof caseObj === 'object' &&
+          caseObj !== null &&
+          Object.keys(caseObj).length > 0 &&
+          Object.values(caseObj).every(
+            (itemObj) =>
+              typeof itemObj === 'object' &&
+              itemObj !== null &&
+              Object.keys(itemObj).length > 0 &&
+              Object.values(itemObj).every(
+                (criterionResponse) => typeof criterionResponse === 'number'
+              )
+          )
+      )
+    ) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for case study question ${JSON.stringify(response)}`,
+      }
+    }
+
+    return { valid: true }
+  } else if (type === 'CONTENT') {
+    // response should be boolean with value true
+    if (!response.read) {
+      return {
+        valid: false,
+        message: `Invalid response submitted for content question ${JSON.stringify(response)}`,
+      }
+    }
+
+    return { valid: true }
+  }
+
+  return {
+    valid: false,
+    message: `Provided invalid question type in answer submission: ${type}`,
+  }
+}
+
 interface SharedQuestionPointsParams {
-  response: ResponseInput
+  response: LiveQuizResponseInput
   instanceInfo: Record<string, string>
   firstResponseReceivedAt?: string
   responseTimestamp: number

--- a/apps/hatchet-worker-response-processor/src/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/helpers.ts
@@ -206,11 +206,12 @@ export function validateStudentResponse({
     }
 
     // if restrictions are defined, check that the response satisfies them
+    const trimmedResponse = response.value.trim()
     if (
       restrictions &&
       'maxLength' in restrictions &&
       typeof restrictions.maxLength === 'number' &&
-      response.value.length > restrictions.maxLength
+      trimmedResponse.length > restrictions.maxLength
     ) {
       return {
         valid: false,

--- a/apps/hatchet-worker-response-processor/src/index.ts
+++ b/apps/hatchet-worker-response-processor/src/index.ts
@@ -2,7 +2,7 @@ import {
   ConcurrencyLimitStrategy,
   Priority,
 } from '@hatchet-dev/typescript-sdk/index.js'
-import type { ResponseInput } from '@klicker-uzh/types'
+import type { LiveQuizResponseInput } from '@klicker-uzh/types'
 import {
   aggregateAssessmentResponses,
   processAssessmentResponse,
@@ -44,7 +44,7 @@ export const processAssessmentResponseWorkflow = hatchet.workflow<{
   participantId: string
   liveQuizId: string
   instanceId: string
-  response: ResponseInput
+  response: LiveQuizResponseInput
   cookie?: string
   responseTimestamp: number
 }>({

--- a/apps/hatchet-worker-response-processor/src/processor.ts
+++ b/apps/hatchet-worker-response-processor/src/processor.ts
@@ -6,7 +6,11 @@ import type {
   DurableContext,
   JsonObject,
 } from '@hatchet-dev/typescript-sdk/index.js'
-import type { LiveQuizResponseInput } from '@klicker-uzh/types'
+import type {
+  FreeTextRestrictions,
+  LiveQuizResponseInput,
+  NumericalRestrictions,
+} from '@klicker-uzh/types'
 import { verifyJWT, type JWTPayload } from '@klicker-uzh/util'
 import { strict as assert } from 'assert'
 import { createHash } from 'crypto'
@@ -169,18 +173,32 @@ export async function processResponseMessage(
         parsedSolutions = JSON.parse(solutions)
       }
     } catch (e) {
-      ctx.logger.info(`Error parsing solutions: ${String(e)}`)
+      throw new Error('Error parsing solutions: ' + String(e))
     }
 
     // validate the incoming response
+    let parsedRestrictions:
+      | NumericalRestrictions
+      | FreeTextRestrictions
+      | undefined
+    try {
+      if (restrictions) {
+        parsedRestrictions = restrictions
+          ? typeof restrictions === 'string'
+            ? JSON.parse(restrictions)
+            : restrictions
+          : undefined
+      }
+    } catch (e) {
+      throw new Error(
+        `Error ${String(e)} occurred when parsing restrictions: ${restrictions}`
+      )
+    }
+
     const { valid, message: validationError } = validateStudentResponse({
       type: type as any,
       response,
-      restrictions: restrictions
-        ? typeof restrictions === 'string'
-          ? JSON.parse(restrictions)
-          : restrictions
-        : undefined,
+      restrictions: parsedRestrictions,
     })
 
     if (!valid) {

--- a/apps/hatchet-worker-response-processor/src/processor.ts
+++ b/apps/hatchet-worker-response-processor/src/processor.ts
@@ -6,7 +6,7 @@ import type {
   DurableContext,
   JsonObject,
 } from '@hatchet-dev/typescript-sdk/index.js'
-import type { ResponseInput } from '@klicker-uzh/types'
+import type { LiveQuizResponseInput } from '@klicker-uzh/types'
 import { verifyJWT, type JWTPayload } from '@klicker-uzh/util'
 import { strict as assert } from 'assert'
 import { createHash } from 'crypto'
@@ -18,6 +18,7 @@ import {
   getNumericalQuestionPoints,
   getSelectionQuestionPoints,
   updateLeaderboards,
+  validateStudentResponse,
 } from './helpers.js'
 import getRedis from './redis.js'
 
@@ -28,7 +29,7 @@ export type Message = {
   messageId: string
   sessionId: string
   instanceId: string
-  response: ResponseInput
+  response: LiveQuizResponseInput
   cookie?: string
   responseTimestamp: number
 }
@@ -155,6 +156,7 @@ export async function processResponseMessage(
     const {
       type,
       solutions,
+      restrictions,
       firstResponseReceivedAt,
       sessionBlockId,
       choiceCount,
@@ -168,6 +170,30 @@ export async function processResponseMessage(
       }
     } catch (e) {
       ctx.logger.info(`Error parsing solutions: ${String(e)}`)
+    }
+
+    // validate the incoming response
+    const { valid, message: validationError } = validateStudentResponse({
+      type: type as any,
+      response,
+      restrictions: restrictions
+        ? typeof restrictions === 'string'
+          ? JSON.parse(restrictions)
+          : restrictions
+        : undefined,
+    })
+
+    if (!valid) {
+      ctx.logger.error(
+        'Response validation failed: ' +
+          validationError +
+          JSON.stringify({
+            messageId: message.messageId,
+            sessionId: message.sessionId,
+            instanceId: message.instanceId,
+          })
+      )
+      return { status: 400 }
     }
 
     let pointsAwarded: number | string = 0

--- a/apps/response-api/src/index.ts
+++ b/apps/response-api/src/index.ts
@@ -111,7 +111,7 @@ async function handleAddResponse(req: IncomingMessage, res: ServerResponse) {
     messageId: randomUUID(),
     sessionId: String(liveQuizId),
     instanceId: String(instanceId),
-    response: response, // pass through as-is; worker validates
+    response, // pass through as-is; worker validates
     cookie,
     responseTimestamp: Date.now(),
   }

--- a/packages/grading/package.json
+++ b/packages/grading/package.json
@@ -11,6 +11,7 @@
     "remeda": "2.15.0"
   },
   "devDependencies": {
+    "@klicker-uzh/types": "workspace:*",
     "@rollup/plugin-node-resolve": "~15.3.0",
     "@rollup/plugin-typescript": "~12.1.2",
     "@types/jest": "^29.5.13",

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -1,3 +1,4 @@
+import { CaseStudyResponseObject } from '@klicker-uzh/types'
 import { isDeepEqual, toLowerCase } from 'remeda'
 
 interface GradeQuestionChoicesArgs {
@@ -193,14 +194,6 @@ interface GradeQuestionCaseStudyArgs {
         }[]
       }[]
     | null
-}
-
-type CaseStudyResponseObject = {
-  [caseId: string]: {
-    [itemId: number]: {
-      [criterionId: string]: number // value = response
-    }
-  }
 }
 
 export function gradeQuestionCaseStudy({

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -1,4 +1,4 @@
-import { CaseStudyResponseObject } from '@klicker-uzh/types'
+import type { CaseStudyResponseObject } from '@klicker-uzh/types'
 import { isDeepEqual, toLowerCase } from 'remeda'
 
 interface GradeQuestionChoicesArgs {

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -1405,6 +1405,10 @@ export async function activateLiveQuizBlock(
       case DB.ElementType.NUMERICAL: {
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:info`, {
           ...commonInfo,
+          ...(elementData.options.restrictions &&
+          Object.keys(elementData.options.restrictions).length > 0
+            ? { restrictions: JSON.stringify(elementData.options.restrictions) }
+            : {}),
           solutions:
             elementData.options.exactSolutions &&
             elementData.options.exactSolutions.length > 0
@@ -1423,6 +1427,10 @@ export async function activateLiveQuizBlock(
       case DB.ElementType.FREE_TEXT: {
         redisMulti.hmset(`lq:${quiz.id}:i:${instance.id}:info`, {
           ...commonInfo,
+          ...(elementData.options.restrictions &&
+          Object.keys(elementData.options.restrictions).length > 0
+            ? { restrictions: JSON.stringify(elementData.options.restrictions) }
+            : {}),
           solutions: elementData.options.hasSampleSolution
             ? JSON.stringify(elementData.options.solutions)
             : undefined,

--- a/packages/graphql/src/services/stacks.ts
+++ b/packages/graphql/src/services/stacks.ts
@@ -1647,7 +1647,7 @@ export function updateChoicesResults({
     response.choices === null ||
     typeof response.choices === 'undefined'
   ) {
-    return { results: results, modified: false }
+    return { results, modified: false }
   }
 
   updatedResults.choices = (
@@ -1687,7 +1687,7 @@ export function updateNumericalResults({
     response.value === null ||
     response.value === ''
   ) {
-    return { results: results, modified: false }
+    return { results, modified: false }
   }
 
   // make sure that restrictions are fulfilled
@@ -1701,7 +1701,7 @@ export function updateNumericalResults({
     parsedValue > 1e30 || // prevent overflow
     parsedValue < -1e30 // prevent underflow
   ) {
-    return { results: results, modified: false }
+    return { results, modified: false }
   }
 
   const value = String(parsedValue)
@@ -1755,7 +1755,7 @@ export function updateFreeTextResults({
     (typeof elementData.options.restrictions?.maxLength === 'number' &&
       response.value.length > elementData.options.restrictions?.maxLength)
   ) {
-    return { results: results, modified: false }
+    return { results, modified: false }
   }
 
   const value = toLowerCase(response.value.trim())

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -519,6 +519,8 @@ export default {
         'Ihr Account wurde erstellt. Bitte überprüfen Sie Ihren Posteingang auf einen Aktivierungslink.',
       myCourses: 'Meine Kurse',
       myAssessmentCourses: 'Meine Assessment-Kurse',
+      noAssessmentCourseAssignments:
+        'Sie wurden bisher zu keinen Assessment-Kursen hinzugefügt. Bitte wenden Sie sich an Ihre Dozierenden.',
       insights: 'Einblicke',
       timeline: 'Zeitachse',
       myBookmarks: 'Meine Bookmarks',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -517,6 +517,8 @@ export default {
         'Your account has been created. Please check your inbox for an activation link.',
       myCourses: 'My Courses',
       myAssessmentCourses: 'My Assessment Courses',
+      noAssessmentCourseAssignments:
+        'You have not been assigned to any assessment courses yet. Please contact your lecturers.',
       insights: 'Insights',
       timeline: 'Timeline',
       myBookmarks: 'My Bookmarks',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -92,6 +92,14 @@ export type CaseStudyCaseResponse = {
   itemResponses: CaseStudyItemResponse[]
 }
 
+export type CaseStudyResponseObject = {
+  [caseId: string]: {
+    [itemId: number]: {
+      [criterionId: string]: number // value = response
+    }
+  }
+}
+
 export type ChoiceInput = {
   ix: number
   value: string
@@ -194,10 +202,19 @@ export type OptionsSelectionInput = {
 }
 
 export type ResponseInput = {
-  choices?: ChoicesResponse[] | null
-  value?: string | null
-  selection?: number[] | null
-  assessment?: CaseStudyCaseResponse[] | null
+  choices?: ChoicesResponse[] | null // SC / MC / KPRIM
+  value?: string | null // FREE_TEXT / NUMERICAL
+  selection?: number[] | null // SELECTION
+  assessment?: CaseStudyCaseResponse[] | null // CASE_STUDY
+  read?: boolean | null // CONTENT
+}
+
+export type LiveQuizResponseInput = {
+  choices?: ChoicesResponse[] | null // SC / MC / KPRIM
+  value?: string | null // FREE_TEXT / NUMERICAL
+  selection?: number[] | null // SELECTION
+  assessment?: CaseStudyResponseObject | null // CASE_STUDY - no need to convert to array for pothos validation in live quiz submissions
+  read?: boolean | null // CONTENT
 }
 
 export type ElementOptionsInput = OptionsChoicesInput &

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 15.3.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: 4.24.11
-        version: 4.24.11(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.3.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-intl:
         specifier: 4.3.4
         version: 4.3.4(next@15.3.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(typescript@5.6.3)
@@ -272,7 +272,7 @@ importers:
         version: 5.4.1
       next-auth:
         specifier: 4.24.11
-        version: 4.24.11(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.3.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       ws:
         specifier: 8.18.0
         version: 8.18.0
@@ -1469,6 +1469,9 @@ importers:
         specifier: 2.15.0
         version: 2.15.0
     devDependencies:
+      '@klicker-uzh/types':
+        specifier: workspace:*
+        version: link:../types
       '@rollup/plugin-node-resolve':
         specifier: ~15.3.0
         version: 15.3.1(rollup@4.34.4)
@@ -23432,7 +23435,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.6.3))(typescript@5.6.3))(next-auth@4.24.11(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
       '@prisma/client': 6.14.0(prisma@6.14.0(typescript@5.6.3))(typescript@5.6.3)
-      next-auth: 4.24.11(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-auth: 4.24.11(next@15.3.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   '@next/env@15.1.2': {}
 
@@ -33576,7 +33579,7 @@ snapshots:
 
   neverthrow@3.2.0: {}
 
-  next-auth@4.24.11(next@15.3.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-auth@4.24.11(next@15.3.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.9.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.6
       '@panva/hkdf': 1.2.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Stricter validation of live quiz responses (numerical/free-text rules and content "read" flag).
  * Frontend now submits all choice options with explicit selected flags for consistent grading.
  * New warning shown when no assessment courses are assigned.

* Bug Fixes
  * Invalid responses are rejected early to prevent incorrect processing.

* Refactor
  * Unified response typing across services and minor syntactic cleanups.

* Chores
  * CI: added types package build step and added types package as a dev dependency.

* Documentation
  * Added English and German translations for the new warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->