### PR TITLE
enhance(apps/lti): add launch target resolver and docs for LTI custom claims to support system-level moodle integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Without Traefik, use `http://localhost:<port>` directly. The `*.klicker.com` dom
 - **Test environment caveats**: `pnpm run test:run` triggers Cypress which needs a running DB + seeded data. `pnpm --filter @klicker-uzh/graphql test` needs `HATCHET_CLIENT_TOKEN`. For verifying non-DB changes locally, target specific packages (e.g., `pnpm --filter @klicker-uzh/grading test`, `pnpm --filter @klicker-uzh/util test`).
 - **PR review triage**: Copilot/CodeRabbit/SonarCloud flag many false positives. Always check if guards/fallbacks already exist before "fixing" reported issues. Confirm with the actual code, not the bot summary.
 - **agent-browser via npx**: Always use `npx agent-browser` instead of bare `agent-browser`. Global install conflicts with Volta's Node shim and fails with "Could not execute command".
+- **LTI launch target resolver contract**: Launch targets are resolved in strict precedence `custom claim (klicker_redirect_to)` -> `query redirectTo` -> `LTI_REDIRECT_URL`, and validation fails closed on the first present invalid source. Use URL hostname exact/subdomain checks against `COOKIE_DOMAIN` and `DF_DOMAIN` (never substring matching). (`apps/lti/src/launchTarget.ts`)
 
 ## Factory Skills (AI Assistance)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Without Traefik, use `http://localhost:<port>` directly. The `*.klicker.com` dom
 - **Test environment caveats**: `pnpm run test:run` triggers Cypress which needs a running DB + seeded data. `pnpm --filter @klicker-uzh/graphql test` needs `HATCHET_CLIENT_TOKEN`. For verifying non-DB changes locally, target specific packages (e.g., `pnpm --filter @klicker-uzh/grading test`, `pnpm --filter @klicker-uzh/util test`).
 - **PR review triage**: Copilot/CodeRabbit/SonarCloud flag many false positives. Always check if guards/fallbacks already exist before "fixing" reported issues. Confirm with the actual code, not the bot summary.
 - **agent-browser via npx**: Always use `npx agent-browser` instead of bare `agent-browser`. Global install conflicts with Volta's Node shim and fails with "Could not execute command".
-- **LTI launch target resolver contract**: Launch targets are resolved in strict precedence `custom claim (klicker_redirect_to)` -> `query redirectTo` -> `LTI_REDIRECT_URL`, and validation fails closed on the first present invalid source. Use URL hostname exact/subdomain checks against `COOKIE_DOMAIN` and `DF_DOMAIN` (never substring matching). (`apps/lti/src/launchTarget.ts`)
+- **LTI launch target resolver contract**: Launch targets are resolved in strict precedence `custom claim (klicker_redirect_to)` -> `query redirectTo`; no env fallback is used in resolver logic. Validation fails closed on the first present invalid source and enforces URL hostname exact/subdomain checks against `COOKIE_DOMAIN` and `DF_DOMAIN` (never substring matching). (`apps/lti/src/launchTarget.ts`)
 
 ## Factory Skills (AI Assistance)
 

--- a/apps/docs/docs/tutorials/lti_integration.mdx
+++ b/apps/docs/docs/tutorials/lti_integration.mdx
@@ -48,9 +48,10 @@ Launch target resolution uses the following precedence:
 
 1. `token.platformContext.custom.klicker_redirect_to`
 2. `redirectTo` query parameter on the LTI URL
-3. `LTI_REDIRECT_URL` environment fallback
 
 This means existing OLAT links with `?redirectTo=...` remain fully supported and can continue to be used unchanged.
+
+If neither `klicker_redirect_to` nor `redirectTo` is provided, the launch is rejected as a configuration error.
 
 ## How can I integrate KlickerUZH pages into my OLAT course?
 

--- a/apps/docs/docs/tutorials/lti_integration.mdx
+++ b/apps/docs/docs/tutorials/lti_integration.mdx
@@ -36,6 +36,22 @@ KlickerUZH allows you to set a course language during creation or in the course 
 
 While this means that all activities integrated into OLAT using the provided LTI access links will be displayed in the course language, students may still change the language to their preferred language using the corresponding functionality in the avatar dropdown. Students accessing your course activities directly through the KlickerUZH app will see the activities in their preferred language, which they can set in the app settings.
 
