### PR TITLE
fix(packages/graphql): avoid hatchet rate limits by using batch task calls for point correction audit logs

### DIFF
--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -98,6 +98,16 @@ jobs:
         ports:
           - 6380:6379
 
+      redis_cache:
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        image: redis:7
+        ports:
+          - 6381:6379
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -131,7 +141,50 @@ jobs:
 
       - name: Run tests
         run: |
+          set -euo pipefail
+
           . ./util/_create_hatchet_token_graphql.sh
+          export HATCHET_CLIENT_TOKEN="$TOKEN"
+
+          pnpm --filter @klicker-uzh/hatchet-worker-general run build
+
+          cleanup() {
+            if [[ -n "${HATCHET_WORKER_PID:-}" ]]; then
+              kill "$HATCHET_WORKER_PID" >/dev/null 2>&1 || true
+              wait "$HATCHET_WORKER_PID" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup EXIT
+
+          HATCHET_CLIENT_HOST_PORT=localhost:7077 \
+          HATCHET_CLIENT_TLS_STRATEGY=none \
+          HATCHET_API_URL=http://localhost:8888 \
+          HATCHET_HOST_PORT=localhost:7077 \
+          HATCHET_LOG_LEVEL=DEBUG \
+          HATCHET_TENANT_ID=707d0855-80ab-4e1f-a156-f1c4546cbf52 \
+          HATCHET_WORKER_NAME=hatchet-worker-general \
+          LOG_LEVEL=info \
+          NODE_ENV=test \
+          DATABASE_URL=postgresql://klicker:klicker@localhost:5432/klicker-prod \
+          REDIS_HOST=localhost \
+          REDIS_PORT=6379 \
+          REDIS_ASSESSMENT_HOST=localhost \
+          REDIS_ASSESSMENT_PORT=6380 \
+          REDIS_CACHE_HOST=localhost \
+          REDIS_CACHE_PORT=6381 \
+          APP_ORIGIN_API=http://api.klicker.com \
+          APP_ORIGIN_AUTH=http://auth.klicker.com \
+          APP_ORIGIN_LTI=http://lti.klicker.com \
+          APP_ORIGIN_PWA=http://pwa.klicker.com \
+          APP_ORIGIN_MANAGE=http://manage.klicker.com \
+          APP_ORIGIN_CONTROL=http://control.klicker.com \
+          APP_ORIGIN_ASSESSMENT_API=http://assessment-api.klicker.com \
+          APP_ORIGIN_ASSESSMENT_PWA=http://assessment.klicker.com \
+          pnpm exec env HATCHET_CLIENT_TOKEN="$HATCHET_CLIENT_TOKEN" node apps/hatchet-worker-general/dist/index.js > hatchet-worker.log 2>&1 &
+
+          HATCHET_WORKER_PID=$!
+          sleep 5
+
           cd packages/graphql
           pnpm vitest run
         env:

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -98,16 +98,6 @@ jobs:
         ports:
           - 6380:6379
 
-      redis_cache:
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        image: redis:7
-        ports:
-          - 6381:6379
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -141,50 +131,7 @@ jobs:
 
       - name: Run tests
         run: |
-          set -euo pipefail
-
           . ./util/_create_hatchet_token_graphql.sh
-          export HATCHET_CLIENT_TOKEN="$TOKEN"
-
-          pnpm --filter @klicker-uzh/hatchet-worker-general run build
-
-          cleanup() {
-            if [[ -n "${HATCHET_WORKER_PID:-}" ]]; then
-              kill "$HATCHET_WORKER_PID" >/dev/null 2>&1 || true
-              wait "$HATCHET_WORKER_PID" >/dev/null 2>&1 || true
-            fi
-          }
-          trap cleanup EXIT
-
-          HATCHET_CLIENT_HOST_PORT=localhost:7077 \
-          HATCHET_CLIENT_TLS_STRATEGY=none \
-          HATCHET_API_URL=http://localhost:8888 \
-          HATCHET_HOST_PORT=localhost:7077 \
-          HATCHET_LOG_LEVEL=DEBUG \
-          HATCHET_TENANT_ID=707d0855-80ab-4e1f-a156-f1c4546cbf52 \
-          HATCHET_WORKER_NAME=hatchet-worker-general \
-          LOG_LEVEL=info \
-          NODE_ENV=test \
-          DATABASE_URL=postgresql://klicker:klicker@localhost:5432/klicker-prod \
-          REDIS_HOST=localhost \
-          REDIS_PORT=6379 \
-          REDIS_ASSESSMENT_HOST=localhost \
-          REDIS_ASSESSMENT_PORT=6380 \
-          REDIS_CACHE_HOST=localhost \
-          REDIS_CACHE_PORT=6381 \
-          APP_ORIGIN_API=http://api.klicker.com \
-          APP_ORIGIN_AUTH=http://auth.klicker.com \
-          APP_ORIGIN_LTI=http://lti.klicker.com \
-          APP_ORIGIN_PWA=http://pwa.klicker.com \
-          APP_ORIGIN_MANAGE=http://manage.klicker.com \
-          APP_ORIGIN_CONTROL=http://control.klicker.com \
-          APP_ORIGIN_ASSESSMENT_API=http://assessment-api.klicker.com \
-          APP_ORIGIN_ASSESSMENT_PWA=http://assessment.klicker.com \
-          pnpm exec env HATCHET_CLIENT_TOKEN="$HATCHET_CLIENT_TOKEN" node apps/hatchet-worker-general/dist/index.js > hatchet-worker.log 2>&1 &
-
-          HATCHET_WORKER_PID=$!
-          sleep 5
-
           cd packages/graphql
           pnpm vitest run
         env:

--- a/packages/graphql/src/services/courses.ts
+++ b/packages/graphql/src/services/courses.ts
@@ -1006,10 +1006,11 @@ async function upsertResponseAppliedCorrection(
     },
   })
 
