### PR TITLE
fix: ensure that base points are always set to false for content elements and flashcards

### DIFF
--- a/apps/hatchet-worker-response-processor/src/processors/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/helpers.ts
@@ -335,7 +335,7 @@ export function getChoicesQuestionPoints({
     firstResponseReceivedAt,
     responseTimestamp,
     pointsPercentage,
-    basePoints: basePoints === 'false' ? false : true,
+    basePoints: basePoints === 'true' ? true : false,
     pointsMultiplier,
     roundedResult: true,
   })
@@ -418,7 +418,7 @@ export function getNumericalQuestionPoints({
     firstResponseReceivedAt,
     responseTimestamp,
     getsMaxPoints: parsedSolutions && pointsPercentage === 1,
-    basePoints: basePoints === 'false' ? false : true,
+    basePoints: basePoints === 'true' ? true : false,
     pointsMultiplier,
     roundedResult: true,
   })
@@ -484,7 +484,7 @@ export function getFreeTextQuestionPoints({
     firstResponseReceivedAt,
     responseTimestamp,
     getsMaxPoints: Boolean(pointsPercentage),
-    basePoints: basePoints === 'false' ? false : true,
+    basePoints: basePoints === 'true' ? true : false,
     pointsMultiplier,
     roundedResult: true,
   })
@@ -546,7 +546,7 @@ export function getSelectionQuestionPoints({
     firstResponseReceivedAt,
     responseTimestamp,
     pointsPercentage,
-    basePoints: basePoints === 'false' ? false : true,
+    basePoints: basePoints === 'true' ? true : false,
     pointsMultiplier,
     roundedResult: true,
   })
@@ -608,7 +608,7 @@ export function getCaseStudyQuestionPoints({
     firstResponseReceivedAt,
     responseTimestamp,
     pointsPercentage,
-    basePoints: basePoints === 'false' ? false : true,
+    basePoints: basePoints === 'true' ? true : false,
     pointsMultiplier,
     roundedResult: true,
   })

--- a/packages/graphql/src/scripts/2025-09-21_remove_base_points_content.ts
+++ b/packages/graphql/src/scripts/2025-09-21_remove_base_points_content.ts
@@ -101,9 +101,11 @@ async function run() {
           })
 
           // send audit log message to hatchet
+          const logMessage = `[CORRECTION] [Base Points Content Elements] Removed base points from live quiz response ${response.id} by participant ${response.participantId} for content element instance ${response.instanceId} (was ${response.basePoints})`
           hatchetClient.events.push('create-audit-log-entry', {
-            info: `[CORRECTION] [Base Points Content Elements] Removed base points from live quiz response ${response.id} by participant ${response.participantId} for content element instance ${response.instanceId} (was ${response.basePoints})`,
+            info: logMessage,
           })
+          console.log(logMessage)
         })
       )
 

--- a/packages/graphql/src/scripts/2025-09-21_remove_base_points_content.ts
+++ b/packages/graphql/src/scripts/2025-09-21_remove_base_points_content.ts
@@ -86,31 +86,25 @@ async function run() {
   })
   console.log('Found live quiz responses to update:', responses.length)
 
