### PR TITLE
fix(packages/graphql): ensure that gamification and assessment settings are correctly applied to course activities

### DIFF
--- a/apps/frontend-manage/src/components/activities/creation/CourseSelectionMonitorMicrolearning.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/CourseSelectionMonitorMicrolearning.tsx
@@ -28,11 +28,11 @@ function CourseSelectionMonitorMicrolearning({
       )
 
       if (!course) {
-        console.log('Invalid course selection detected')
+        setCourseGamified(false)
         return
       }
 
-      setCourseGamified(course.isGamified)
+      setCourseGamified(true)
       setTouched({
         startDate: true,
         endDate: true,

--- a/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/liveQuiz/LiveQuizSettingsStep.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@apollo/client'
 import {
   faCheck,
-  faCrown,
   faGears,
   faQuestionCircle,
   faTriangleExclamation,
@@ -303,14 +302,8 @@ function LiveQuizSettingsStep({
                     </div>
                   </div>
                   <div className="w-60">
-                    <div className="mb-1 flex flex-row items-center justify-center gap-2">
-                      <FontAwesomeIcon
-                        icon={faCrown}
-                        className="text-orange-400"
-                      />
-                      <div className="text-lg font-bold">
-                        {t('shared.generic.scoring')}
-                      </div>
+                    <div className="mb-2 flex flex-row items-center justify-center gap-2 text-lg font-bold">
+                      {t('shared.generic.scoring')}
                     </div>
 
                     {values.isGamificationEnabled ||

--- a/apps/frontend-manage/src/components/activities/creation/microLearning/MicroLearningSettingsStep.tsx
+++ b/apps/frontend-manage/src/components/activities/creation/microLearning/MicroLearningSettingsStep.tsx
@@ -36,7 +36,6 @@ function MicroLearningSettingsStep({
 }: MicroLearningWizardStepProps) {
   const t = useTranslations()
   const [courseGamified, setCourseGamified] = useState(false)
-
   const groupedCourses = useGamifiedCourseGrouping({
     gamifiedCourses: gamifiedCourses ?? [],
     nonGamifiedCourses: nonGamifiedCourses ?? [],

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -812,7 +812,16 @@ export async function updateCourseSettings(
         ? {
             liveQuizzes: {
               updateMany: {
-                where: { isDeleted: false },
+                where: {
+                  isDeleted: false,
+                  status: {
+                    in: [
+                      DB.PublicationStatus.DRAFT,
+                      DB.PublicationStatus.SCHEDULED,
+                      DB.PublicationStatus.PUBLISHED,
+                    ],
+                  },
+                },
                 data: {
                   isGamificationEnabled: newGamificationSetting,
                   isAssessmentEnabled: newAssessmentSetting,
@@ -821,7 +830,16 @@ export async function updateCourseSettings(
             },
             practiceQuizzes: {
               updateMany: {
-                where: { isDeleted: false },
+                where: {
+                  isDeleted: false,
+                  status: {
+                    in: [
+                      DB.PublicationStatus.DRAFT,
+                      DB.PublicationStatus.SCHEDULED,
+                      DB.PublicationStatus.PUBLISHED,
+                    ],
+                  },
+                },
                 data: {
                   isGamificationEnabled: newGamificationSetting,
                   isAssessmentEnabled: newAssessmentSetting,
@@ -830,7 +848,16 @@ export async function updateCourseSettings(
             },
             microLearnings: {
               updateMany: {
-                where: { isDeleted: false },
+                where: {
+                  isDeleted: false,
+                  status: {
+                    in: [
+                      DB.PublicationStatus.DRAFT,
+                      DB.PublicationStatus.SCHEDULED,
+                      DB.PublicationStatus.PUBLISHED,
+                    ],
+                  },
+                },
                 data: {
                   isGamificationEnabled: newGamificationSetting,
                   isAssessmentEnabled: newAssessmentSetting,
@@ -839,7 +866,16 @@ export async function updateCourseSettings(
             },
             groupActivities: {
               updateMany: {
-                where: { isDeleted: false },
+                where: {
+                  isDeleted: false,
+                  status: {
+                    in: [
+                      DB.PublicationStatus.DRAFT,
+                      DB.PublicationStatus.SCHEDULED,
+                      DB.PublicationStatus.PUBLISHED,
+                    ],
+                  },
+                },
                 data: {
                   isGamificationEnabled: newGamificationSetting,
                   isAssessmentEnabled: newAssessmentSetting,

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -767,10 +767,19 @@ export async function updateCourseSettings(
     course._count.groupActivities > 0
   const containsGroups = course._count.participantGroups > 0
 
+  // check if the gamification and/or assessment settings were changed
+  const newGamificationSetting =
+    course.isGamificationEnabled !== isGamificationEnabled &&
+    (isGamificationEnabled || (!containsActivities && !containsGroups))
+      ? (isGamificationEnabled ?? false)
+      : undefined
+  const newAssessmentSetting =
+    course.isAssessmentEnabled !== isAssessmentEnabled
+      ? (isAssessmentEnabled ?? undefined)
+      : undefined
+
   const updatedCourse = await ctx.prisma.course.update({
-    where: {
-      id,
-    },
+    where: { id },
     data: {
       name: name ?? undefined,
       displayName: displayName ?? undefined,
@@ -787,10 +796,7 @@ export async function updateCourseSettings(
       groupDeadlineDate: groupDeadlineDate ?? undefined,
       notificationEmail: notificationEmail ?? undefined,
       // only enable gamification or disable it if there are no activities or groups
-      isGamificationEnabled:
-        isGamificationEnabled || (!containsActivities && !containsGroups)
-          ? (isGamificationEnabled ?? false)
-          : undefined,
+      isGamificationEnabled: newGamificationSetting,
       // set assessment mode - if enabling, remove PIN
       isAssessmentEnabled: isAssessmentEnabled ?? undefined,
       pinCode: isAssessmentEnabled ? null : undefined,
@@ -801,6 +807,47 @@ export async function updateCourseSettings(
         !isGroupCreationEnabled && !containsGroups
           ? { deleteMany: {} }
           : undefined,
+      // if the gamification or assessment setting was changed, update all activities assigned to the course
+      ...(newGamificationSetting || newAssessmentSetting
+        ? {
+            liveQuizzes: {
+              updateMany: {
+                where: { isDeleted: false },
+                data: {
+                  isGamificationEnabled: newGamificationSetting,
+                  isAssessmentEnabled: newAssessmentSetting,
+                },
+              },
+            },
+            practiceQuizzes: {
+              updateMany: {
+                where: { isDeleted: false },
+                data: {
+                  isGamificationEnabled: newGamificationSetting,
+                  isAssessmentEnabled: newAssessmentSetting,
+                },
+              },
+            },
+            microLearnings: {
+              updateMany: {
+                where: { isDeleted: false },
+                data: {
+                  isGamificationEnabled: newGamificationSetting,
+                  isAssessmentEnabled: newAssessmentSetting,
+                },
+              },
+            },
+            groupActivities: {
+              updateMany: {
+                where: { isDeleted: false },
+                data: {
+                  isGamificationEnabled: newGamificationSetting,
+                  isAssessmentEnabled: newAssessmentSetting,
+                },
+              },
+            },
+          }
+        : {}),
     },
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course-level toggles for Gamification and Assessments now propagate to related activities, but only when the course enablement state actually changes.

* **Bug Fixes**
  * Avoids unnecessary bulk updates by only applying propagation on real state transitions.
  * If a selected course is missing, gamification is immediately deactivated; valid courses now force gamification active to prevent stale state.

* **Style**
  * Simplified scoring header (icon removed) and minor UI formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->