-  // add audit logging entry for change
-  await ctx.hatchet.events.push('create-audit-log-entry', {
-    info: `[INFO] [Correct Assessment Points Instance] User ${ctx.user.sub} corrected points for participant ${lqr.participantId} on instance ${instance.id}. Deducted points: base ${appliedCorrection.deductedBasePoints}, correctness ${appliedCorrection.deductedCorrectnessPoints}, bonus ${appliedCorrection.deductedBonusPoints}. Awarded points: base ${appliedCorrection.awardedBasePoints}, correctness ${appliedCorrection.awardedCorrectnessPoints}, bonus ${appliedCorrection.awardedBonusPoints}.`,
-  })
+  return {
+    message: {
+      info: `[INFO] [Correct Assessment Points Instance] User ${ctx.user.sub} corrected points for participant ${lqr.participantId} on instance ${instance.id}. Deducted points: base ${appliedCorrection.deductedBasePoints}, correctness ${appliedCorrection.deductedCorrectnessPoints}, bonus ${appliedCorrection.deductedBonusPoints}. Awarded points: base ${appliedCorrection.awardedBasePoints}, correctness ${appliedCorrection.awardedCorrectnessPoints}, bonus ${appliedCorrection.awardedBonusPoints}.`,
+    },
+  }
 }
 
 export async function correctAssessmentPointsInstance(
@@ -1166,7 +1167,7 @@ export async function correctAssessmentPointsInstance(
           include: { correctedBy: true, participant: true, instance: true },
         })
 