-  // update the corresponding live quiz responses in batches of 100
+  // update the corresponding live quiz responses individually with a transaction
   if (!DRY_RUN) {
-    const batchSize = 100
-    for (let i = 0; i < responses.length; i += batchSize) {
-      const batch = responses.slice(i, i + batchSize)
-
-      await Promise.all(
-        batch.map(async (response) => {
-          // update the response
-          await prisma.liveQuizResponse.update({
-            where: { id: response.id },
-            data: { basePoints: 0 },
-          })
-
-          // send audit log message to hatchet
-          const logMessage = `[CORRECTION] [Base Points Content Elements] Removed base points from live quiz response ${response.id} by participant ${response.participantId} for content element instance ${response.instanceId} (was ${response.basePoints})`
-          hatchetClient.events.push('create-audit-log-entry', {
-            info: logMessage,
-          })
-          console.log(logMessage)
+    for (const response of responses) {
+      await prisma.$transaction(async (tx) => {
+        // update the response
+        await tx.liveQuizResponse.update({
+          where: { id: response.id },
+          data: { basePoints: 0 },
         })
-      )
 
-      console.log(`Updated batch ${i / batchSize + 1} of live quiz responses`)
+        // send audit log message to hatchet
+        const logMessage = `[CORRECTION] [Base Points Content Elements] Removed base points from live quiz response ${response.id} by participant ${response.participantId} for content element instance ${response.instanceId} (was ${response.basePoints})`
+        await hatchetClient.events.push('create-audit-log-entry', {
+          info: logMessage,
+        })
+        console.log(logMessage)
+      })
     }
+    console.log(`Updated ${responses.length} live quiz responses`)
   }
 
   // return / exit the process

--- a/packages/graphql/src/scripts/2025-09-21_remove_base_points_content.ts
+++ b/packages/graphql/src/scripts/2025-09-21_remove_base_points_content.ts
@@ -1,0 +1,118 @@
+import { hatchetClient } from '@klicker-uzh/hatchet'
+import { PrismaClient } from '@klicker-uzh/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+// ! IMPORTANT INFORMATION
+// This script sets the basePoints setting of all content elements and flashcards to false and updates corresponding instances
+// At the same time, live quiz responses where non-zero amounts of base points were awarded for content elements are updated (alongside the audit log)
+
+const DRY_RUN = true
+
+async function run() {
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+  const prisma = new PrismaClient({ adapter })
+
+  // fetch all elements that are of type content or flashcard and have their base points set to true
+  const elements = await prisma.element.findMany({
+    where: {
+      type: { in: ['CONTENT', 'FLASHCARD'] },
+      basePoints: true,
+    },
+  })
+  console.log('Found elements to update:', elements.length)
+
+  // update the corresponding elements in batches of 100
+  if (!DRY_RUN) {
+    const batchSize = 100
+    for (let i = 0; i < elements.length; i += batchSize) {
+      const batch = elements.slice(i, i + batchSize)
+
+      await Promise.all(
+        batch.map((element) =>
+          prisma.element.update({
+            where: {
+              id: element.id,
+              type: { in: ['CONTENT', 'FLASHCARD'] },
+              basePoints: true,
+            },
+            data: { basePoints: false },
+          })
+        )
+      )
+
+      console.log(`Updated batch ${i / batchSize + 1} of elements`)
+    }
+  }
+
+  // identify all element instances that belong to a content or flashcard element
+  const instances = await prisma.elementInstance.findMany({
+    where: {
+      elementType: { in: ['CONTENT', 'FLASHCARD'] },
+      options: { path: ['basePoints'], equals: true },
+    },
+  })
+  console.log('Found element instances to update:', instances.length)
+
+  // update the corresponding element instances in batches of 100
+  if (!DRY_RUN) {
+    const batchSize = 100
+    for (let i = 0; i < instances.length; i += batchSize) {
+      const batch = instances.slice(i, i + batchSize)
+
+      await Promise.all(
+        batch.map((instance) =>
+          prisma.elementInstance.update({
+            where: { id: instance.id },
+            data: {
+              options: {
+                ...instance.options,
+                basePoints: false,
+              },
+            },
+          })
+        )
+      )
+
+      console.log(`Updated batch ${i / batchSize + 1} of element instances`)
+    }
+  }
+
+  // identify all live quiz responses that are linked to content elements and have non-zero base points
+  const responses = await prisma.liveQuizResponse.findMany({
+    where: {
+      instance: { elementType: 'CONTENT' },
+      basePoints: { gt: 0 },
+    },
+  })
+  console.log('Found live quiz responses to update:', responses.length)
+
+  // update the corresponding live quiz responses in batches of 100
+  if (!DRY_RUN) {
+    const batchSize = 100
+    for (let i = 0; i < responses.length; i += batchSize) {
+      const batch = responses.slice(i, i + batchSize)
+
+      await Promise.all(
+        batch.map(async (response) => {
+          // update the response
+          await prisma.liveQuizResponse.update({
+            where: { id: response.id },
+            data: { basePoints: 0 },
+          })
+
+          // send audit log message to hatchet
+          hatchetClient.events.push('create-audit-log-entry', {
+            info: `[CORRECTION] [Base Points Content Elements] Removed base points from live quiz response ${response.id} by participant ${response.participantId} for content element instance ${response.instanceId} (was ${response.basePoints})`,
+          })
+        })
+      )
+
+      console.log(`Updated batch ${i / batchSize + 1} of live quiz responses`)
+    }
+  }
+
+  // return / exit the process
+  return process.exit(0)
+}
+
+await run()

--- a/packages/graphql/src/services/elements.ts
+++ b/packages/graphql/src/services/elements.ts
@@ -536,7 +536,10 @@ export async function manipulateElement(
       name: name!,
       content: content!,
       explanation: explanation ?? undefined,
-      basePoints: basePoints!,
+      basePoints:
+        type === DB.ElementType.CONTENT || type === DB.ElementType.FLASHCARD
+          ? false
+          : basePoints!,
       pointsMultiplier: pointsMultiplier!,
       options: processedOptions,
       owner: { connect: { id: ctx.user.sub } },
@@ -567,7 +570,10 @@ export async function manipulateElement(
       name: name ?? undefined,
       content: content ?? undefined,
       explanation: typeof explanation === 'undefined' ? undefined : explanation,
-      basePoints: basePoints!,
+      basePoints:
+        type === DB.ElementType.CONTENT || type === DB.ElementType.FLASHCARD
+          ? false
+          : basePoints!,
       pointsMultiplier: pointsMultiplier ?? 1,
       version: { increment: 1 },
       options: options ? processedOptions : undefined,
@@ -815,7 +821,10 @@ export async function applyElementBatchOperations(
                 : undefined,
             basePoints:
               typeof basePoints !== 'undefined' && basePoints !== null
-                ? basePoints
+                ? element.type !== DB.ElementType.CONTENT &&
+                  element.type !== DB.ElementType.FLASHCARD
+                  ? basePoints
+                  : false
                 : undefined,
           },
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected scoring so base points are applied only when explicitly enabled, fixing point calculations across question types.

- Changes
  - Content and Flashcard items now have base points disabled by default on create, update, and batch operations.

- Chores
  - Added a maintenance tool to find and disable base points on existing Content/Flashcard items and related responses; supports dry-run mode and audit logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->