### PR TITLE
fix(chat): stabilize missing-thread redirect target with query params

### DIFF
--- a/apps/chat/src/app/RuntimeProvider.tsx
+++ b/apps/chat/src/app/RuntimeProvider.tsx
@@ -45,11 +45,6 @@ export function RuntimeProvider({
   const [threadsLoaded, setThreadsLoaded] = useState(false)
   const lastSyncedThreadId = useRef<string | null>(null)
   const syncInFlight = useRef<string | null>(null)
-  const currentQueryString = searchParams.toString()
-  const missingThreadRedirectTarget = currentQueryString
-    ? `/${chatbotId}?${currentQueryString}`
-    : `/${chatbotId}`
-
   // get current thread state
   const activeThread = threads.find((t) => t.id === activeThreadId)
   const messages = activeThread?.messages || []
@@ -106,7 +101,12 @@ export function RuntimeProvider({
     const existingThread = threads.find((thread) => thread.id === threadId)
 
     if (!existingThread) {
-      router.replace(missingThreadRedirectTarget)
+      const queryString = searchParams.toString()
+      const redirectTarget = queryString
+        ? `/${chatbotId}?${queryString}`
+        : `/${chatbotId}`
+
+      router.replace(redirectTarget)
       lastSyncedThreadId.current = null
       syncInFlight.current = null
       return
@@ -151,8 +151,8 @@ export function RuntimeProvider({
   }, [
     activeThreadId,
     chatbotId,
-    missingThreadRedirectTarget,
     router,
+    searchParams,
     switchToThread,
     threadId,
     threads,

--- a/apps/chat/src/app/RuntimeProvider.tsx
+++ b/apps/chat/src/app/RuntimeProvider.tsx
@@ -5,7 +5,7 @@ import {
   useExternalStoreRuntime,
   type ThreadMessageLike,
 } from '@assistant-ui/react'
-import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useChatResponse } from 'src/hooks/useChatResponse'
 import { useThreadManagement } from 'src/hooks/useThreadManagement'
@@ -41,7 +41,6 @@ export function RuntimeProvider({
   } = useSettingsStore()
   const { threadId } = useParams<{ chatbotId: string; threadId?: string }>()
   const router = useRouter()
-  const searchParams = useSearchParams()
   const [threadsLoaded, setThreadsLoaded] = useState(false)
   const lastSyncedThreadId = useRef<string | null>(null)
   const syncInFlight = useRef<string | null>(null)
@@ -101,10 +100,7 @@ export function RuntimeProvider({
     const existingThread = threads.find((thread) => thread.id === threadId)
 
     if (!existingThread) {
-      const queryString = searchParams.toString()
-      const redirectTarget = queryString
-        ? `/${chatbotId}?${queryString}`
-        : `/${chatbotId}`
+      const redirectTarget = `/${chatbotId}${window.location.search}`
 
       router.replace(redirectTarget)
       lastSyncedThreadId.current = null
@@ -152,7 +148,6 @@ export function RuntimeProvider({
     activeThreadId,
     chatbotId,
     router,
-    searchParams,
     switchToThread,
     threadId,
     threads,

--- a/apps/chat/src/app/RuntimeProvider.tsx
+++ b/apps/chat/src/app/RuntimeProvider.tsx
@@ -5,8 +5,8 @@ import {
   useExternalStoreRuntime,
   type ThreadMessageLike,
 } from '@assistant-ui/react'
-import { useParams, useRouter } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useChatResponse } from 'src/hooks/useChatResponse'
 import { useThreadManagement } from 'src/hooks/useThreadManagement'
 import {
@@ -41,9 +41,14 @@ export function RuntimeProvider({
   } = useSettingsStore()
   const { threadId } = useParams<{ chatbotId: string; threadId?: string }>()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [threadsLoaded, setThreadsLoaded] = useState(false)
   const lastSyncedThreadId = useRef<string | null>(null)
   const syncInFlight = useRef<string | null>(null)
+  const missingThreadRedirectTarget = useMemo(() => {
+    const queryString = searchParams.toString()
+    return queryString ? `/${chatbotId}?${queryString}` : `/${chatbotId}`
+  }, [chatbotId, searchParams])
 
   // get current thread state
   const activeThread = threads.find((t) => t.id === activeThreadId)
@@ -101,7 +106,7 @@ export function RuntimeProvider({
     const existingThread = threads.find((thread) => thread.id === threadId)
 
     if (!existingThread) {
-      router.replace(`/${chatbotId}`)
+      router.replace(missingThreadRedirectTarget)
       lastSyncedThreadId.current = null
       syncInFlight.current = null
       return
@@ -146,6 +151,7 @@ export function RuntimeProvider({
   }, [
     activeThreadId,
     chatbotId,
+    missingThreadRedirectTarget,
     router,
     switchToThread,
     threadId,

--- a/apps/chat/src/app/RuntimeProvider.tsx
+++ b/apps/chat/src/app/RuntimeProvider.tsx
@@ -6,7 +6,7 @@ import {
   type ThreadMessageLike,
 } from '@assistant-ui/react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useChatResponse } from 'src/hooks/useChatResponse'
 import { useThreadManagement } from 'src/hooks/useThreadManagement'
 import {
@@ -45,10 +45,10 @@ export function RuntimeProvider({
   const [threadsLoaded, setThreadsLoaded] = useState(false)
   const lastSyncedThreadId = useRef<string | null>(null)
   const syncInFlight = useRef<string | null>(null)
-  const missingThreadRedirectTarget = useMemo(() => {
-    const queryString = searchParams.toString()
-    return queryString ? `/${chatbotId}?${queryString}` : `/${chatbotId}`
-  }, [chatbotId, searchParams])
+  const currentQueryString = searchParams.toString()
+  const missingThreadRedirectTarget = currentQueryString
+    ? `/${chatbotId}?${currentQueryString}`
+    : `/${chatbotId}`
 
   // get current thread state
   const activeThread = threads.find((t) => t.id === activeThreadId)


### PR DESCRIPTION
### Motivation

- Preserve URL query parameters (e.g. `embed=1`) when the runtime redirects from a non-existent thread back to the chatbot root. 
- Ensure the derived redirect target is stable so the thread-sync effect has correct, memoized dependencies.

### Description

- Import `useSearchParams` and `useMemo` and compute `missingThreadRedirectTarget` with `useMemo` from `chatbotId` and `searchParams`.
- Replace the hardcoded `router.replace(`/${chatbotId}`)` with `router.replace(missingThreadRedirectTarget)` in the thread-not-found branch.
- Add `missingThreadRedirectTarget` to the thread-sync effect dependency array so the effect remains deterministic.

### Testing

- Ran `pnpm --filter @klicker-uzh/chat check`, which failed in this environment due to unresolved workspace package type declarations and a Node engine version mismatch, so typecheck could not be completed.
- Attempted `npx agent-browser open http://localhost:3004`, which could not run because the Playwright browser binaries are not installed in this environment, so no visual verification screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698b00e1274083329ab6519e5cf3d1b4)