-        await upsertResponseAppliedCorrection(
+        const logObject = await upsertResponseAppliedCorrection(
           {
             correctionId: correction.id,
             instance: instance as DB.ElementInstance & {
@@ -1188,10 +1189,13 @@ export async function correctAssessmentPointsInstance(
           ctx
         )
 
+        // add an audit log entry for the correction
+        await ctx.tasks.createAuditLogEntry.runNoWait([logObject])
+
         // return the correction to display it to the lecturer
         return correction
       },
-      { timeout: 60000 }
+      { timeout: 300000 } // 5 min timeout to ensure success for the moment -> until asynchronous execution is available
     )
 
     return createdCorrection
@@ -1237,10 +1241,13 @@ export async function correctAssessmentPointsInstance(
           include: { correctedBy: true, instance: true },
         })
 
+        // initialize the audit log entries that should be executed
+        const logEntries: { message: { info: string } }[] = []
+
         // loop over all responses and update them with the corrected points
         await Promise.all(
           responses.map(async (response) => {
-            await upsertResponseAppliedCorrection(
+            const logObject = await upsertResponseAppliedCorrection(
               {
                 correctionId: correction.id,
                 instance: instance as DB.ElementInstance & {
@@ -1261,13 +1268,19 @@ export async function correctAssessmentPointsInstance(
               tx,
               ctx
             )
+
+            // add the log object to the list of log entries
+            logEntries.push(logObject)
           })
         )
+
+        // create the collected audit log entries
+        await ctx.tasks.createAuditLogEntry.runNoWait(logEntries)
 
         // return the correction to display it to the lecturer
         return correction
       },
-      { timeout: 60000 }
+      { timeout: 300000 } // 5 min timeout to ensure success for the moment -> until asynchronous execution is available
     )
 
     return createdCorrection
@@ -1321,10 +1334,13 @@ export async function correctAssessmentPointsInstance(
           include: { correctedBy: true, instance: true },
         })
 
+        // initialize the audit log entries that should be executed
+        const logEntries: { message: { info: string } }[] = []
+
         // loop over all responses and update them with the corrected points
         await Promise.all(
           participations.map(async (participation) => {
-            await upsertResponseAppliedCorrection(
+            const logEntry = await upsertResponseAppliedCorrection(
               {
                 correctionId: correction.id,
                 instance: instance as DB.ElementInstance & {
@@ -1345,13 +1361,19 @@ export async function correctAssessmentPointsInstance(
               tx,
               ctx
             )
+
+            // push the log object to the list of log entries
+            logEntries.push(logEntry)
           })
         )
+
+        // create the collected audit log entries
+        await ctx.tasks.createAuditLogEntry.runNoWait(logEntries)
 
         // return the correction to display it to the lecturer
         return correction
       },
-      { timeout: 60000 }
+      { timeout: 300000 } // 5 min timeout to ensure success for the moment -> until asynchronous execution is available
     )
 
     return createdCorrection
@@ -1515,6 +1537,10 @@ export async function correctAssessmentPointsLiveQuiz(
           include: { correctedBy: true, participant: true, liveQuiz: true },
         })
 
+        // initialize the audit log entries that should be executed
+        const logEntries: { message: { info: string } }[] = []
+
+        // loop over all instances and update the corresponding responses with the corrected points
         await Promise.all(
           liveQuiz.blocks.map(async (block) => {
             await Promise.all(
@@ -1536,7 +1562,7 @@ export async function correctAssessmentPointsLiveQuiz(
                   },
                 })
 
-                await upsertResponseAppliedCorrection(
+                const logEntry = await upsertResponseAppliedCorrection(
                   {
                     correctionId: correction.id,
                     instance: { ...instance, elementBlock: block },
@@ -1555,14 +1581,20 @@ export async function correctAssessmentPointsLiveQuiz(
                   tx,
                   ctx
                 )
+
+                // push the log object to the list of log entries
+                logEntries.push(logEntry)
               })
             )
           })
         )
 
+        // create the collected audit log entries
+        await ctx.tasks.createAuditLogEntry.runNoWait(logEntries)
+
         return correction
       },
-      { timeout: 60000 }
+      { timeout: 300000 } // 5 min timeout to ensure success for the moment -> until asynchronous execution is available
     )
 
     return createdCorrection
