### PR TITLE
fix(apps/frontend-manage): ensure that scoring can be customized for both gamified and assessment live quizzes

### DIFF
--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/AdvancedLiveQuizSettings.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/AdvancedLiveQuizSettings.tsx
@@ -1,4 +1,4 @@
-import { faBook, faDice } from '@fortawesome/free-solid-svg-icons'
+import { faBook } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   LQ_DEFAULT_CORRECT_POINTS,
@@ -6,11 +6,9 @@ import {
   LQ_MAX_BONUS_POINTS,
   LQ_TIME_TO_ZERO_BONUS,
 } from '@klicker-uzh/shared-components/src/constants'
-import ForwardRefButton from '@klicker-uzh/shared-components/src/ForwardRefButton'
-import { Button, FormikNumberField, Modal } from '@uzh-bf/design-system'
+import { FormikNumberField, Modal } from '@uzh-bf/design-system'
 import { useTranslations } from 'next-intl'
 import { Dispatch, SetStateAction } from 'react'
-import { twMerge } from 'tailwind-merge'
 import LiveQuizGradingIllustration from './LiveQuizGradingIllustration'
 
 function AdvancedLiveQuizSettings({
@@ -38,25 +36,6 @@ function AdvancedLiveQuizSettings({
     <Modal
       open={modalOpen}
       onClose={() => setModalOpen(false)}
-      trigger={
-        <ForwardRefButton
-          basic
-          onClick={() => setModalOpen(true)}
-          overrideClassName="h-7 w-7"
-          data={{ cy: 'live-quiz-advanced-settings' }}
-        >
-          <Button.Icon
-            withoutLabel
-            icon={faDice}
-            className={{
-              root: twMerge(
-                'h-5 w-5',
-                showError && 'text-red-600 hover:text-red-700'
-              ),
-            }}
-          />
-        </ForwardRefButton>
-      }
       title={t('manage.activityWizard.liveQuizCustomizedGrading')}
       className={{ content: 'pb-0' }}
       dataCloseButton={{ cy: 'live-quiz-advanced-settings-close' }}

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
@@ -336,6 +336,7 @@ function LiveQuizSettingsStep({
                           <span
                             className="text-primary-100 cursor-pointer hover:underline"
                             onClick={() => setCustomizedGradingModal(true)}
+                            data-cy="live-quiz-advanced-settings"
                           >
                             {t(
                               'manage.activityWizard.liveQuizCustomizedGrading'

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
@@ -302,45 +302,26 @@ function LiveQuizSettingsStep({
                       </div>
                     </div>
                   </div>
-                  <div>
-                    <div className="mb-1 grid grid-cols-9">
-                      <div className="col-span-7 col-start-2 flex flex-row items-center justify-center gap-2">
-                        <FontAwesomeIcon
-                          icon={faCrown}
-                          className="text-orange-400"
-                        />
-                        <div className="text-lg font-bold">
-                          {t('shared.generic.gamification')}
-                        </div>
-                      </div>
-                      <div className="h-7 w-7">
-                        {values.isGamificationEnabled && (
-                          <AdvancedLiveQuizSettings
-                            modalOpen={customizedGradingModal}
-                            setModalOpen={setCustomizedGradingModal}
-                            multiplier={values.multiplier}
-                            defaultPointsValue={String(values.defaultPoints)}
-                            correctPointsValue={String(
-                              values.defaultCorrectPoints
-                            )}
-                            maxBonusValue={String(values.maxBonusPoints)}
-                            timeToZeroValue={String(values.timeToZeroBonus)}
-                            showError={
-                              !!errors.defaultPoints ||
-                              !!errors.defaultCorrectPoints ||
-                              !!errors.maxBonusPoints ||
-                              !!errors.timeToZeroBonus
-                            }
-                          />
-                        )}
+                  <div className="w-60">
+                    <div className="mb-1 flex flex-row items-center justify-center gap-2">
+                      <FontAwesomeIcon
+                        icon={faCrown}
+                        className="text-orange-400"
+                      />
+                      <div className="text-lg font-bold">
+                        {t('shared.generic.scoring')}
                       </div>
                     </div>
 
-                    {values.isGamificationEnabled ? (
+                    {values.isGamificationEnabled ||
+                    values.isAssessmentEnabled ? (
                       <>
                         <MultiplierSelector
-                          disabled={!values.isGamificationEnabled}
-                          className={{ trigger: 'w-59 h-8' }}
+                          disabled={
+                            !values.isGamificationEnabled &&
+                            !values.isAssessmentEnabled
+                          }
+                          className={{ trigger: 'w-58 h-8' }}
                         />
                         <div className="mt-2 flex flex-row items-start gap-2.5">
                           <FontAwesomeIcon
@@ -365,7 +346,7 @@ function LiveQuizSettingsStep({
                     ) : (
                       <UserNotification
                         message={t(
-                          'manage.activityWizard.liveQuizGamificationDeactivated'
+                          'manage.activityWizard.liveQuizNoCustomizedScoring'
                         )}
                       />
                     )}
@@ -415,6 +396,21 @@ function LiveQuizSettingsStep({
                 continueDisabled={continueDisabled}
                 onPrevStep={() => onPrevStep!(values)}
                 onCloseWizard={closeWizard}
+              />
+              <AdvancedLiveQuizSettings
+                modalOpen={customizedGradingModal}
+                setModalOpen={setCustomizedGradingModal}
+                multiplier={values.multiplier}
+                defaultPointsValue={String(values.defaultPoints)}
+                correctPointsValue={String(values.defaultCorrectPoints)}
+                maxBonusValue={String(values.maxBonusPoints)}
+                timeToZeroValue={String(values.timeToZeroBonus)}
+                showError={
+                  !!errors.defaultPoints ||
+                  !!errors.defaultCorrectPoints ||
+                  !!errors.maxBonusPoints ||
+                  !!errors.timeToZeroBonus
+                }
               />
             </div>
           </Form>

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1859,8 +1859,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       liveQuizCustomizedGrading: 'Benutzerdefinierte Bewertung',
       liveQuizPointsExplanation:
         'Diese erweiterten Einstellungen ermöglichen es, die Punktevergabe bei einem Live-Quiz zu verändern. Bitte beachten Sie, dass alle Punkteinstellungen und die Illustrationen der Punktevergabe sich auf Elemente mit einem Multiplikator von 1x beziehen. Höhere Multiplikatoren werden auf alle Komponenten ausser den Standardpunkten angewendet. Der auf der Aktivität gesetzte Multiplikator wird in der Illustration bereits mit einbezogen. Die Antwortzeit beginnt abzulaufen sobald der erste Teilnehmer eine vollständig korrekte Antwort abgegeben hat. Für mehr Informationen konsultieren Sie bitte unsere <link>Dokumentation</link>.',
-      liveQuizGamificationDeactivated:
-        'Gamifizierung ist für dieses Live Quiz aktuell nicht aktiviert. Bitte wählen Sie entweder einen gamifizierten Kurs oder aktivieren Sie die Gamifizierung manuell.',
+      liveQuizNoCustomizedScoring:
+        'Die Fragen in diesem Live Quiz werden aktuell nicht bepunktet. Um die Bepunktung zu aktivieren, weisen Sie es einem gamifizierten und/oder Assessment-Kurs zu oder aktivieren Sie die Gamifizierung manuell.',
       liveQuizDefaultPoints: 'Standardpunkte',
       liveQuizDefaultPointsTooltip:
         'Teilnehmende in einem Live-Quiz erhalten diese Anzahl Punkte für das Teilnehmen an einer Frage. Wenn keine Musterlösung definiert ist, werden nur Standardpunkte vergeben. Der Standardwert beträgt {defaultValue}.',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1846,8 +1846,8 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       liveQuizCustomizedGrading: 'Customized Grading',
       liveQuizPointsExplanation:
         'These advanced settings allow you to change the point allocation in a live quiz. Please note that all point settings and the illustrations of the point allocation refer to elements with a multiplier of 1x. Larger multipliers are applied to all components except from the standard points. The multiplier set on the activity is already included in the illustration. The answer time starts running as soon as the first participant has answered the question completely correctly. For more information, please consult our <link>documentation</link>.',
-      liveQuizGamificationDeactivated:
-        'Gamification is currently not activated for this live quiz. Please select a gamified course or activate gamification manually.',
+      liveQuizNoCustomizedScoring:
+        'Questions in this live quiz are currently not scored. To enable scoring, assign it to a gamified and/or assessment course or manually activate gamification.',
       liveQuizDefaultPoints: 'Standard points',
       liveQuizDefaultPointsTooltip:
         'Participants in a live quiz receive this number of points for participating in a question. If no sample solution is defined, only standard points are awarded. The default value is {defaultValue}.',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoring controls now appear when either gamification or assessment is enabled; controls disable only if both are off.

* **Style**
  * “Gamification” relabeled to “Scoring” with a more compact header; advanced settings shown via a clickable label and relocated after navigation.

* **Refactor**
  * Advanced settings modal no longer has an internal trigger and is opened via external control.

* **Localization**
  * Updated translation key and copy clarifying that scoring is not active and how to enable it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->