### PR TITLE
fix(packages/shared-components): handle undefined text for slate conversion

### DIFF
--- a/packages/shared-components/src/utils/slateMdConversion.ts
+++ b/packages/shared-components/src/utils/slateMdConversion.ts
@@ -187,12 +187,12 @@ export const convertToSlate = (mdObj?: string | null) => {
 }
 
 const formatText = (input: any) => {
-  if (!input || input.text === '') {
+  if (!input || !input.text || input.text === '') {
     return ''
   }
   return serialize({
     type: 'paragraph',
-    text: input.text || '',
+    text: input.text,
     bold: input.bold || false,
     italic: input.italic || false,
     code: input.code || false,

--- a/packages/shared-components/src/utils/slateMdConversion.ts
+++ b/packages/shared-components/src/utils/slateMdConversion.ts
@@ -187,12 +187,12 @@ export const convertToSlate = (mdObj?: string | null) => {
 }
 
 const formatText = (input: any) => {
-  if (input.text === '') {
+  if (!input || input.text === '') {
     return ''
   }
   return serialize({
     type: 'paragraph',
-    text: input.text,
+    text: input.text || '',
     bold: input.bold || false,
     italic: input.italic || false,
     code: input.code || false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when converting rich text with missing or empty text by treating empty input as invalid and defaulting to an empty string. This prevents unexpected errors and blank rendering, improving reliability when editing, viewing, or sharing content that includes empty paragraphs or placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->