@@ -1641,6 +1673,10 @@ export async function correctAssessmentPointsLiveQuiz(
           include: { correctedBy: true, liveQuiz: true },
         })
 
+        // initialize the audit log entries that should be executed
+        const logEntries: { message: { info: string } }[] = []
+
+        // loop over all instances and participants to upsert all relevant responses
         await Promise.all(
           liveQuiz.blocks.map(async (block) => {
             await Promise.all(
@@ -1656,7 +1692,7 @@ export async function correctAssessmentPointsLiveQuiz(
                     async ([pId, instanceResponseMap]) => {
                       const response = instanceResponseMap[instance.id]
 
-                      await upsertResponseAppliedCorrection(
+                      const logEntry = await upsertResponseAppliedCorrection(
                         {
                           correctionId: correction.id,
                           instance: { ...instance, elementBlock: block },
@@ -1675,6 +1711,9 @@ export async function correctAssessmentPointsLiveQuiz(
                         tx,
                         ctx
                       )
+
+                      // push the log object to the list of log entries
+                      logEntries.push(logEntry)
                     }
                   )
                 )
@@ -1683,9 +1722,12 @@ export async function correctAssessmentPointsLiveQuiz(
           })
         )
 
+        // create the collected audit log entries
+        await ctx.tasks.createAuditLogEntry.runNoWait(logEntries)
+
         return correction
       },
-      { timeout: 60000 }
+      { timeout: 300000 } // 5 min timeout to ensure success for the moment -> until asynchronous execution is available
     )
 
     return createdCorrection
@@ -1729,6 +1771,9 @@ export async function correctAssessmentPointsLiveQuiz(
           include: { correctedBy: true, liveQuiz: true },
         })
 
+        // initialize the audit log entries that should be executed
+        const logEntries: { message: { info: string } }[] = []
+
         // loop over all instances and participants to upsert all relevant responses
         await Promise.all(
           liveQuiz.blocks.map(async (block) => {
@@ -1753,7 +1798,7 @@ export async function correctAssessmentPointsLiveQuiz(
                       },
                     })
 
-                    await upsertResponseAppliedCorrection(
+                    const logEntry = await upsertResponseAppliedCorrection(
                       {
                         correctionId: correction.id,
                         instance: { ...instance, elementBlock: block },
@@ -1772,6 +1817,9 @@ export async function correctAssessmentPointsLiveQuiz(
                       tx,
                       ctx
                     )
+
+                    // push the log object to the list of log entries
+                    logEntries.push(logEntry)
                   })
                 )
               })
@@ -1779,9 +1827,12 @@ export async function correctAssessmentPointsLiveQuiz(
           })
         )
 
+        // create the collected audit log entries
+        await ctx.tasks.createAuditLogEntry.runNoWait(logEntries)
+
         return correction
       },
-      { timeout: 60000 }
+      { timeout: 300000 } // 5 min timeout to ensure success for the moment -> until asynchronous execution is available
     )
 
     return createdCorrection

--- a/packages/graphql/test/docker/docker-compose.test.yml
+++ b/packages/graphql/test/docker/docker-compose.test.yml
@@ -11,23 +11,23 @@ services:
       - --providers.file.watch=true
 
       # API and dashboard
-      - "--api.insecure=true"
-      - "--api.dashboard=true"
+      - '--api.insecure=true'
+      - '--api.dashboard=true'
 
       # Entry points configuration
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.websecure.address=:443"
+      - '--entrypoints.web.address=:80'
+      - '--entrypoints.websecure.address=:443'
 
       # HTTP/2 configuration (critical for subscriptions)
-      - "--entrypoints.websecure.http.tls=true"
-      - "--entrypoints.websecure.http2.maxConcurrentStreams=250"
+      - '--entrypoints.websecure.http.tls=true'
+      - '--entrypoints.websecure.http2.maxConcurrentStreams=250'
     ports:
       - 80:80
       - 443:443
       - 8090:8080
     volumes:
