### PR TITLE
Add matriculation number support to participant invitations

### DIFF
--- a/packages/graphql/src/services/participantInvitations.ts
+++ b/packages/graphql/src/services/participantInvitations.ts
@@ -10,7 +10,12 @@ import * as R from 'remeda'
 
 export interface InvitationResult {
   email: string
-  status: 'created' | 'auto_accepted' | 'duplicate' | 'duplicate_updated' | 'error'
+  status:
+    | 'created'
+    | 'auto_accepted'
+    | 'duplicate'
+    | 'duplicate_updated'
+    | 'error'
   invitationId?: number
   participantId?: string
   error?: string
@@ -92,8 +97,9 @@ export async function createParticipantInvitations(
 
       if (existingInvitation) {
         const matriculationUpdated =
-          normalizedMatriculationNumber &&
-          existingInvitation.matriculationNumber !== normalizedMatriculationNumber
+          normalizedMatriculationNumber != null &&
+          existingInvitation.matriculationNumber !==
+            normalizedMatriculationNumber
 
         if (matriculationUpdated) {
           await prisma.participantInvitation.update({
@@ -178,7 +184,8 @@ export async function createParticipantInvitations(
     totalProcessed: invitations.length,
     created: statusCounts.created || 0,
     autoAccepted: statusCounts.auto_accepted || 0,
-    duplicates: (statusCounts.duplicate || 0) + (statusCounts.duplicate_updated || 0),
+    duplicates:
+      (statusCounts.duplicate || 0) + (statusCounts.duplicate_updated || 0),
     errors: statusCounts.error || 0,
     results,
   }

--- a/packages/util/test/email.test.ts
+++ b/packages/util/test/email.test.ts
@@ -4,6 +4,7 @@ import {
   collectAllEmails,
   collectInvitationEmails,
   normalizeEmail,
+  normalizeMatriculationNumber,
 } from '../src/email.js'
 
 describe('Email utilities', () => {
@@ -63,6 +64,32 @@ describe('Email utilities', () => {
       expect(new Set(result)).toEqual(
         new Set(['user@df.uzh.ch', 'user@uzh.ch'])
       )
+    })
+  })
+
+  describe('normalizeMatriculationNumber', () => {
+    it('returns null for null and undefined', () => {
+      expect(normalizeMatriculationNumber(null)).toBeNull()
+      expect(normalizeMatriculationNumber(undefined)).toBeNull()
+    })
+
+    it('returns null for empty or whitespace-only strings', () => {
+      expect(normalizeMatriculationNumber('')).toBeNull()
+      expect(normalizeMatriculationNumber('   ')).toBeNull()
+      expect(normalizeMatriculationNumber('\t\n')).toBeNull()
+    })
+
+    it('trims whitespace from valid values', () => {
+      expect(normalizeMatriculationNumber('  12345678  ')).toBe('12345678')
+    })
+
+    it('preserves case (unlike email normalization)', () => {
+      expect(normalizeMatriculationNumber('AB-12345')).toBe('AB-12345')
+    })
+
+    it('returns valid matriculation numbers as-is', () => {
+      expect(normalizeMatriculationNumber('12345678')).toBe('12345678')
+      expect(normalizeMatriculationNumber('00-123-456')).toBe('00-123-456')
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added matriculation number support to participant invitations, enabling CSV imports to include optional matriculation numbers
  * Introduced ability to update existing invitations with matriculation numbers from import data
  * Extended invitation status tracking to distinguish between duplicate invitations and those updated with matriculation numbers

* **Chores**
  * Updated database schema to store matriculation numbers with participant invitations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->