### PR TITLE
enhance(packages/graphql): instead of unlinking, set expiration date on instance keys within block closure operation

### DIFF
--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -1413,7 +1413,8 @@ async function removeCacheEntriesBlock({
     if (keys.length > 0) {
       const pipe = redis.pipeline()
       for (const key of keys) {
-        pipe.unlink(key)
+        // set an expiration time of 1 day to all hash sets of the live quiz
+        pipe.expire(key, 60 * 60 * 24)
       }
       await pipe.exec()
     }
@@ -1432,7 +1433,8 @@ async function removeCacheEntriesBlock({
     if (keys.length > 0) {
       const pipe = redis.pipeline()
       for (const key of keys) {
-        pipe.unlink(key)
+        // set an expiration time of 1 day to all hash sets of the live quiz
+        pipe.expire(key, 60 * 60 * 24)
       }
       await pipe.exec()
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved cache handling for live quizzes by transitioning to time-based expiration, enhancing stability and reducing potential disruptions.
  - Background reliability improvement with no changes to the user interface or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->