### PR TITLE
fix(packages/graphql): make sure that live quiz pins are modified only in the required cases

### DIFF
--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -307,11 +307,11 @@ export async function manipulateLiveQuiz(
 
   // check if a new pin code is required
   const requiresNewPin =
-    (pinProtection && // 1) pin protection is required (corresponding setting or assessment course)
-      (!existingActivity || // 2) only assign during creation, on course assignment change, on pin setting change with no course assigned
-        ((courseId || existingActivity.courseId) &&
-          courseId !== existingActivity.courseId))) ||
-    (existingActivity && !existingActivity.courseId && !courseId)
+    pinProtection && // 1) pin protection is required (corresponding setting or assessment course)
+    (!existingActivity || // 2) only assign during creation, on course assignment change, on pin setting change with no course assigned
+      ((courseId || existingActivity.courseId) &&
+        courseId !== existingActivity.courseId) ||
+      (existingActivity && !existingActivity.courseId && !courseId))
 
   // find a new pin code that is still available, if required
   let newPinCode: string | undefined | null = existingActivity?.pinCode

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -308,10 +308,10 @@ export async function manipulateLiveQuiz(
   // check if a new pin code is required
   const requiresNewPin =
     pinProtection && // 1) pin protection is required (corresponding setting or assessment course)
-    (!existingActivity || // 2) only assign during creation, on course assignment change, on pin setting change with no course assigned
-      ((courseId || existingActivity.courseId) &&
+    (!existingActivity || // 2.1) assign new pin on activity creation
+      ((courseId || existingActivity.courseId) && // 2.2) assign new pin on course assignment change (course defined at least before or after)
         courseId !== existingActivity.courseId) ||
-      (existingActivity && !existingActivity.courseId && !courseId))
+      (existingActivity && !existingActivity.courseId && !courseId)) // 2.3) assign new pin on pin setting change with no course assigned before and after edit
 
   // find a new pin code that is still available, if required
   let newPinCode: string | undefined | null = existingActivity?.pinCode

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -215,24 +215,6 @@ export async function manipulateLiveQuiz(
   if (id) {
     existingActivity = await ctx.prisma.liveQuiz.findUnique({
       where: { id, isDeleted: false },
-      include: {
-        course: {
-          include: {
-            _count: {
-              select: {
-                permissions: {
-                  where: {
-                    userId: ctx.user.sub,
-                    permissionLevel: {
-                      in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
     })
 
     if (!existingActivity) {
@@ -305,9 +287,16 @@ export async function manipulateLiveQuiz(
     )
   }
 
-  // if required, find a new pin code for the live quiz that is still available
+  // check if a new pin code is required
+  const requiresNewPin =
+    pinProtection && // 1) pin protection is required (corresponding setting or assessment course)
+    (!existingActivity || // 2) only assign during creation or on course assignment change
+      ((courseId || existingActivity.courseId) &&
+        courseId !== existingActivity.courseId))
+
+  // find a new pin code that is still available, if required
   let newPinCode: string | undefined | null = existingActivity?.pinCode
-  if (pinProtection && (!courseId || courseId !== existingActivity?.courseId)) {
+  if (requiresNewPin) {
     let pinValid = false
 
     for (let attempt = 0; attempt < 10; attempt++) {

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -289,10 +289,11 @@ export async function manipulateLiveQuiz(
 
   // check if a new pin code is required
   const requiresNewPin =
-    pinProtection && // 1) pin protection is required (corresponding setting or assessment course)
-    (!existingActivity || // 2) only assign during creation or on course assignment change
-      ((courseId || existingActivity.courseId) &&
-        courseId !== existingActivity.courseId))
+    (pinProtection && // 1) pin protection is required (corresponding setting or assessment course)
+      (!existingActivity || // 2) only assign during creation, on course assignment change, on pin setting change with no course assigned
+        ((courseId || existingActivity.courseId) &&
+          courseId !== existingActivity.courseId))) ||
+    (existingActivity && !existingActivity.courseId && !courseId)
 
   // find a new pin code that is still available, if required
   let newPinCode: string | undefined | null = existingActivity?.pinCode

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -215,6 +215,24 @@ export async function manipulateLiveQuiz(
   if (id) {
     existingActivity = await ctx.prisma.liveQuiz.findUnique({
       where: { id, isDeleted: false },
+      include: {
+        course: {
+          include: {
+            _count: {
+              select: {
+                permissions: {
+                  where: {
+                    userId: ctx.user.sub,
+                    permissionLevel: {
+                      in: [DB.PermissionLevel.ADMIN, DB.PermissionLevel.OWNER],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     })
 
     if (!existingActivity) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of PIN handling for live quizzes to prevent unintended PIN changes when creating or reassigning quizzes; maintains correct behavior when a quiz has no associated course and PIN protection is enabled.
  - Consistent error handling when a new unused PIN cannot be found.

- Performance
  - Minor efficiency improvement during live-quiz PIN decision-making.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->