### PR TITLE
fix(apps/frontend-manage): ensure that open overview functionality only forwards to course overview if sufficient permissions are available

### DIFF
--- a/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivityWizard.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/groupActivity/GroupActivityWizard.tsx
@@ -79,9 +79,6 @@ function GroupActivityWizard({
 }: GroupActivityWizardProps) {
   const t = useTranslations()
   const [isWizardCompleted, setIsWizardCompleted] = useState(false)
-  const [selectedCourseId, setSelectedCourseId] = useState<string | undefined>(
-    undefined
-  )
   const [activeStep, setActiveStep] = useState(0)
   const [stepValidity, setStepValidity] = useState<boolean[]>(
     Array(4).fill(!!initialValues)
@@ -303,8 +300,12 @@ function GroupActivityWizard({
     courseId: initialValues?.course?.id || formDefaultValues.courseId,
   })
 
-  const [createGroupActivity] = useMutation(CreateGroupActivityDocument)
-  const [editGroupActivity] = useMutation(EditGroupActivityDocument)
+  const [createGroupActivity, { data: creationData }] = useMutation(
+    CreateGroupActivityDocument
+  )
+  const [editGroupActivity, { data: editingData }] = useMutation(
+    EditGroupActivityDocument
+  )
 
   const handleSubmit = useCallback(
     async (values: GroupActivityFormValues) => {
@@ -315,7 +316,6 @@ function GroupActivityWizard({
         createGroupActivity,
         editGroupActivity,
         setIsWizardCompleted,
-        setSelectedCourseId,
         onError: () =>
           toast({
             type: 'error',
@@ -335,6 +335,13 @@ function GroupActivityWizard({
     },
     [createGroupActivity, editGroupActivity, initialValues?.id]
   )
+
+  const selectedCourseId =
+    creationData?.createGroupActivity?.courseId ??
+    editingData?.editGroupActivity?.courseId
+  const isActivityReviewer =
+    creationData?.createGroupActivity?.isActivityReviewer ??
+    editingData?.editGroupActivity?.isActivityReviewer
 
   return (
     <WizardLayout
@@ -362,7 +369,11 @@ function GroupActivityWizard({
           )}
           name={formData.name}
           editMode={editMode}
-          viewElementHref={`/courses/${selectedCourseId}?tab=groupActivities`}
+          viewElementHref={
+            isActivityReviewer
+              ? `/courses/${selectedCourseId}?tab=groupActivities`
+              : '/activities'
+          }
           onRestartForm={() => {
             setIsWizardCompleted(false)
             closeWizard()

--- a/apps/frontend-manage/src/components/activities/creation/groupActivity/submitGroupActivityForm.ts
+++ b/apps/frontend-manage/src/components/activities/creation/groupActivity/submitGroupActivityForm.ts
@@ -39,7 +39,6 @@ interface GroupActivityFormSubmissionProps {
       | undefined
   ) => Promise<FetchResult<EditGroupActivityMutation>>
   setIsWizardCompleted: (isCompleted: boolean) => void
-  setSelectedCourseId: (courseId: string | undefined) => void
   onError: () => void
 }
 
@@ -50,7 +49,6 @@ async function submitGroupActivityForm({
   createGroupActivity,
   editGroupActivity,
   setIsWizardCompleted,
-  setSelectedCourseId,
   onError,
 }: GroupActivityFormSubmissionProps) {
   try {
@@ -183,7 +181,6 @@ async function submitGroupActivityForm({
     }
 
     if (success) {
-      setSelectedCourseId(values.courseId)
       setIsWizardCompleted(true)
     }
   } catch (error) {

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizWizard.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizWizard.tsx
@@ -314,6 +314,13 @@ function LiveQuizWizard({
     [createLiveQuiz, editMode, editLiveQuiz, initialValues?.id]
   )
 
+  const isActivityReviewer =
+    creationData?.createLiveQuiz?.isActivityReviewer ??
+    editingData?.editLiveQuiz?.isActivityReviewer
+  const selectedCourseId =
+    creationData?.createLiveQuiz?.courseId ??
+    editingData?.editLiveQuiz?.courseId
+
   return (
     <WizardLayout
       title={title}
@@ -341,9 +348,8 @@ function LiveQuizWizard({
           name={formData.name}
           editMode={editMode}
           viewElementHref={
-            (creationData?.createLiveQuiz?.courseId ??
-            editingData?.editLiveQuiz?.courseId)
-              ? `/courses/${formData.courseId}?tab=liveQuizzes`
+            isActivityReviewer && selectedCourseId
+              ? `/courses/${selectedCourseId}?tab=liveQuizzes`
               : '/activities'
           }
           onRestartForm={() => {

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizWizard.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizWizard.tsx
@@ -277,8 +277,11 @@ function LiveQuizWizard({
       formDefaultValues.isModerationEnabled,
   })
 
-  const [editLiveQuiz] = useMutation(EditLiveQuizDocument)
-  const [createLiveQuiz, { data }] = useMutation(CreateLiveQuizDocument)
+  const [editLiveQuiz, { data: editingData }] =
+    useMutation(EditLiveQuizDocument)
+  const [createLiveQuiz, { data: creationData }] = useMutation(
+    CreateLiveQuizDocument
+  )
   const [startLiveQuiz] = useMutation(StartLiveQuizDocument)
 
   const handleSubmit = useCallback(
@@ -338,7 +341,8 @@ function LiveQuizWizard({
           name={formData.name}
           editMode={editMode}
           viewElementHref={
-            formData.courseId && formData.courseId !== 'no-course-selected'
+            (creationData?.createLiveQuiz?.courseId ??
+            editingData?.editLiveQuiz?.courseId)
               ? `/courses/${formData.courseId}?tab=liveQuizzes`
               : '/activities'
           }
@@ -350,12 +354,16 @@ function LiveQuizWizard({
           setStepNumber={setActiveStep}
           onCloseWizard={closeWizard}
         >
-          {!editMode && data?.createLiveQuiz?.id ? (
+          {creationData?.createLiveQuiz?.id || editingData?.editLiveQuiz?.id ? (
             <Button
               data={{ cy: 'quick-start' }}
               onClick={async () => {
                 await startLiveQuiz({
-                  variables: { id: data.createLiveQuiz!.id },
+                  variables: {
+                    id:
+                      creationData?.createLiveQuiz?.id ??
+                      editingData!.editLiveQuiz!.id,
+                  },
                   update(cache, { data: res }) {
                     // return early if the mutation failed
                     if (!res?.startLiveQuiz) return
@@ -382,13 +390,19 @@ function LiveQuizWizard({
                   optimisticResponse: {
                     startLiveQuiz: {
                       __typename: 'LiveQuizMeta',
-                      id: data.createLiveQuiz!.id,
-                      name: data.createLiveQuiz!.name,
+                      id:
+                        creationData?.createLiveQuiz?.id ??
+                        editingData!.editLiveQuiz!.id,
+                      name:
+                        creationData?.createLiveQuiz?.name ??
+                        editingData!.editLiveQuiz!.name,
                       status: PublicationStatus.Published,
                     },
                   },
                 })
-                router.push(`/quizzes/${data.createLiveQuiz!.id}/cockpit`)
+                router.push(
+                  `/quizzes/${creationData?.createLiveQuiz?.id ?? editingData?.editLiveQuiz?.id}/cockpit`
+                )
               }}
             >
               <Button.Icon icon={faPlay} />

--- a/apps/frontend-manage/src/components/activities/creation/microLearning/MicroLearningWizard.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/microLearning/MicroLearningWizard.tsx
@@ -76,9 +76,6 @@ function MicroLearningWizard({
 }: MicroLearningWizardProps) {
   const t = useTranslations()
   const [isWizardCompleted, setIsWizardCompleted] = useState(false)
-  const [selectedCourseId, setSelectedCourseId] = useState<string | undefined>(
-    undefined
-  )
   const [activeStep, setActiveStep] = useState(0)
   const [stepValidity, setStepValidity] = useState<boolean[]>(
     Array(4).fill(!!initialValues)
@@ -269,10 +266,10 @@ function MicroLearningWizard({
     courseId: initialValues?.course?.id ?? formDefaultValues.courseId,
   })
 
-  const [createMicroLearning, { data: microLearningCreateData }] = useMutation(
+  const [createMicroLearning, { data: creationData }] = useMutation(
     CreateMicroLearningDocument
   )
-  const [editMicroLearning, { data: microLearningEditData }] = useMutation(
+  const [editMicroLearning, { data: editingData }] = useMutation(
     EditMicroLearningDocument
   )
   const handleSubmit = useCallback(
@@ -284,7 +281,6 @@ function MicroLearningWizard({
         editMode,
         createMicroLearning,
         editMicroLearning,
-        setSelectedCourseId,
         setIsWizardCompleted,
         onError: () =>
           toast({
@@ -305,6 +301,15 @@ function MicroLearningWizard({
     },
     [createMicroLearning, editMicroLearning, editMode, initialValues?.id]
   )
+
+  const activityId =
+    creationData?.createMicroLearning?.id ?? editingData?.editMicroLearning?.id
+  const selectedCourseId =
+    creationData?.createMicroLearning?.courseId ??
+    editingData?.editMicroLearning?.courseId
+  const isActivityReviewer =
+    creationData?.createMicroLearning?.isActivityReviewer ??
+    editingData?.editMicroLearning?.isActivityReviewer
 
   return (
     <WizardLayout
@@ -332,8 +337,12 @@ function MicroLearningWizard({
           )}
           name={formData.name}
           editMode={editMode}
-          previewElementHref={`${process.env.NEXT_PUBLIC_PWA_URL}/course/${selectedCourseId}/microLearnings/${microLearningCreateData?.createMicroLearning?.id || microLearningEditData?.editMicroLearning?.id}/`}
-          viewElementHref={`/courses/${selectedCourseId}?tab=microLearnings`}
+          previewElementHref={`${process.env.NEXT_PUBLIC_PWA_URL}/course/${selectedCourseId}/microLearnings/${activityId}/`}
+          viewElementHref={
+            isActivityReviewer
+              ? `/courses/${selectedCourseId}?tab=microLearnings`
+              : '/activities'
+          }
           onRestartForm={() => {
             setIsWizardCompleted(false)
             closeWizard()

--- a/apps/frontend-manage/src/components/activities/creation/microLearning/submitMicrolearningForm.ts
+++ b/apps/frontend-manage/src/components/activities/creation/microLearning/submitMicrolearningForm.ts
@@ -42,7 +42,6 @@ interface MicroLearningFormSubmissionProps {
         >
       | undefined
   ) => Promise<FetchResult<EditMicroLearningMutation>>
-  setSelectedCourseId: (courseId?: string) => void
   setIsWizardCompleted: (isCompleted: boolean) => void
   onError: () => void
 }
@@ -54,7 +53,6 @@ async function submitMicrolearningForm({
   editMode,
   createMicroLearning,
   editMicroLearning,
-  setSelectedCourseId,
   setIsWizardCompleted,
   onError,
 }: MicroLearningFormSubmissionProps) {
@@ -175,7 +173,6 @@ async function submitMicrolearningForm({
     }
 
     if (success) {
-      setSelectedCourseId(values.courseId)
       setIsWizardCompleted(true)
     } else {
       onError()

--- a/apps/frontend-manage/src/components/activities/creation/practiceQuiz/PracticeQuizWizard.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/practiceQuiz/PracticeQuizWizard.tsx
@@ -86,11 +86,8 @@ function PracticeQuizWizard({
   duplicationMode,
 }: PracticeQuizWizardProps) {
   const t = useTranslations()
-  const [selectedCourseId, setSelectedCourseId] = useState<string | undefined>(
-    undefined
-  )
-  const [isWizardCompleted, setIsWizardCompleted] = useState(false)
 
+  const [isWizardCompleted, setIsWizardCompleted] = useState(false)
   const [activeStep, setActiveStep] = useState(0)
   const [stepValidity, setStepValidity] = useState<boolean[]>(
     Array(4).fill(!!initialValues)
@@ -251,10 +248,10 @@ function PracticeQuizWizard({
         : formDefaultValues.resetTimeDays,
   })
 
-  const [createPracticeQuiz, { data: practiceQuizCreateData }] = useMutation(
+  const [createPracticeQuiz, { data: creationData }] = useMutation(
     CreatePracticeQuizDocument
   )
-  const [editPracticeQuiz, { data: practiceQuizEditData }] = useMutation(
+  const [editPracticeQuiz, { data: editingData }] = useMutation(
     EditPracticeQuizDocument
   )
   const handleSubmit = useCallback(
@@ -266,7 +263,6 @@ function PracticeQuizWizard({
         editMode,
         createPracticeQuiz,
         editPracticeQuiz,
-        setSelectedCourseId,
         setIsWizardCompleted,
         onError: () =>
           toast({
@@ -287,6 +283,15 @@ function PracticeQuizWizard({
     },
     [createPracticeQuiz, editMode, editPracticeQuiz, initialValues?.id]
   )
+
+  const activityId =
+    creationData?.createPracticeQuiz?.id ?? editingData?.editPracticeQuiz?.id
+  const selectedCourseId =
+    creationData?.createPracticeQuiz?.courseId ??
+    editingData?.editPracticeQuiz?.courseId
+  const isActivityReviewer =
+    creationData?.createPracticeQuiz?.isActivityReviewer ??
+    editingData?.editPracticeQuiz?.isActivityReviewer
 
   return (
     <WizardLayout
@@ -314,8 +319,12 @@ function PracticeQuizWizard({
           )}
           name={formData.name}
           editMode={editMode}
-          previewElementHref={`${process.env.NEXT_PUBLIC_PWA_URL}/course/${selectedCourseId}/practiceQuizzes/${practiceQuizEditData?.editPracticeQuiz?.id || practiceQuizCreateData?.createPracticeQuiz?.id}`}
-          viewElementHref={`/courses/${selectedCourseId}?tab=practiceQuizzes`}
+          previewElementHref={`${process.env.NEXT_PUBLIC_PWA_URL}/course/${selectedCourseId}/practiceQuizzes/${activityId}`}
+          viewElementHref={
+            isActivityReviewer
+              ? `/courses/${selectedCourseId}?tab=practiceQuizzes`
+              : '/activities'
+          }
           onRestartForm={() => {
             setIsWizardCompleted(false)
             closeWizard()

--- a/apps/frontend-manage/src/components/activities/creation/practiceQuiz/submitPracticeQuizForm.ts
+++ b/apps/frontend-manage/src/components/activities/creation/practiceQuiz/submitPracticeQuizForm.ts
@@ -38,7 +38,6 @@ interface PracticeQuizFormSubmissionProps {
         >
       | undefined
   ) => Promise<FetchResult<EditPracticeQuizMutation>>
-  setSelectedCourseId: (courseId?: string) => void
   setIsWizardCompleted: (isCompleted: boolean) => void
   onError: () => void
 }
@@ -50,7 +49,6 @@ async function submitPracticeQuizForm({
   editMode,
   createPracticeQuiz,
   editPracticeQuiz,
-  setSelectedCourseId,
   setIsWizardCompleted,
   onError,
 }: PracticeQuizFormSubmissionProps) {
@@ -178,7 +176,6 @@ async function submitPracticeQuizForm({
 
     if (success) {
       setIsWizardCompleted(true)
-      setSelectedCourseId(values.courseId)
     } else {
       onError()
     }

--- a/packages/graphql/src/services/liveQuizzes.ts
+++ b/packages/graphql/src/services/liveQuizzes.ts
@@ -294,9 +294,10 @@ export async function manipulateLiveQuiz(
   const pinProtection = assessmentSetting || isPinProtected
 
   // if the activity is part of an assessment course, the course assignment can only be modified by course admins / owners
+  const isCourseAdminOwner = !!existingActivity?.course?._count.permissions
   if (
     existingActivity?.isAssessmentEnabled &&
-    !existingActivity?.course?._count.permissions &&
+    !isCourseAdminOwner &&
     (courseId === null || courseId !== existingActivity?.courseId)
   ) {
     throw new GraphQLError(
@@ -519,7 +520,7 @@ export async function manipulateLiveQuiz(
     reviewStatus: activity.reviewStatus,
     type: ActivityType.LIVE_QUIZ,
     status: activity.status,
-    courseId: activity.course?.id,
+    courseId: isCourseAdminOwner ? activity.course?.id : null, // only return course id if the user can access corresponding course overview
     courseName: activity.course?.name,
     courseLanguage: activity.course?.language,
     courseStartDate: activity.course?.startDate,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Role-aware navigation after completing Group Activity, Microlearning, Practice Quiz, and Live Quiz: reviewers go to the course tab; others go to Activities.
  - Preview/View and "Start Now" links now reliably use created or edited activity IDs, improving routing across create/edit flows.

- Bug Fixes
  - Consistent post-submission behavior across creation and editing paths.
  - Live Quiz course association is now restricted to course admins/owners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->