### PR TITLE
enhance(apps/frontend-manage): add quick access options to point corrections from assessment results view

### DIFF
--- a/apps/frontend-manage/src/components/courses/PointCorrectionsModal.tsx
+++ b/apps/frontend-manage/src/components/courses/PointCorrectionsModal.tsx
@@ -21,25 +21,6 @@ import {
   PointCorrectionsFormValues,
 } from './pointCorrections/types'
 
-const initialValues: PointCorrectionsFormValues = {
-  scopeType: '',
-  quizId: '',
-  instanceId: '',
-  participantScope: '',
-  participantId: '',
-  lecturerReason: '',
-  studentReason: '',
-  useSameReasonForStudents: false,
-  adjustments: {
-    baseAward: false,
-    baseDeduct: false,
-    correctnessAward: false,
-    correctnessDeduct: false,
-    bonusAward: false,
-    bonusDeduct: false,
-  },
-}
-
 const stepFieldPaths: (
   | keyof PointCorrectionsFormValues
   | `adjustments.${keyof PointCorrectionsFormValues['adjustments']}`
@@ -70,9 +51,15 @@ const stepFieldPaths: (
 function PointCorrectionsModal({
   courseId,
   onClose,
+  preselectedLiveQuizId,
+  preselectedInstanceId,
+  preselectedParticipantId,
 }: {
   courseId: string
   onClose: () => void
+  preselectedLiveQuizId?: string
+  preselectedInstanceId?: string
+  preselectedParticipantId?: string
 }) {
   const t = useTranslations()
   const [activeStep, setActiveStep] = useState(0)
@@ -178,6 +165,27 @@ function PointCorrectionsModal({
         .concat(reasonSchema),
     ]
   }, [t])
+
+  const initialValues: PointCorrectionsFormValues = {
+    scopeType: preselectedInstanceId ? 'instance' : '',
+    quizId: preselectedLiveQuizId ?? '',
+    instanceId: preselectedInstanceId ?? '',
+    participantScope: preselectedParticipantId
+      ? PointCorrectionType.Single
+      : '',
+    participantId: preselectedParticipantId ?? '',
+    lecturerReason: '',
+    studentReason: '',
+    useSameReasonForStudents: false,
+    adjustments: {
+      baseAward: false,
+      baseDeduct: false,
+      correctnessAward: false,
+      correctnessDeduct: false,
+      bonusAward: false,
+      bonusDeduct: false,
+    },
+  }
 
   const stepTitles = [
     t('manage.pointCorrections.scopeTitle'),
@@ -318,12 +326,15 @@ function PointCorrectionsModal({
           <PointCorrectionsScopeStep
             key="scope"
             quizzes={endedQuizzesData?.endedLiveQuizzesCourse ?? []}
+            disabledLiveQuizSelection={Boolean(preselectedLiveQuizId)}
+            disabledInstanceSelection={Boolean(preselectedInstanceId)}
           />,
           <PointCorrectionsAudienceStep
             key="audience"
             participants={
               courseParticipantsData?.assessmentCourseParticipants ?? []
             }
+            fixedParticipant={Boolean(preselectedParticipantId)}
           />,
           <PointCorrectionsAdjustmentsStep key="adjustments" />,
           <PointCorrectionsReasonStep key="reason" />,

--- a/apps/frontend-manage/src/components/courses/pointCorrections/PointCorrectionsAudienceStep.tsx
+++ b/apps/frontend-manage/src/components/courses/pointCorrections/PointCorrectionsAudienceStep.tsx
@@ -7,8 +7,10 @@ import type { PointCorrectionsFormValues } from './types'
 
 function PointCorrectionsAudienceStep({
   participants,
+  fixedParticipant = false,
 }: {
   participants: { id: string; email: string }[]
+  fixedParticipant?: boolean
 }) {
   const t = useTranslations()
   const [participantScopeField] =
@@ -40,6 +42,7 @@ function PointCorrectionsAudienceStep({
           <FormikSelectField
             required
             name="participantScope"
+            disabled={fixedParticipant}
             label={t('manage.pointCorrections.audienceLabel')}
             placeholder={t('manage.pointCorrections.audiencePlaceholder')}
             items={[
@@ -66,6 +69,7 @@ function PointCorrectionsAudienceStep({
             <FormikSelectField
               required
               name="participantId"
+              disabled={fixedParticipant}
               label={t('manage.pointCorrections.participantLabel')}
               placeholder={t('manage.pointCorrections.participantPlaceholder')}
               items={participantOptions}

--- a/apps/frontend-manage/src/components/courses/pointCorrections/PointCorrectionsScopeStep.tsx
+++ b/apps/frontend-manage/src/components/courses/pointCorrections/PointCorrectionsScopeStep.tsx
@@ -14,6 +14,8 @@ import type { CorrectionScope, PointCorrectionsFormValues } from './types'
 
 function PointCorrectionsScopeStep({
   quizzes,
+  disabledLiveQuizSelection,
+  disabledInstanceSelection,
 }: {
   quizzes: {
     id: string
@@ -21,6 +23,8 @@ function PointCorrectionsScopeStep({
     displayName: string
     instances: { id: string; name: string }[]
   }[]
+  disabledLiveQuizSelection: boolean
+  disabledInstanceSelection: boolean
 }) {
   const t = useTranslations()
   const [scopeField, , scopeHelpers] =
@@ -93,6 +97,7 @@ function PointCorrectionsScopeStep({
               description: t(
                 'manage.pointCorrections.scopeOptionInstanceDescription'
               ),
+              className: 'disabled:opacity-100',
               data: { cy: 'point-corrections-scope-instance' },
             },
             {
@@ -108,6 +113,7 @@ function PointCorrectionsScopeStep({
             <Button
               key={option.value}
               type="button"
+              disabled={disabledInstanceSelection}
               onClick={() =>
                 scopeHelpers.setValue(option.value as CorrectionScope)
               }
@@ -115,7 +121,8 @@ function PointCorrectionsScopeStep({
                 root: twMerge(
                   'flex h-full flex-col gap-2 rounded-lg border-2 p-4 text-left focus:outline-none',
                   scopeField.value === option.value &&
-                    'border-primary-100 bg-primary-50'
+                    'border-primary-100 bg-primary-50',
+                  option.className
                 ),
               }}
               aria-pressed={scopeField.value === option.value}
@@ -144,6 +151,7 @@ function PointCorrectionsScopeStep({
           <FormikSelectField
             required
             name="quizId"
+            disabled={disabledLiveQuizSelection}
             label={t('manage.pointCorrections.quizLabel')}
             placeholder={t('manage.pointCorrections.quizPlaceholder')}
             items={quizOptions}
@@ -156,6 +164,9 @@ function PointCorrectionsScopeStep({
           <div className="flex-1">
             <FormikSelectField
               required
+              disabled={
+                disabledInstanceSelection || instanceOptions.length === 0
+              }
               label={t('manage.pointCorrections.instanceLabel')}
               name="instanceId"
               placeholder={t('manage.pointCorrections.instancePlaceholder')}

--- a/apps/frontend-manage/src/components/liveQuiz/results/LiveQuizSingleStudentResults.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/results/LiveQuizSingleStudentResults.tsx
@@ -5,6 +5,7 @@ import {
   faCircleMinus,
   faCircleXmark,
   faFileCircleCheck,
+  faPenToSquare,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
@@ -24,8 +25,10 @@ import {
   UserNotification,
 } from '@uzh-bf/design-system'
 import { useFormatter, useTranslations } from 'next-intl'
+import { useRouter } from 'next/router'
 import { Fragment, useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import PointCorrectionsModal from '../../courses/PointCorrectionsModal'
 import StudentAssessmentResponseModal, {
   AssessmentResultInstance,
 } from './StudentAssessmentResponseModal'
@@ -69,8 +72,13 @@ function LiveQuizSingleStudentResults({
   quizBonusPoints: number
 }) {
   const t = useTranslations()
+  const router = useRouter()
   const formatter = useFormatter()
   const toStudentElementResponse = useStudentInstanceResponseMapper()
+
+  const [instancePointCorrection, setInstancePointCorrection] = useState<
+    { instanceId: string; participantId: string } | undefined
+  >(undefined)
 
   const { data, error } = useSuspenseQuery(
     GetLiveQuizStudentAssessmentResponsesDocument,
@@ -211,7 +219,7 @@ function LiveQuizSingleStudentResults({
             <ShadcnTableHead className="w-10 whitespace-normal px-2 text-center text-[0.7rem] leading-tight">
               {t('shared.generic.total')}
             </ShadcnTableHead>
-            <ShadcnTableHead className="w-10 whitespace-normal px-1 text-center text-[0.7rem] leading-tight">
+            <ShadcnTableHead className="whitespace-normal px-0 text-center text-[0.7rem] leading-tight">
               <span className="sr-only">
                 {t('manage.assessment.liveQuizResponse')}
               </span>
@@ -250,7 +258,7 @@ function LiveQuizSingleStudentResults({
                       totals.totalAvailablePoints
                     )}
                   </ShadcnTableCell>
-                  <ShadcnTableCell />
+                  <ShadcnTableCell className="w-0 max-w-0 px-0" />
                 </ShadcnTableRow>
 
                 {instances.map((instance, instanceIx) => {
@@ -327,41 +335,71 @@ function LiveQuizSingleStudentResults({
                           instance.totalAvailablePoints
                         )}
                       </ShadcnTableCell>
-                      <ShadcnTableCell className="px-1 py-3 text-center">
-                        <Tooltip
-                          tooltip={
-                            !!instance.submission
-                              ? t('manage.assessment.liveQuizOpenResponse')
-                              : t(
-                                  'manage.assessment.liveQuizNoResponseSubmitted'
-                                )
-                          }
-                        >
-                          <Button
-                            className={{ root: 'h-7 w-7 justify-center p-0' }}
-                            disabled={!instance.submission}
-                            onClick={() => {
-                              if (!instance.submission) return
-
-                              const response = toStudentElementResponse({
-                                instance,
-                                submission: instance.submission,
-                              })
-
-                              if (!response) return
-                              setSelectedInstance({ instance, response })
-                            }}
-                            data={{
-                              cy: `live-quiz-student-instance-${blockIx}-${instanceIx}-modal`,
-                            }}
-                            variant="ghost"
+                      <ShadcnTableCell className="px-0 py-3">
+                        <div className="-mx-2 flex justify-center gap-0 md:-mx-3">
+                          <Tooltip
+                            tooltip={
+                              !!instance.submission
+                                ? t('manage.assessment.liveQuizOpenResponse')
+                                : t(
+                                    'manage.assessment.liveQuizNoResponseSubmitted'
+                                  )
+                            }
                           >
-                            <Button.Icon
-                              icon={faFileCircleCheck}
-                              className={{ root: 'h-3.5 w-3.5' }}
-                            />
-                          </Button>
-                        </Tooltip>
+                            <Button
+                              className={{
+                                root: 'h-7 w-7 items-center justify-center',
+                              }}
+                              disabled={!instance.submission}
+                              onClick={() => {
+                                if (!instance.submission) return
+
+                                const response = toStudentElementResponse({
+                                  instance,
+                                  submission: instance.submission,
+                                })
+
+                                if (!response) return
+                                setSelectedInstance({ instance, response })
+                              }}
+                              data={{
+                                cy: `live-quiz-student-instance-${blockIx}-${instanceIx}-modal`,
+                              }}
+                              variant="ghost"
+                            >
+                              <Button.Icon
+                                withoutLabel
+                                icon={faFileCircleCheck}
+                                className={{ root: 'h-3.5 w-3.5' }}
+                              />
+                            </Button>
+                          </Tooltip>
+                          <Tooltip
+                            tooltip={t(
+                              'manage.assessment.liveQuizOpenCorrection'
+                            )}
+                          >
+                            <Button
+                              className={{ root: 'h-7 w-7 justify-center p-0' }}
+                              onClick={() => {
+                                setInstancePointCorrection({
+                                  instanceId: String(instance.id),
+                                  participantId,
+                                })
+                              }}
+                              data={{
+                                cy: `live-quiz-student-instance-${blockIx}-${instanceIx}-correction`,
+                              }}
+                              variant="ghost"
+                            >
+                              <Button.Icon
+                                withoutLabel
+                                icon={faPenToSquare}
+                                className={{ root: 'h-3.5 w-3.5' }}
+                              />
+                            </Button>
+                          </Tooltip>
+                        </div>
                       </ShadcnTableCell>
                     </ShadcnTableRow>
                   )
@@ -380,6 +418,16 @@ function LiveQuizSingleStudentResults({
           onClose={() => setSelectedInstance(null)}
         />
       )}
+
+      {typeof instancePointCorrection !== 'undefined' && router.query.id ? (
+        <PointCorrectionsModal
+          courseId={router.query.id as string}
+          onClose={() => setInstancePointCorrection(undefined)}
+          preselectedLiveQuizId={router.query.quizId as string}
+          preselectedInstanceId={instancePointCorrection?.instanceId}
+          preselectedParticipantId={instancePointCorrection?.participantId}
+        />
+      ) : null}
     </>
   )
 }

--- a/apps/frontend-manage/src/components/liveQuiz/results/LiveQuizSingleStudentResults.tsx
+++ b/apps/frontend-manage/src/components/liveQuiz/results/LiveQuizSingleStudentResults.tsx
@@ -336,7 +336,7 @@ function LiveQuizSingleStudentResults({
                         )}
                       </ShadcnTableCell>
                       <ShadcnTableCell className="px-0 py-3">
-                        <div className="-mx-2 flex justify-center gap-0 md:-mx-3">
+                        <div className="flex justify-center gap-0">
                           <Tooltip
                             tooltip={
                               !!instance.submission

--- a/apps/frontend-manage/src/pages/courses/[id]/assessment/liveQuiz/[quizId].tsx
+++ b/apps/frontend-manage/src/pages/courses/[id]/assessment/liveQuiz/[quizId].tsx
@@ -1,11 +1,13 @@
 import { useQuery } from '@apollo/client'
+import { faPenToSquare } from '@fortawesome/free-regular-svg-icons'
 import { GetAssessmentResultsLiveQuizDocument } from '@klicker-uzh/graphql/dist/ops'
 import Loader from '@klicker-uzh/shared-components/src/Loader'
-import { H2, UserNotification } from '@uzh-bf/design-system'
+import { Button, H2, UserNotification } from '@uzh-bf/design-system'
 import { GetStaticPropsContext } from 'next'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
 import { Suspense, useState } from 'react'
+import PointCorrectionsModal from '~/components/courses/PointCorrectionsModal'
 import Layout from '../../../../../components/Layout'
 import LiveQuizSingleStudentResults from '../../../../../components/liveQuiz/results/LiveQuizSingleStudentResults'
 import LiveQuizStudentResultsTable from '../../../../../components/liveQuiz/results/LiveQuizStudentResultsTable'
@@ -13,6 +15,8 @@ import LiveQuizStudentResultsTable from '../../../../../components/liveQuiz/resu
 function AssessmentLiveQuiz() {
   const t = useTranslations()
   const router = useRouter()
+
+  const [correctionsModal, setCorrectionsModal] = useState(false)
   const [selectedParticipant, setSelectedParticipant] = useState<{
     id: string
     email: string
@@ -48,7 +52,17 @@ function AssessmentLiveQuiz() {
 
   return (
     <Layout>
-      <H2>{`${t('manage.assessment.assessmentResults')} - ${t('shared.generic.liveQuiz')}: ${quiz.name}`}</H2>
+      <div className="mb-2 flex flex-row justify-between">
+        <H2>{`${t('manage.assessment.assessmentResults')} - ${t('shared.generic.liveQuiz')}: ${quiz.name}`}</H2>
+        <Button
+          onClick={() => setCorrectionsModal(true)}
+          className={{ root: 'h-8' }}
+          data={{ cy: 'assessment-course-point-corrections' }}
+        >
+          <Button.Icon icon={faPenToSquare} />
+          <Button.Label>{t('manage.course.pointCorrections')}</Button.Label>
+        </Button>
+      </div>
       <div className="flex w-full flex-row gap-2">
         <div className="w-1/2">
           <LiveQuizStudentResultsTable
@@ -81,6 +95,14 @@ function AssessmentLiveQuiz() {
           )}
         </div>
       </div>
+
+      {correctionsModal && router.query.id ? (
+        <PointCorrectionsModal
+          courseId={router.query.id as string}
+          onClose={() => setCorrectionsModal(false)}
+          preselectedLiveQuizId={router.query.quizId as string}
+        />
+      ) : null}
     </Layout>
   )
 }

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -3663,12 +3663,23 @@ export async function getEndedLiveQuizzesCourse(
 }
 
 export async function getAssessmentCourseParticipants(
-  { courseId }: { courseId: string },
+  {
+    courseId,
+    preferredAffiliation = 'uzh',
+  }: { courseId: string; preferredAffiliation?: string },
   ctx: ContextWithUser
 ) {
   const course = await ctx.prisma.course.findUnique({
     where: { id: courseId, isAssessmentEnabled: true },
-    include: { participations: { include: { participant: true } } },
+    include: {
+      participations: {
+        include: {
+          participant: {
+            include: { accounts: { where: { ssoType: preferredAffiliation } } },
+          },
+        },
+      },
+    },
   })
 
   if (!course) return []
@@ -3676,7 +3687,10 @@ export async function getAssessmentCourseParticipants(
   return sortBy(
     course.participations.map((p) => ({
       id: p.participant.id,
-      email: p.participant.email ?? 'E-Mail Missing',
+      email:
+        p.participant.accounts[0]?.ssoEmail ??
+        p.participant.email ??
+        'E-Mail Missing',
       username: p.participant.username,
     })),
     [prop('email'), 'asc']

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -1308,6 +1308,7 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
         'Dieser Studierende hat noch keine Antworten eingereicht.',
       liveQuizResponse: 'Antwort',
       liveQuizOpenResponse: 'Antwort ansehen',
+      liveQuizOpenCorrection: 'Punktkorrektur öffnen',
       liveQuizNoResponseSubmitted: 'Keine Antwort abgegeben',
       liveQuizQuestionAnswered: 'Beantwortet',
       liveQuizQuestionNotAnswered: 'Nicht beantwortet',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -1304,6 +1304,7 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
         'This student has not submitted any responses yet.',
       liveQuizResponse: 'Response',
       liveQuizOpenResponse: 'View response',
+      liveQuizOpenCorrection: 'Open point correction modal',
       liveQuizNoResponseSubmitted: 'No response submitted',
       liveQuizQuestionAnswered: 'Answered',
       liveQuizQuestionNotAnswered: 'Not answered',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Open point correction from live quiz header and per-student results, with prefilled quiz, instance, and participant.
  - Selection fields can be locked when preselected to prevent changes.
  - Participant list uses preferred affiliation email when available for clearer identification.

- UI
  - Added correction buttons with icons alongside existing actions.
  - Adjusted table spacing and layout in results for the new controls.

- Localization
  - Added English and German labels for opening the point correction modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->