### PR TITLE
chore(packages/graphql): make sure redis exec and assessment caches are set up correctly in graphql test workflows

### DIFF
--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -88,6 +88,16 @@ jobs:
         ports:
           - 6379:6379
 
+      redis_assessment:
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        image: redis:7
+        ports:
+          - 6380:6379
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -61,7 +61,7 @@ function Header({
   const showProfileSetup =
     participant &&
     participant.role === UserRole.Participant &&
-    !process.env.NEXT_PUBLIC_IS_ASSESSMENT &&
+    process.env.NEXT_PUBLIC_IS_ASSESSMENT !== 'true' &&
     (!participant?.avatar || !participant?.email)
 
   return (
@@ -143,7 +143,7 @@ function Header({
               <AvatarWithLevel
                 avatar={participant?.avatar}
                 level={
-                  !process.env.NEXT_PUBLIC_IS_ASSESSMENT
+                  process.env.NEXT_PUBLIC_IS_ASSESSMENT !== 'true'
                     ? participant?.level
                     : undefined
                 }

--- a/apps/frontend-pwa/src/components/common/Header.tsx
+++ b/apps/frontend-pwa/src/components/common/Header.tsx
@@ -61,6 +61,7 @@ function Header({
   const showProfileSetup =
     participant &&
     participant.role === UserRole.Participant &&
+    !process.env.NEXT_PUBLIC_IS_ASSESSMENT &&
     (!participant?.avatar || !participant?.email)
 
   return (
@@ -141,7 +142,11 @@ function Header({
             <>
               <AvatarWithLevel
                 avatar={participant?.avatar}
-                level={participant?.level}
+                level={
+                  !process.env.NEXT_PUBLIC_IS_ASSESSMENT
+                    ? participant?.level
+                    : undefined
+                }
               />
               {showProfileSetup && (
                 <FontAwesomeIcon

--- a/packages/graphql/test/docker/docker-compose.test.yml
+++ b/packages/graphql/test/docker/docker-compose.test.yml
@@ -86,6 +86,13 @@ services:
     networks:
       - klicker
 
+  redis_assessment:
+    image: docker.io/library/redis:7
+    ports:
+      - 6380:6379
+    networks:
+      - klicker
+
 networks:
   klicker:
     driver: bridge

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -110,8 +110,8 @@ export async function testInitialization(
   })
 
   const pubSub = createPubSub()
-  const redisExec = new Redis()
-  const redisAssessmentExec = new Redis()
+  const redisExec = new Redis({ host: '127.0.0.1', port: 6379 })
+  const redisAssessmentExec = new Redis({ host: '127.0.0.1', port: 6380 })
 
   const hatchetCtx = {
     hatchet,
@@ -276,9 +276,10 @@ export async function testInitialization(
     hatchet,
     tasks,
     emitter,
-    redisExec: vi.fn() as unknown as ContextWithUser['redisExec'],
+    // Provide actual Redis clients so cache operations (e.g., keys/unlink) work
+    redisExec: redisExec as unknown as ContextWithUser['redisExec'],
     redisAssessmentExec:
-      vi.fn() as unknown as ContextWithUser['redisAssessmentExec'],
+      redisAssessmentExec as unknown as ContextWithUser['redisAssessmentExec'],
     pubSub: {
       publish: vi.fn(),
       subscribe: vi.fn().mockReturnValue(new Repeater(() => {})),

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -276,10 +276,8 @@ export async function testInitialization(
     hatchet,
     tasks,
     emitter,
-    // Provide actual Redis clients so cache operations (e.g., keys/unlink) work
-    redisExec: redisExec as unknown as ContextWithUser['redisExec'],
-    redisAssessmentExec:
-      redisAssessmentExec as unknown as ContextWithUser['redisAssessmentExec'],
+    redisExec,
+    redisAssessmentExec,
     pubSub: {
       publish: vi.fn(),
       subscribe: vi.fn().mockReturnValue(new Repeater(() => {})),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Assessment builds hide the profile-setup prompt and no longer display participant level in the header.

- Tests
  - Test environment now runs a separate Redis instance for assessment and uses real Redis clients for assessment-related tests.

- Chores
  - CI workflow and test infrastructure updated to include an additional Redis service to support assessment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->