+## How can I configure Moodle with a system-wide LTI tool?
+
+You can configure Moodle with one fixed KlickerUZH LTI tool URL and route each activity launch through a custom LTI parameter.
+
+- Use your KlickerUZH LTI URL as the fixed launch URL of the Moodle tool.
+- For each Moodle activity, set the custom parameter `klicker_redirect_to=<absolute target URL>`, where the value is the full target URL in KlickerUZH (for example a practice quiz, microlearning, leaderboard, or account page).
+- The value of `klicker_redirect_to` must be an **absolute URL** on an allowed KlickerUZH domain.
+
+Launch target resolution uses the following precedence:
+
+1. `token.platformContext.custom.klicker_redirect_to`
+2. `redirectTo` query parameter on the LTI URL
+3. `LTI_REDIRECT_URL` environment fallback
+
+This means existing OLAT links with `?redirectTo=...` remain fully supported and can continue to be used unchanged.
+
 ## How can I integrate KlickerUZH pages into my OLAT course?
 
 To successfully integrate individual KlickerUZH pages into your OLAT course, we outline the required steps for the different components below, showing you how to integrate the [course overview and student documentation](#course-overview-and-student-documentation), [activity lists (including Live Quiz and Live Q&A)](#activity-lists-including-live-quiz-and-live-qa), [leaderboard](#leaderboard), [account management](#account-management), and [individual activity links](#individual-activity-links).
@@ -43,7 +59,7 @@ To successfully integrate individual KlickerUZH pages into your OLAT course, we 
 To embed a KlickerUZH element in OLAT, you always start by creating a new course element of the type “LTI Page.” The subsequent steps depend on the type of KlickerUZH element you would like to create (as listed below).
 
 :::warning
-Please note that the LTI integration is currently only supported for UZH OLAT for security reasons. If you would like to use it at your institution or with another LMS, please have your administrator reach out to us.
+The examples below focus on UZH OLAT. Moodle can also be integrated with a system-wide LTI tool using `klicker_redirect_to` as described above. If you would like to use another LMS, please have your administrator reach out to us.
 :::
 
 ### Course Overview and Student Documentation

--- a/apps/lti/src/index.ts
+++ b/apps/lti/src/index.ts
@@ -2,6 +2,7 @@ import { signJWT } from '@klicker-uzh/util'
 import { Provider } from 'ltijs'
 // @ts-ignore
 import Database from 'ltijs-sequelize'
+import { appendJwt, resolveLaunchTarget } from './launchTarget.js'
 
 // Validate required environment variables
 if (!process.env.APP_ORIGIN_LTI) {
@@ -86,61 +87,35 @@ Provider.onConnect(async (token, req, res) => {
     domain: process.env.COOKIE_DOMAIN as string,
   })
 
-  if (typeof req.query.redirectTo === 'string') {
-    if (
-      !req.query.redirectTo.includes(process.env.COOKIE_DOMAIN as string) &&
-      !req.query.redirectTo.includes(process.env.DF_DOMAIN as string)
-    ) {
-      // log error
-      const error =
-        'COOKIE_DOMAIN or DF_DOMAIN is not part of redirectTo. Please check your configuration.'
-      console.error(error)
+  const launchTarget = resolveLaunchTarget(token, {
+    query: req.query as Record<string, unknown>,
+  })
 
-      // remove lti token to avoid issues caused by this cookie
-      res.clearCookie('lti-token', {
-        secure: true,
-        sameSite: 'none',
-        domain: process.env.COOKIE_DOMAIN as string,
-      })
+  if (!launchTarget.ok) {
+    console.error(
+      `event=lti_launch_rejected targetSource=${launchTarget.source ?? 'null'} reason=${launchTarget.reason} rawType=${getRawType(launchTarget.rawValue)}`
+    )
 
-      return res.end()
-    }
+    // remove lti token to avoid issues caused by this cookie
+    res.clearCookie('lti-token', {
+      secure: true,
+      sameSite: 'none',
+      domain: process.env.COOKIE_DOMAIN as string,
+    })
 
-    // TODO: treat DF_DOMAIN separately with different secret
-
-    const url = req.query.redirectTo as string
-    console.log('Redirecting to:', url)
-    return res.redirect(`${url}?jwt=${jwt}`)
-  } else if (typeof process.env.LTI_REDIRECT_URL === 'string') {
-    if (
-      !process.env.LTI_REDIRECT_URL.includes(
-        process.env.COOKIE_DOMAIN as string
-      ) &&
-      !process.env.LTI_REDIRECT_URL.includes(process.env.DF_DOMAIN as string)
-    ) {
-      // log error
-      const error =
-        'COOKIE_DOMAIN or DF_DOMAIN is not part of LTI_REDIRECT_URL. Please check your configuration.'
-      console.error(error)
-
-      // remove lti token to avoid issues caused by this cookie
-      res.clearCookie('lti-token', {
-        secure: true,
-        sameSite: 'none',
-        domain: process.env.COOKIE_DOMAIN as string,
-      })
-
-      return res.end()
-    }
-
-    // TODO: treat DF_DOMAIN separately with different secret
-
-    const url = process.env.LTI_REDIRECT_URL as string
-    console.log('Redirecting to:', url)
-    return res.redirect(`${url}?jwt=${jwt}`)
+    return res.status(400).json({
+      error: 'invalid_launch_target',
+      reason: launchTarget.reason,
+      source: launchTarget.source,
+    })
   }
 
-  return res.end()
+  const redirectUrl = appendJwt(launchTarget.target, jwt)
+  console.log(
+    `event=lti_launch_redirect targetSource=${launchTarget.source} targetHost=${launchTarget.target.hostname}`
+  )
+
+  return res.redirect(redirectUrl)
 })
 
 // setup function
@@ -197,3 +172,9 @@ Provider.app.get('/info', async (req, res) => {
 })
 
 setup().catch((e) => console.error(e))
+
+function getRawType(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  return typeof value
+}

--- a/apps/lti/src/launchTarget.ts
+++ b/apps/lti/src/launchTarget.ts
@@ -3,7 +3,7 @@
 
 const CUSTOM_REDIRECT_CLAIM_KEY = 'klicker_redirect_to'
 
-export type LaunchTargetSource = 'custom' | 'query' | 'env'
+export type LaunchTargetSource = 'custom' | 'query'
 
 export type LaunchTargetFailureReason =
   | 'missing_target'
@@ -32,10 +32,6 @@ export function resolveLaunchTarget(
     {
       source: 'query',
       value: req.query.redirectTo,
-    },
-    {
-      source: 'env',
-      value: process.env.LTI_REDIRECT_URL,
     },
   ]
 

--- a/apps/lti/src/launchTarget.ts
+++ b/apps/lti/src/launchTarget.ts
@@ -1,0 +1,139 @@
+// Keep launch-target parsing and validation centralized so a future
+// Provider.onDeepLinking(...) implementation can reuse the same contract.
+
+const CUSTOM_REDIRECT_CLAIM_KEY = 'klicker_redirect_to'
+
+export type LaunchTargetSource = 'custom' | 'query' | 'env'
+
+export type LaunchTargetFailureReason =
+  | 'missing_target'
+  | 'invalid_type'
+  | 'invalid_url'
+  | 'disallowed_host'
+
+export type ResolveLaunchTargetResult =
+  | { ok: true; source: LaunchTargetSource; target: URL }
+  | {
+      ok: false
+      source: LaunchTargetSource | null
+      reason: LaunchTargetFailureReason
+      rawValue?: unknown
+    }
+
+export function resolveLaunchTarget(
+  token: unknown,
+  req: { query: Record<string, unknown> }
+): ResolveLaunchTargetResult {
+  const candidates: Array<{ source: LaunchTargetSource; value: unknown }> = [
+    {
+      source: 'custom',
+      value: extractCustomRedirectTarget(token),
+    },
+    {
+      source: 'query',
+      value: req.query.redirectTo,
+    },
+    {
+      source: 'env',
+      value: process.env.LTI_REDIRECT_URL,
+    },
+  ]
+
+  for (const candidate of candidates) {
+    if (candidate.value == null) continue
+    return validateLaunchTarget(candidate.value, candidate.source)
+  }
+
+  return {
+    ok: false,
+    source: null,
+    reason: 'missing_target',
+  }
+}
+
+export function validateLaunchTarget(
+  rawValue: unknown,
+  source: LaunchTargetSource
+): ResolveLaunchTargetResult {
+  if (typeof rawValue !== 'string') {
+    return {
+      ok: false,
+      source,
+      reason: 'invalid_type',
+      rawValue,
+    }
+  }
+
+  let target: URL
+  try {
+    target = new URL(rawValue)
+  } catch {
+    return {
+      ok: false,
+      source,
+      reason: 'invalid_url',
+      rawValue,
+    }
+  }
+
+  const allowedDomains = getAllowedDomains()
+  if (!isAllowedHost(target.hostname, allowedDomains)) {
+    return {
+      ok: false,
+      source,
+      reason: 'disallowed_host',
+      rawValue,
+    }
+  }
+
+  return {
+    ok: true,
+    source,
+    target,
+  }
+}
+
+export function appendJwt(target: URL, jwt: string): string {
+  const url = new URL(target.toString())
+  url.searchParams.set('jwt', jwt)
+  return url.toString()
+}
+
+function extractCustomRedirectTarget(token: unknown): unknown {
+  if (!isRecord(token)) return undefined
+
+  const platformContext = token.platformContext
+  if (!isRecord(platformContext)) return undefined
+
+  const custom = platformContext.custom
+  if (!isRecord(custom)) return undefined
+
+  return custom[CUSTOM_REDIRECT_CLAIM_KEY]
+}
+
+function getAllowedDomains(): string[] {
+  return [process.env.COOKIE_DOMAIN, process.env.DF_DOMAIN]
+    .filter((domain): domain is string => typeof domain === 'string')
+    .map((domain) => normalizeDomain(domain))
+    .filter((domain) => domain.length > 0)
+}
+
+function normalizeDomain(domain: string): string {
+  return domain.trim().toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '')
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase().replace(/\.+$/, '')
+}
+
+function isAllowedHost(host: string, allowedDomains: string[]): boolean {
+  const normalizedHost = normalizeHost(host)
+  return allowedDomains.some(
+    (domain) =>
+      normalizedHost === domain || normalizedHost.endsWith(`.${domain}`)
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/apps/lti/src/launchTarget.ts
+++ b/apps/lti/src/launchTarget.ts
@@ -117,10 +117,18 @@ function extractCustomRedirectTarget(token: unknown): unknown {
 }
 
 function getAllowedDomains(): string[] {
-  return [process.env.COOKIE_DOMAIN, process.env.DF_DOMAIN]
+  const allowedDomains = [process.env.COOKIE_DOMAIN, process.env.DF_DOMAIN]
     .filter((domain): domain is string => typeof domain === 'string')
     .map((domain) => normalizeDomain(domain))
     .filter((domain) => domain.length > 0)
+
+  if (allowedDomains.length === 0) {
+    throw new Error(
+      'No allowed LTI redirect domains configured. Please set at least one of COOKIE_DOMAIN or DF_DOMAIN environment variables.'
+    )
+  }
+
+  return allowedDomains
 }
 
 function normalizeDomain(domain: string): string {

--- a/apps/lti/src/launchTarget.ts
+++ b/apps/lti/src/launchTarget.ts
@@ -72,6 +72,15 @@ export function validateLaunchTarget(
     }
   }
 
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    return {
+      ok: false,
+      source,
+      reason: 'invalid_url',
+      rawValue,
+    }
+  }
+
   const allowedDomains = getAllowedDomains()
   if (!isAllowedHost(target.hostname, allowedDomains)) {
     return {
@@ -115,11 +124,31 @@ function getAllowedDomains(): string[] {
 }
 
 function normalizeDomain(domain: string): string {
-  return domain.trim().toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '')
+  let normalized = domain.trim().toLowerCase()
+
+  while (normalized.startsWith('.')) {
+    normalized = normalized.slice(1)
+  }
+
+  while (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1)
+  }
+
+  return normalized
 }
 
 function normalizeHost(host: string): string {
-  return host.trim().toLowerCase().replace(/\.+$/, '')
+  let normalized = host.trim().toLowerCase()
+
+  while (normalized.startsWith('.')) {
+    normalized = normalized.slice(1)
+  }
+
+  while (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1)
+  }
+
+  return normalized
 }
 
 function isAllowedHost(host: string, allowedDomains: string[]): boolean {


### PR DESCRIPTION
## What changed
- Added claim-based launch target support via `klicker_redirect_to`.
- Preserved OLAT query-based routing via `redirectTo` (default path).
- Removed `LTI_REDIRECT_URL` as a runtime launch source in the resolver.
- Launch now fails with deterministic `400` when neither custom claim nor query target is provided.
- Kept strict hostname allowlist validation and safe JWT query injection.

## Why
- OLAT remains the primary/default integration path.
- Moodle system-tool routing is additive and does not require DB mappings.
- Missing launch target should be treated as a configuration error, not silently redirected.

## Compatibility
- Existing OLAT links continue working (`?redirectTo=...`).
- Moodle claim path works when configured (`klicker_redirect_to`).
- Deploy config key `LTI_REDIRECT_URL` may still exist, but is ignored by the resolver in this PR.

## Validation focus for CI/staging
1. Valid query target only (`redirectTo`) -> redirect with `jwt`.
2. Valid custom claim only (`klicker_redirect_to`) -> redirect with `jwt`.
3. Both custom and query present -> custom wins.
4. Missing custom and query -> `400 invalid_launch_target` + `missing_target`.
5. Invalid/disallowed host in query -> `400` and cookie cleared.
6. Invalid custom type/value -> `400` and cookie cleared.
7. Target with existing query params -> params preserved; `jwt` added/replaced.
8. `LTI_REDIRECT_URL` set but no custom/query -> still `400`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moodle and other LMSs supported for a system-wide LTI tool; configurable Klicker redirect parameter with defined precedence.
  * Resolved launch flow now appends a session token to validated targets and rejects invalid launches with a clear error.

* **Documentation**
  * Added configuration guide for Moodle/other LMSs and detailed launch-target rules: absolute URLs on allowed domains, strict validation, and rejection when no valid target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->