### PR TITLE
refactor: deduplicate normalizeMatriculationNumber and add duplicate_…

### DIFF
--- a/packages/graphql/src/scripts/importParticipantInvitations.ts
+++ b/packages/graphql/src/scripts/importParticipantInvitations.ts
@@ -2,7 +2,10 @@
 
 import { prisma } from '@klicker-uzh/prisma'
 import { InvitationStatus } from '@klicker-uzh/prisma/client'
-import { InvitationEmailMode } from '@klicker-uzh/util'
+import {
+  InvitationEmailMode,
+  normalizeMatriculationNumber,
+} from '@klicker-uzh/util'
 import { parse } from 'csv-parse/sync'
 import { readFileSync } from 'fs'
 import * as R from 'remeda'
@@ -161,12 +164,12 @@ async function run() {
 
         for (const invitation of invitations) {
           const normalizedEmail = invitation.email.toLowerCase()
-          const matriculationNumber = normalizeMatriculationNumber(
-            invitation.matriculationNumber
-          )
 
-          if (matriculationNumber) {
-            latestMatriculationByEmail.set(normalizedEmail, matriculationNumber)
+          if (invitation.matriculationNumber) {
+            latestMatriculationByEmail.set(
+              normalizedEmail,
+              invitation.matriculationNumber
+            )
           }
         }
 
@@ -425,19 +428,6 @@ async function run() {
   }
 }
 
-function normalizeMatriculationNumber(
-  matriculationNumber?: string | null
-): string | null {
-  if (typeof matriculationNumber !== 'string') {
-    return null
-  }
-
-  const trimmedMatriculationNumber = matriculationNumber.trim()
-  return trimmedMatriculationNumber.length > 0
-    ? trimmedMatriculationNumber
-    : null
-}
-
 async function updateExistingInvitationMatriculationNumbers(
   existingInvitations: ExistingInvitationInfo[],
   latestMatriculationByEmail: Map<string, string>,
@@ -492,6 +482,7 @@ function summarizeInvitationResults(results: InvitationResult[]) {
           summary.autoAccepted += 1
           break
         case 'duplicate':
+        case 'duplicate_updated':
           summary.duplicates += 1
           break
         case 'error':
@@ -518,9 +509,7 @@ async function resolveParticipantWithoutInvitation(
   dryRun: boolean
 ): Promise<InvitationResult | null> {
   const normalizedEmail = invitation.email.toLowerCase()
-  const matriculationNumber = normalizeMatriculationNumber(
-    invitation.matriculationNumber
-  )
+  const matriculationNumber = invitation.matriculationNumber ?? null
 
   const participantAccount = await prisma.participantAccount.findFirst({
     where: {

--- a/packages/graphql/src/services/participantInvitations.ts
+++ b/packages/graphql/src/services/participantInvitations.ts
@@ -4,12 +4,13 @@ import {
   InvitationEmailMode,
   InvitationEmailMode as InvitationEmailModeValue,
   normalizeEmail,
+  normalizeMatriculationNumber,
 } from '@klicker-uzh/util'
 import * as R from 'remeda'
 
 export interface InvitationResult {
   email: string
-  status: 'created' | 'auto_accepted' | 'duplicate' | 'error'
+  status: 'created' | 'auto_accepted' | 'duplicate' | 'duplicate_updated' | 'error'
   invitationId?: number
   participantId?: string
   error?: string
@@ -90,10 +91,11 @@ export async function createParticipantInvitations(
       })
 
       if (existingInvitation) {
-        if (
+        const matriculationUpdated =
           normalizedMatriculationNumber &&
           existingInvitation.matriculationNumber !== normalizedMatriculationNumber
-        ) {
+
+        if (matriculationUpdated) {
           await prisma.participantInvitation.update({
             where: { id: existingInvitation.id },
             data: {
@@ -104,7 +106,7 @@ export async function createParticipantInvitations(
 
         results.push({
           email: normalizedEmail,
-          status: 'duplicate',
+          status: matriculationUpdated ? 'duplicate_updated' : 'duplicate',
           invitationId: existingInvitation.id,
         })
         continue
@@ -176,7 +178,7 @@ export async function createParticipantInvitations(
     totalProcessed: invitations.length,
     created: statusCounts.created || 0,
     autoAccepted: statusCounts.auto_accepted || 0,
-    duplicates: statusCounts.duplicate || 0,
+    duplicates: (statusCounts.duplicate || 0) + (statusCounts.duplicate_updated || 0),
     errors: statusCounts.error || 0,
     results,
   }
@@ -227,17 +229,4 @@ async function autoAcceptInvitation(
   })
 
   return result
-}
-
-function normalizeMatriculationNumber(
-  matriculationNumber?: string | null
-): string | null {
-  if (typeof matriculationNumber !== 'string') {
-    return null
-  }
-
-  const trimmedMatriculationNumber = matriculationNumber.trim()
-  return trimmedMatriculationNumber.length > 0
-    ? trimmedMatriculationNumber
-    : null
 }

--- a/packages/util/src/email.ts
+++ b/packages/util/src/email.ts
@@ -82,3 +82,17 @@ export function collectAllEmails(
 ): string[] {
   return collectInvitationEmails(primaryEmail, affiliationEmails).allEmails
 }
+
+/**
+ * Normalize a matriculation number: trim whitespace, return null if empty or not a string.
+ */
+export function normalizeMatriculationNumber(
+  matriculationNumber?: string | null
+): string | null {
+  if (typeof matriculationNumber !== 'string') {
+    return null
+  }
+
+  const trimmed = matriculationNumber.trim()
+  return trimmed.length > 0 ? trimmed : null
+}


### PR DESCRIPTION
…updated status

- Extract normalizeMatriculationNumber to @klicker-uzh/util (shared email module) to eliminate duplication between service and import script
- Add 'duplicate_updated' status to InvitationResult to distinguish duplicates that had their matriculation number updated from unchanged duplicates
- Remove redundant re-normalization in import script where data was already normalized by the Zod transform

https://claude.ai/code/session_01FLXXeProJX2dzFYHNqAE7W