### PR TITLE
fix(chat): tighten embedded runtime reload transition

### DIFF
--- a/apps/chat/src/app/RuntimeProvider.tsx
+++ b/apps/chat/src/app/RuntimeProvider.tsx
@@ -44,6 +44,11 @@ export function RuntimeProvider({
   const [threadsLoaded, setThreadsLoaded] = useState(false)
   const lastSyncedThreadId = useRef<string | null>(null)
   const syncInFlight = useRef<string | null>(null)
+  const previousRuntimeContext = useRef<{
+    chatbotId: string
+    embedded: boolean
+    threadId?: string
+  } | null>(null)
 
   // get current thread state
   const activeThread = threads.find((t) => t.id === activeThreadId)
@@ -59,7 +64,26 @@ export function RuntimeProvider({
 
   // load runtime data on component mount / chatbot changes
   useEffect(() => {
-    if (embedded && !threadId) return
+    const previousContext = previousRuntimeContext.current
+
+    if (embedded && !threadId) {
+      previousRuntimeContext.current = { chatbotId, embedded, threadId }
+      return
+    }
+
+    const chatbotChanged = previousContext?.chatbotId !== chatbotId
+    const embeddedThreadBecameAvailable =
+      embedded &&
+      !!threadId &&
+      previousContext?.embedded &&
+      !previousContext.threadId
+
+    const shouldLoadRuntimeData =
+      !previousContext || chatbotChanged || embeddedThreadBecameAvailable
+
+    previousRuntimeContext.current = { chatbotId, embedded, threadId }
+
+    if (!shouldLoadRuntimeData) return
 
     let isMounted = true
 
@@ -79,11 +103,7 @@ export function RuntimeProvider({
     return () => {
       isMounted = false
     }
-    // threadId intentionally excluded -- thread switches are handled by the
-    // sync effect below; re-running loadThreads on every navigation wipes
-    // already-fetched messages and causes race conditions.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatbotId, embedded, loadCredits, loadModeOptions, loadThreads])
+  }, [chatbotId, embedded, loadCredits, loadModeOptions, loadThreads, threadId])
 
   // sync active thread with URL params
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent unnecessary runtime reloads when navigating between non-embedded contexts and ensure the embedded runtime only reloads when embedded mode transitions from no `threadId` to a present `threadId`.

### Description
- Add `previousRuntimeContext` to track `{ chatbotId, embedded, threadId }`, change the embedded-availability check to `previousContext?.embedded && !previousContext.threadId`, set `previousRuntimeContext` when embedded without a thread and guard runtime loading with `shouldLoadRuntimeData`, and restore `threadId` to the effect dependencies while preserving the `loadThreads`, `loadModeOptions`, and `loadCredits` initialization.

### Testing
- Ran `pnpm prettier --write apps/chat/src/app/RuntimeProvider.tsx` which succeeded.
- Ran `pnpm --filter ./apps/chat check` which failed due to unrelated workspace package type artifacts and a Node engine mismatch in the environment.
- Attempted a Playwright screenshot against `http://localhost:3004` which failed because the local chat app was not running (network error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698b00e12b5083329277a205def536d7)