-      - "../../../../util/traefik/rules_docker.yaml:/etc/traefik/rules.yaml"
-      - "../../../../util/traefik/ssl:/etc/certs:ro"
+      - '../../../../util/traefik/rules_docker.yaml:/etc/traefik/rules.yaml'
+      - '../../../../util/traefik/ssl:/etc/certs:ro'
     networks:
       - klicker
 
@@ -41,7 +41,7 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "klicker", "-d", "klicker-prod"]
+      test: ['CMD', 'pg_isready', '-U', 'klicker', '-d', 'klicker-prod']
       interval: 5s
       timeout: 5s
       retries: 5
@@ -61,7 +61,7 @@ services:
     ports:
       - 5433:5432
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "hatchet", "-d", "hatchet"]
+      test: ['CMD', 'pg_isready', '-U', 'hatchet', '-d', 'hatchet']
       interval: 5s
       timeout: 10s
       retries: 10
@@ -73,30 +73,30 @@ services:
   hatchet:
     image: ghcr.io/hatchet-dev/hatchet/hatchet-lite:v0.73.1
     ports:
-      - "8888:8888"
-      - "7077:7077"
+      - '8888:8888'
+      - '7077:7077'
     environment:
-      DATABASE_URL: "postgresql://hatchet:hatchet@postgres_hatchet:5432/hatchet?sslmode=disable"
+      DATABASE_URL: 'postgresql://hatchet:hatchet@postgres_hatchet:5432/hatchet?sslmode=disable'
       SERVER_AUTH_COOKIE_DOMAIN: localhost
-      SERVER_AUTH_COOKIE_INSECURE: "t"
-      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
-      SERVER_GRPC_INSECURE: "t"
+      SERVER_AUTH_COOKIE_INSECURE: 't'
+      SERVER_GRPC_BIND_ADDRESS: '0.0.0.0'
+      SERVER_GRPC_INSECURE: 't'
       SERVER_GRPC_BROADCAST_ADDRESS: localhost:7077
       SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: localhost:7077
-      SERVER_GRPC_PORT: "7077"
+      SERVER_GRPC_PORT: '7077'
       SERVER_URL: http://localhost:8888
-      SERVER_AUTH_SET_EMAIL_VERIFIED: "t"
-      SERVER_DEFAULT_ENGINE_VERSION: "V1"
+      SERVER_AUTH_SET_EMAIL_VERIFIED: 't'
+      SERVER_DEFAULT_ENGINE_VERSION: 'V1'
       SERVER_LOGGER_LEVEL: debug
       SERVER_LOGGER_FORMAT: console
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888/healthz"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8888/healthz']
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 20s
     volumes:
-      - "hatchet_lite_config:/config"
+      - 'hatchet_lite_config:/config'
     networks:
       - klicker
     depends_on:

--- a/packages/graphql/test/docker/docker-compose.test.yml
+++ b/packages/graphql/test/docker/docker-compose.test.yml
@@ -11,23 +11,23 @@ services:
       - --providers.file.watch=true
 
       # API and dashboard
-      - '--api.insecure=true'
-      - '--api.dashboard=true'
+      - "--api.insecure=true"
+      - "--api.dashboard=true"
 
       # Entry points configuration
-      - '--entrypoints.web.address=:80'
-      - '--entrypoints.websecure.address=:443'
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
 
       # HTTP/2 configuration (critical for subscriptions)
-      - '--entrypoints.websecure.http.tls=true'
-      - '--entrypoints.websecure.http2.maxConcurrentStreams=250'
+      - "--entrypoints.websecure.http.tls=true"
+      - "--entrypoints.websecure.http2.maxConcurrentStreams=250"
     ports:
       - 80:80
       - 443:443
       - 8090:8080
     volumes:
-      - '../../../../util/traefik/rules_docker.yaml:/etc/traefik/rules.yaml'
-      - '../../../../util/traefik/ssl:/etc/certs:ro'
+      - "../../../../util/traefik/rules_docker.yaml:/etc/traefik/rules.yaml"
+      - "../../../../util/traefik/ssl:/etc/certs:ro"
     networks:
       - klicker
 
@@ -41,7 +41,7 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U', 'klicker', '-d', 'klicker-prod']
+      test: ["CMD", "pg_isready", "-U", "klicker", "-d", "klicker-prod"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -51,33 +51,57 @@ services:
     volumes:
       - ../../../../util/init.sql:/docker-entrypoint-initdb.d/init.sql
 
+  # Dedicated database for Hatchet workflows
+  postgres_hatchet:
+    image: docker.io/library/postgres:15
+    environment:
+      POSTGRES_USER: hatchet
+      POSTGRES_PASSWORD: hatchet
+      POSTGRES_DB: hatchet
+    ports:
+      - 5433:5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "hatchet", "-d", "hatchet"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    networks:
+      - klicker
+
   # Hatchet service for workflow orchestration
   hatchet:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-lite:v0.73.1
     ports:
-      - '8888:8888'
-      - '7077:7077'
+      - "8888:8888"
+      - "7077:7077"
     environment:
-      DATABASE_URL: 'postgresql://hatchet:hatchet@postgres:5432/hatchet?sslmode=disable'
+      DATABASE_URL: "postgresql://hatchet:hatchet@postgres_hatchet:5432/hatchet?sslmode=disable"
       SERVER_AUTH_COOKIE_DOMAIN: localhost
-      SERVER_AUTH_COOKIE_INSECURE: 't'
-      SERVER_GRPC_BIND_ADDRESS: '0.0.0.0'
-      SERVER_GRPC_INSECURE: 't'
+      SERVER_AUTH_COOKIE_INSECURE: "t"
+      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
+      SERVER_GRPC_INSECURE: "t"
       SERVER_GRPC_BROADCAST_ADDRESS: localhost:7077
-      SERVER_GRPC_PORT: '7077'
+      SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: localhost:7077
+      SERVER_GRPC_PORT: "7077"
       SERVER_URL: http://localhost:8888
-      SERVER_AUTH_SET_EMAIL_VERIFIED: 't'
-      SERVER_DEFAULT_ENGINE_VERSION: 'V1'
+      SERVER_AUTH_SET_EMAIL_VERIFIED: "t"
+      SERVER_DEFAULT_ENGINE_VERSION: "V1"
+      SERVER_LOGGER_LEVEL: debug
+      SERVER_LOGGER_FORMAT: console
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8888/healthz']
+      test: ["CMD", "curl", "-f", "http://localhost:8888/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 20s
     volumes:
-      - 'hatchet_lite_config:/config'
+      - "hatchet_lite_config:/config"
     networks:
       - klicker
+    depends_on:
+      postgres_hatchet:
+        condition: service_healthy
 
   redis_exec:
     image: docker.io/library/redis:7
@@ -90,6 +114,13 @@ services:
     image: docker.io/library/redis:7
     ports:
       - 6380:6379
+    networks:
+      - klicker
+
+  redis_cache:
+    image: docker.io/library/redis:7
+    ports:
+      - 6381:6379
     networks:
       - klicker
 

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -138,7 +138,7 @@ export async function testInitialization(
         message,
       }: {
         message: Record<string, string | undefined> & {
-          correlationId: string
+          correlationId?: string
           info: string
         }
       }) => {

--- a/packages/graphql/test/helpers.ts
+++ b/packages/graphql/test/helpers.ts
@@ -133,7 +133,7 @@ export async function testInitialization(
   // initialize tasks to be called
   const tasks = {
     createAuditLogEntry: hatchet.task({
-      name: 'create-audit-logging-entry',
+      name: 'create-audit-log-entry',
       fn: async ({
         message,
       }: {

--- a/packages/graphql/test/instancePointCorrections.test.ts
+++ b/packages/graphql/test/instancePointCorrections.test.ts
@@ -1,7 +1,6 @@
 import type { Hatchet } from '@hatchet-dev/typescript-sdk'
 import { PointCorrectionType, PrismaClient } from '@klicker-uzh/prisma/client'
 import { EventEmitter } from 'events'
-import {} from 'src/ops.js'
 import { ContextWithUser } from '../src/lib/context.js'
 import { correctAssessmentPointsInstance } from '../src/services/courses.js'
 import {
@@ -24,12 +23,12 @@ describe('Unit tests covering point corrections for instances', () => {
   beforeAll(async () => {
     const {
       prisma: newPrisma,
-      hatchet: newHatchet,
       emitter: newEmitter,
+      hatchet: newHatchet,
     } = await initializePrisma()
     prisma = newPrisma
-    hatchet = newHatchet
     emitter = newEmitter
+    hatchet = newHatchet
   })
 
   afterAll(async () => {

--- a/packages/graphql/test/liveQuizPointCorrections.test.ts
+++ b/packages/graphql/test/liveQuizPointCorrections.test.ts
@@ -1,7 +1,6 @@
 import type { Hatchet } from '@hatchet-dev/typescript-sdk'
 import { PointCorrectionType, PrismaClient } from '@klicker-uzh/prisma/client'
 import { EventEmitter } from 'events'
-import {} from 'src/ops.js'
 import { correctAssessmentPointsLiveQuiz } from 'src/services/courses.js'
 import { ContextWithUser } from '../src/lib/context.js'
 import {
@@ -24,12 +23,12 @@ describe('Unit tests covering point corrections for live quizzes', () => {
   beforeAll(async () => {
     const {
       prisma: newPrisma,
-      hatchet: newHatchet,
       emitter: newEmitter,
+      hatchet: newHatchet,
     } = await initializePrisma()
     prisma = newPrisma
-    hatchet = newHatchet
     emitter = newEmitter
+    hatchet = newHatchet
   })
 
   afterAll(async () => {

--- a/packages/graphql/test/run-tests-local.sh
+++ b/packages/graphql/test/run-tests-local.sh
@@ -2,12 +2,46 @@
 
 set -e
 
+HATCHET_WORKER_PID=""
+HATCHET_WORKER_ENV_FILE=""
+
+wait_for_port() {
+  local host="$1"
+  local port="$2"
+  local label="$3"
+
+  for i in {1..30}; do
+    if nc -z "$host" "$port" >/dev/null 2>&1; then
+      echo "$label is ready!"
+      return 0
+    fi
+
+    if [[ "$i" == "30" ]]; then
+      echo "$label failed to become ready on ${host}:${port}. Exiting." >&2
+      return 1
+    fi
+
+    echo "Waiting for $label... ($i/30)"
+    sleep 2
+  done
+}
+
 echo "=== GraphQL Test Suite (Vitest) ==="
 echo "Starting services and running tests locally..."
 
 # Function to cleanup services on exit
 cleanup() {
   echo ""
+  if [[ -n "$HATCHET_WORKER_PID" ]]; then
+    echo "Stopping Hatchet worker (PID $HATCHET_WORKER_PID)..."
+    if kill -0 "$HATCHET_WORKER_PID" >/dev/null 2>&1; then
+      kill "$HATCHET_WORKER_PID" >/dev/null 2>&1 || true
+      wait "$HATCHET_WORKER_PID" 2>/dev/null || true
+    fi
+  fi
+  if [[ -n "$HATCHET_WORKER_ENV_FILE" && -f "$HATCHET_WORKER_ENV_FILE" ]]; then
+    rm -f "$HATCHET_WORKER_ENV_FILE"
+  fi
   echo "Cleaning up services..."
   docker compose -f test/docker/docker-compose.test.yml down --volumes --remove-orphans 2>/dev/null || true
 }
@@ -54,6 +88,11 @@ for i in {1..30}; do
   sleep 2
 done
 
+echo "Checking Redis services..."
+wait_for_port localhost 6379 "Redis exec" || exit 1
+wait_for_port localhost 6380 "Redis assessment" || exit 1
+wait_for_port localhost 6381 "Redis cache" || exit 1
+
 # Generate Hatchet token
 echo "Generating Hatchet client token..."
 TOKEN=$(docker compose -f test/docker/docker-compose.test.yml exec -T hatchet /hatchet-admin token create --config /config --tenant-id 707d0855-80ab-4e1f-a156-f1c4546cbf52 | xargs)
@@ -70,6 +109,50 @@ export DATABASE_URL="postgresql://klicker:klicker@localhost:5432/klicker-prod"
 export HATCHET_CLIENT_TOKEN="$TOKEN"
 export HATCHET_CLIENT_TLS_STRATEGY="none"
 export NODE_ENV="test"
+
+echo "Starting Hatchet worker..."
+pushd ../../apps/hatchet-worker-general >/dev/null
+
+HATCHET_WORKER_ENV_FILE="$PWD/.env.test.local"
+cat <<EOF > "$HATCHET_WORKER_ENV_FILE"
+HATCHET_CLIENT_TOKEN=$HATCHET_CLIENT_TOKEN
+HATCHET_CLIENT_HOST_PORT=localhost:7077
+HATCHET_CLIENT_TLS_STRATEGY=none
+HATCHET_API_URL=http://localhost:8888
+HATCHET_HOST_PORT=localhost:7077
+HATCHET_LOG_LEVEL=DEBUG
+HATCHET_TENANT_ID=707d0855-80ab-4e1f-a156-f1c4546cbf52
+HATCHET_WORKER_NAME=hatchet-worker-general
+LOG_LEVEL=info
+NODE_ENV=test
+DATABASE_URL=postgresql://klicker:klicker@localhost:5432/klicker-prod
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_ASSESSMENT_HOST=localhost
+REDIS_ASSESSMENT_PORT=6380
+REDIS_CACHE_HOST=localhost
+REDIS_CACHE_PORT=6381
+APP_ORIGIN_API=http://api.klicker.com
+APP_ORIGIN_AUTH=http://auth.klicker.com
+APP_ORIGIN_LTI=http://lti.klicker.com
+APP_ORIGIN_PWA=http://pwa.klicker.com
+APP_ORIGIN_MANAGE=http://manage.klicker.com
+APP_ORIGIN_CONTROL=http://control.klicker.com
+APP_ORIGIN_ASSESSMENT_API=http://assessment-api.klicker.com
+APP_ORIGIN_ASSESSMENT_PWA=http://assessment.klicker.com
+EOF
+
+pnpm exec node --env-file "$HATCHET_WORKER_ENV_FILE" dist/index.js &
+HATCHET_WORKER_PID=$!
+
+popd >/dev/null
+
+echo "Hatchet worker started with PID ${HATCHET_WORKER_PID}"
+sleep 5
+if ! kill -0 "$HATCHET_WORKER_PID" >/dev/null 2>&1; then
+  echo "Hatchet worker failed to start. Check logs above." >&2
+  exit 1
+fi
 
 echo ""
 echo "=== Environment Setup ==="

--- a/packages/types/src/hatchet.ts
+++ b/packages/types/src/hatchet.ts
@@ -97,7 +97,7 @@ export interface PreparedHatchetTasks {
   createAuditLogEntry: TaskWorkflowDeclaration<
     {
       message: Record<string, string | undefined> & {
-        correlationId: string
+        correlationId?: string
         info: string
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Batched audit logging for corrections to reduce overhead and improve throughput.
  - Increased operation timeouts to 5 minutes to better handle long-running tasks.
  - Made correlation IDs optional in audit events for greater flexibility.

- Tests
  - Enhanced local test environment with dedicated Postgres/Redis services and a managed worker lifecycle for improved reliability.

- Chores
  - Updated background service versions and configurations to align with the new auditing flow and infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->