### PR TITLE
enhance(apps/lti): allow linking of existing credential-based user account with new LTI

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,4 +3,7 @@ version = 1
 name = "klicker-uzh"
 
 [setup]
-script = "pnpm install"
+script = '''
+pnpm install
+pnpm build
+'''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ Without Traefik, use `http://localhost:<port>` directly. The `*.klicker.com` dom
 - **PR review triage**: Copilot/CodeRabbit/SonarCloud flag many false positives. Always check if guards/fallbacks already exist before "fixing" reported issues. Confirm with the actual code, not the bot summary.
 - **agent-browser via npx**: Always use `npx agent-browser` instead of bare `agent-browser`. Global install conflicts with Volta's Node shim and fails with "Could not execute command".
 - **LTI launch target resolver contract**: Launch targets are resolved in strict precedence `custom claim (klicker_redirect_to)` -> `query redirectTo`; no env fallback is used in resolver logic. Validation fails closed on the first present invalid source and enforces URL hostname exact/subdomain checks against `COOKIE_DOMAIN` and `DF_DOMAIN` (never substring matching). (`apps/lti/src/launchTarget.ts`)
+- **Participant email uniqueness across auth modes**: Prisma enforces `Participant @@unique([email, isSSOAccount])`, so the same normalized email can exist once as manual and once as SSO. To block new cross-mode duplicates, account creation must explicitly check normalized email collisions in service logic. (`packages/graphql/src/services/accounts.ts`)
 
 ## Factory Skills (AI Assistance)
 

--- a/apps/frontend-pwa/src/lib/getParticipantToken.ts
+++ b/apps/frontend-pwa/src/lib/getParticipantToken.ts
@@ -152,6 +152,9 @@ export default async function getParticipantToken({
         domain: process.env.COOKIE_DOMAIN,
         path: '/',
       })
+    } else {
+      // LTI auth attempted but failed -- clear stale token to prevent session leakage
+      participantToken = null
     }
 
     return {

--- a/apps/frontend-pwa/src/lib/getParticipantToken.ts
+++ b/apps/frontend-pwa/src/lib/getParticipantToken.ts
@@ -125,9 +125,12 @@ export default async function getParticipantToken({
       }
     }
 
-    participantToken = result?.data?.loginParticipantWithLti?.participantToken
+    const ltiParticipantToken =
+      result?.data?.loginParticipantWithLti?.participantToken ?? null
 
-    if (participantToken) {
+    if (ltiParticipantToken) {
+      participantToken = ltiParticipantToken
+
       // set a proper participant_token
       nookies.set(ctx, 'participant_token', participantToken, {
         domain: process.env.COOKIE_DOMAIN,

--- a/apps/frontend-pwa/src/pages/createAccount.tsx
+++ b/apps/frontend-pwa/src/pages/createAccount.tsx
@@ -1,4 +1,5 @@
 import { signJWT, verifyJWT } from '@klicker-uzh/util'
+import { toast } from '@uzh-bf/design-system'
 import generatePassword from 'generate-password'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslations } from 'next-intl'
@@ -60,9 +61,10 @@ function CreateAccount({
             },
           })
 
-          if (login) {
-            const participantToken =
-              login.data?.createParticipantAccount?.participantToken ?? null
+          const createResult = login.data?.createParticipantAccount
+          const participantToken = createResult?.participantToken ?? null
+
+          if (participantToken) {
             await router.replace(
               `/editProfile?newAccount=true&participantToken=${participantToken}`,
               {
@@ -73,7 +75,23 @@ function CreateAccount({
                 },
               }
             )
+            return
           }
+
+          // keep legacy non-LTI behavior for direct /createAccount usage
+          if (!signedLtiData && createResult?.participant) {
+            await router.push({
+              pathname: '/login',
+              query: { newAccount: true },
+            })
+            return
+          }
+
+          toast({
+            type: 'error',
+            message: t('pwa.profile.createProfileFailed'),
+            options: { duration: 6000 },
+          })
 
           setSubmitting(false)
         }}

--- a/packages/graphql/src/services/accounts.ts
+++ b/packages/graphql/src/services/accounts.ts
@@ -562,6 +562,7 @@ interface ResolveOrCreateParticipantForLtiArgs {
   username?: string
   password?: string
   isProfilePublic?: boolean
+  courseId?: string
 }
 
 async function resolveOrCreateParticipantForLti(
@@ -571,20 +572,36 @@ async function resolveOrCreateParticipantForLti(
     username,
     password,
     isProfilePublic,
+    courseId,
   }: ResolveOrCreateParticipantForLtiArgs,
   ctx: Context
 ): Promise<ResolveOrCreateParticipantForLtiResult> {
-  return ctx.prisma.$transaction(async (prisma) => {
-    const ltiData = (await verifyJWT(
-      signedLtiData,
-      process.env.APP_SECRET as string
-    )) as {
-      email?: string
-      sub: string
-      scope: string
-    }
+  const ltiData = (await verifyJWT(
+    signedLtiData,
+    process.env.APP_SECRET as string
+  )) as {
+    email?: string
+    sub: string
+    scope: string
+  }
 
+  return ctx.prisma.$transaction(async (prisma) => {
     const normalizedEmail = normalizeEmail(ltiData.email)
+
+    const ensureParticipation = async (participantId: string) => {
+      if (courseId) {
+        await prisma.participation.upsert({
+          where: {
+            courseId_participantId: { courseId, participantId },
+          },
+          create: {
+            course: { connect: { id: courseId } },
+            participant: { connect: { id: participantId } },
+          },
+          update: {},
+        })
+      }
+    }
 
     const accountBySsoId = await prisma.participantAccount.findUnique({
       where: { ssoId: ltiData.sub },
@@ -604,6 +621,8 @@ async function resolveOrCreateParticipantForLti(
       console.info(
         `event=lti_linked_by_ssoid participantId=${account.participant.id} ssoType=${account.ssoType}`
       )
+
+      await ensureParticipation(account.participant.id)
 
       return {
         type: 'resolved',
@@ -655,6 +674,8 @@ async function resolveOrCreateParticipantForLti(
             `event=lti_linked_by_email participantId=${account.participant.id} ssoType=${account.ssoType} reusedSsoType=true`
           )
 
+          await ensureParticipation(account.participant.id)
+
           return {
             type: 'resolved',
             mode: 'linked_by_email',
@@ -679,6 +700,8 @@ async function resolveOrCreateParticipantForLti(
         console.info(
           `event=lti_linked_by_email participantId=${account.participant.id} ssoType=${account.ssoType} reusedSsoType=false`
         )
+
+        await ensureParticipation(account.participant.id)
 
         return {
           type: 'resolved',
@@ -740,6 +763,8 @@ async function resolveOrCreateParticipantForLti(
       `event=lti_created_new participantId=${account.participant.id} ssoType=${account.ssoType}`
     )
 
+    await ensureParticipation(account.participant.id)
+
     return {
       type: 'resolved',
       mode: 'created_new',
@@ -787,29 +812,16 @@ export async function createParticipantAccount(
         username,
         password,
         isProfilePublic,
+        courseId: courseId ?? undefined,
       },
       ctx
     )
-    if (resolved.type !== 'resolved') return null
+    if (resolved.type !== 'resolved') {
+      console.warn(`event=lti_create_account_failed type=${resolved.type}`)
+      return null
+    }
 
     const account = resolved.account
-
-    // if a courseId is specified, add a participation in the corresponding course
-    if (courseId) {
-      await ctx.prisma.participation.upsert({
-        where: {
-          courseId_participantId: {
-            courseId,
-            participantId: account.participant.id,
-          },
-        },
-        create: {
-          course: { connect: { id: courseId } },
-          participant: { connect: { id: account.participant.id } },
-        },
-        update: {},
-      })
-    }
 
     try {
       const jwt = await doParticipantLogin(
@@ -958,29 +970,17 @@ export async function loginParticipantWithLti(
     {
       signedLtiData,
       allowCreate: false,
+      courseId: courseId ?? undefined,
     },
     ctx
   )
 
-  if (resolved.type !== 'resolved') return null
+  if (resolved.type !== 'resolved') {
+    console.warn(`event=lti_login_failed type=${resolved.type}`)
+    return null
+  }
 
   const account = resolved.account
-
-  if (courseId) {
-    await ctx.prisma.participation.upsert({
-      where: {
-        courseId_participantId: {
-          courseId,
-          participantId: account.participant.id,
-        },
-      },
-      create: {
-        course: { connect: { id: courseId } },
-        participant: { connect: { id: account.participant.id } },
-      },
-      update: {},
-    })
-  }
 
   const jwt = await doParticipantLogin(
     {

--- a/packages/graphql/src/services/accounts.ts
+++ b/packages/graphql/src/services/accounts.ts
@@ -3,6 +3,7 @@ import { DisplayMode } from '@klicker-uzh/types'
 import {
   getInitialInstanceResults,
   getInitialInstanceStatistics,
+  normalizeEmail,
   processElementData,
   recomputeDerivedPermissions,
   signJWT,
@@ -540,6 +541,213 @@ export async function deleteParticipantAccount(ctx: ContextWithUser) {
   return true
 }
 
+type ResolveOrCreateParticipantForLtiResult =
+  | {
+      type: 'resolved'
+      mode: 'linked_by_ssoid' | 'linked_by_email' | 'created_new'
+      account: DB.ParticipantAccount & { participant: DB.Participant }
+    }
+  | {
+      type:
+        | 'conflict_duplicate_email'
+        | 'missing_email'
+        | 'not_found'
+        | 'username_taken'
+        | 'invalid_create_input'
+    }
+
+interface ResolveOrCreateParticipantForLtiArgs {
+  signedLtiData: string
+  allowCreate: boolean
+  username?: string
+  password?: string
+  isProfilePublic?: boolean
+}
+
+async function resolveOrCreateParticipantForLti(
+  {
+    signedLtiData,
+    allowCreate,
+    username,
+    password,
+    isProfilePublic,
+  }: ResolveOrCreateParticipantForLtiArgs,
+  ctx: Context
+): Promise<ResolveOrCreateParticipantForLtiResult> {
+  return ctx.prisma.$transaction(async (prisma) => {
+    const ltiData = (await verifyJWT(
+      signedLtiData,
+      process.env.APP_SECRET as string
+    )) as {
+      email?: string
+      sub: string
+      scope: string
+    }
+
+    const normalizedEmail = normalizeEmail(ltiData.email)
+
+    const accountBySsoId = await prisma.participantAccount.findUnique({
+      where: { ssoId: ltiData.sub },
+      include: { participant: true },
+    })
+
+    if (accountBySsoId) {
+      const account =
+        normalizedEmail && accountBySsoId.ssoEmail !== normalizedEmail
+          ? await prisma.participantAccount.update({
+              where: { id: accountBySsoId.id },
+              data: { ssoEmail: normalizedEmail },
+              include: { participant: true },
+            })
+          : accountBySsoId
+
+      console.info(
+        `event=lti_linked_by_ssoid participantId=${account.participant.id} ssoType=${account.ssoType}`
+      )
+
+      return {
+        type: 'resolved',
+        mode: 'linked_by_ssoid',
+        account,
+      }
+    }
+
+    if (normalizedEmail) {
+      const matchedParticipants = await prisma.participant.findMany({
+        where: { email: normalizedEmail },
+      })
+
+      if (matchedParticipants.length > 1) {
+        console.warn(
+          `event=lti_conflict_duplicate_email normalizedEmail=${normalizedEmail} matches=${matchedParticipants.length}`
+        )
+        return { type: 'conflict_duplicate_email' }
+      }
+
+      if (matchedParticipants.length === 1) {
+        const participant = matchedParticipants[0]!
+
+        const accountForSsoType = await prisma.participantAccount.findUnique({
+          where: {
+            participantId_ssoType: {
+              participantId: participant.id,
+              ssoType: ltiData.scope,
+            },
+          },
+          include: { participant: true },
+        })
+
+        if (accountForSsoType) {
+          const account =
+            accountForSsoType.ssoId !== ltiData.sub ||
+            accountForSsoType.ssoEmail !== normalizedEmail
+              ? await prisma.participantAccount.update({
+                  where: { id: accountForSsoType.id },
+                  data: {
+                    ssoId: ltiData.sub,
+                    ssoEmail: normalizedEmail,
+                  },
+                  include: { participant: true },
+                })
+              : accountForSsoType
+
+          console.info(
+            `event=lti_linked_by_email participantId=${account.participant.id} ssoType=${account.ssoType} reusedSsoType=true`
+          )
+
+          return {
+            type: 'resolved',
+            mode: 'linked_by_email',
+            account,
+          }
+        }
+
+        const account = await prisma.participantAccount.create({
+          data: {
+            ssoId: ltiData.sub,
+            ssoType: ltiData.scope,
+            ssoEmail: normalizedEmail,
+            participant: {
+              connect: {
+                id: participant.id,
+              },
+            },
+          },
+          include: { participant: true },
+        })
+
+        console.info(
+          `event=lti_linked_by_email participantId=${account.participant.id} ssoType=${account.ssoType} reusedSsoType=false`
+        )
+
+        return {
+          type: 'resolved',
+          mode: 'linked_by_email',
+          account,
+        }
+      }
+    }
+
+    if (!allowCreate) {
+      return normalizedEmail ? { type: 'not_found' } : { type: 'missing_email' }
+    }
+
+    if (!normalizedEmail) {
+      return { type: 'missing_email' }
+    }
+
+    if (!username || !password || typeof isProfilePublic !== 'boolean') {
+      return { type: 'invalid_create_input' }
+    }
+
+    const trimmedUsername = username.trim()
+    const existingUsername = await prisma.participant.findUnique({
+      where: { username: trimmedUsername },
+      select: { id: true },
+    })
+
+    if (existingUsername) {
+      return { type: 'username_taken' }
+    }
+
+    const participant = await prisma.participant.create({
+      data: {
+        email: normalizedEmail,
+        username: trimmedUsername,
+        password: await bcrypt.hash(password, 10),
+        isEmailValid: true,
+        isProfilePublic,
+        isSSOAccount: true,
+        lastLoginAt: new Date(),
+      },
+    })
+
+    const account = await prisma.participantAccount.create({
+      data: {
+        ssoId: ltiData.sub,
+        ssoType: ltiData.scope,
+        ssoEmail: normalizedEmail,
+        participant: {
+          connect: {
+            id: participant.id,
+          },
+        },
+      },
+      include: { participant: true },
+    })
+
+    console.info(
+      `event=lti_created_new participantId=${account.participant.id} ssoType=${account.ssoType}`
+    )
+
+    return {
+      type: 'resolved',
+      mode: 'created_new',
+      account,
+    }
+  })
+}
+
 interface CreateParticipantAccountArgs {
   email: string
   username: string
@@ -572,71 +780,36 @@ export async function createParticipantAccount(
   }
 
   if (signedLtiData) {
-    const account = await ctx.prisma.$transaction(async (prisma) => {
-      const ltiData = (await verifyJWT(
+    const resolved = await resolveOrCreateParticipantForLti(
+      {
         signedLtiData,
-        process.env.APP_SECRET as string
-      )) as { email: string; sub: string; scope: 'LTI1.1' | 'LTI1.3' }
-      // check if the username is already taken by another user
-      const existingUser = await prisma.participant.findMany({
+        allowCreate: true,
+        username,
+        password,
+        isProfilePublic,
+      },
+      ctx
+    )
+    if (resolved.type !== 'resolved') return null
+
+    const account = resolved.account
+
+    // if a courseId is specified, add a participation in the corresponding course
+    if (courseId) {
+      await ctx.prisma.participation.upsert({
         where: {
-          OR: [{ username: username.trim() }, { email: ltiData.email }],
-        },
-      })
-
-      if (existingUser.length > 0) {
-        // another user already uses the requested username or email, returning old user
-        return null
-      }
-
-      const account = await prisma.participantAccount.create({
-        data: {
-          ssoId: ltiData.sub,
-          ssoType: ltiData.scope,
-          participant: {
-            connectOrCreate: {
-              where: {
-                email_isSSOAccount: {
-                  email: ltiData.email.toLowerCase(),
-                  isSSOAccount: true,
-                },
-              },
-              create: {
-                email: ltiData.email.toLowerCase(),
-                username: username.trim(),
-                password: await bcrypt.hash(password, 10),
-                isEmailValid: true,
-                isProfilePublic,
-                isSSOAccount: true,
-                lastLoginAt: new Date(),
-              },
-            },
+          courseId_participantId: {
+            courseId,
+            participantId: account.participant.id,
           },
         },
-        include: { participant: true },
+        create: {
+          course: { connect: { id: courseId } },
+          participant: { connect: { id: account.participant.id } },
+        },
+        update: {},
       })
-
-      // if a courseId is specified, add a participation in the corresponding course
-      if (courseId) {
-        await prisma.participation.upsert({
-          where: {
-            courseId_participantId: {
-              courseId,
-              participantId: account.participant.id,
-            },
-          },
-          create: {
-            course: { connect: { id: courseId } },
-            participant: { connect: { id: account.participant.id } },
-          },
-          update: {},
-        })
-      }
-
-      return account
-    })
-
-    if (!account) return null
+    }
 
     try {
       const jwt = await doParticipantLogin(
@@ -657,11 +830,25 @@ export async function createParticipantAccount(
     }
   }
 
+  const normalizedEmail = normalizeEmail(email)
+  if (!normalizedEmail) return null
+
+  const existingParticipantWithEmail = await ctx.prisma.participant.findFirst({
+    where: {
+      email: normalizedEmail,
+    },
+    select: { id: true },
+  })
+
+  if (existingParticipantWithEmail) {
+    return null
+  }
+
   try {
     const participant = await ctx.prisma.$transaction(async (prisma) => {
       const participant = await prisma.participant.create({
         data: {
-          email: email.trim().toLowerCase(),
+          email: normalizedEmail,
           username: username.trim(),
           password: await bcrypt.hash(password, 10),
           isEmailValid: false,
@@ -690,6 +877,8 @@ export async function createParticipantAccount(
 
       return participant
     })
+
+    if (!participant) return null
 
     const activationJWT = await signJWT(
       {
@@ -765,57 +954,20 @@ export async function loginParticipantWithLti(
     }
   }
 
-  const ltiData = (await verifyJWT(
-    signedLtiData,
-    process.env.APP_SECRET as string
-  )) as {
-    sub: string
-    email?: string
-    scope: string
-  }
+  const resolved = await resolveOrCreateParticipantForLti(
+    {
+      signedLtiData,
+      allowCreate: false,
+    },
+    ctx
+  )
 
-  console.log('ltiData', ltiData)
+  if (resolved.type !== 'resolved') return null
 
-  let account = await ctx.prisma.participantAccount.findUnique({
-    where: { ssoId: ltiData.sub as string },
-    include: { participant: true },
-  })
-
-  console.log('account', account)
-
-  // check if there is a participant account already given the email address
-  // if so, create a new participant account with the LTI data and new sub
-  if (!account && ltiData.email) {
-    const existingParticipant = await ctx.prisma.participant.findUnique({
-      where: {
-        email_isSSOAccount: { email: ltiData.email, isSSOAccount: true },
-      },
-    })
-
-    console.log('existingParticipant', existingParticipant)
-
-    if (!existingParticipant) {
-      return null
-    }
-
-    account = await ctx.prisma.participantAccount.create({
-      data: {
-        ssoId: ltiData.sub,
-        ssoType: ltiData.scope,
-        participant: {
-          connect: {
-            id: existingParticipant.id,
-          },
-        },
-      },
-      include: { participant: true },
-    })
-  }
-
-  if (!account?.participant) return null
+  const account = resolved.account
 
   if (courseId) {
-    const participation = await ctx.prisma.participation.upsert({
+    await ctx.prisma.participation.upsert({
       where: {
         courseId_participantId: {
           courseId,
@@ -828,8 +980,6 @@ export async function loginParticipantWithLti(
       },
       update: {},
     })
-
-    console.log('participation', participation)
   }
 
   const jwt = await doParticipantLogin(

--- a/packages/graphql/test/accountLtiLinking.test.ts
+++ b/packages/graphql/test/accountLtiLinking.test.ts
@@ -122,6 +122,7 @@ async function createTestCourse() {
     data: {
       name: `${TEST_PREFIX}-course`,
       displayName: 'Test Course',
+      pinCode: 123456,
       startDate: now,
       endDate: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
       groupDeadlineDate: new Date(now.getTime() + 180 * 24 * 60 * 60 * 1000),

--- a/packages/graphql/test/accountLtiLinking.test.ts
+++ b/packages/graphql/test/accountLtiLinking.test.ts
@@ -76,6 +76,12 @@ async function cleanupTestData() {
 
   const participantIds = participants.map((participant) => participant.id)
 
+  if (participantIds.length > 0) {
+    await prisma.participation.deleteMany({
+      where: { participantId: { in: participantIds } },
+    })
+  }
+
   await prisma.participantAccount.deleteMany({
     where:
       participantIds.length > 0
@@ -93,6 +99,37 @@ async function cleanupTestData() {
       where: { id: { in: participantIds } },
     })
   }
+
+  await prisma.course.deleteMany({
+    where: { name: { startsWith: TEST_PREFIX } },
+  })
+
+  await prisma.user.deleteMany({
+    where: { email: { startsWith: TEST_PREFIX } },
+  })
+}
+
+async function createTestCourse() {
+  const user = await prisma.user.create({
+    data: {
+      email: `${TEST_PREFIX}-owner@example.com`,
+      shortname: TEST_PREFIX.slice(0, 10),
+    },
+  })
+
+  const now = new Date()
+  const course = await prisma.course.create({
+    data: {
+      name: `${TEST_PREFIX}-course`,
+      displayName: 'Test Course',
+      startDate: now,
+      endDate: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
+      groupDeadlineDate: new Date(now.getTime() + 180 * 24 * 60 * 60 * 1000),
+      owner: { connect: { id: user.id } },
+    },
+  })
+
+  return { user, course }
 }
 
 describe('LTI participant linking and creation', () => {
@@ -246,6 +283,81 @@ describe('LTI participant linking and creation', () => {
       where: { ssoId: ssoIdFor('ambiguous') },
     })
     expect(account).toBeNull()
+  })
+
+  it('creates participation when courseId is provided during LTI login', async () => {
+    const { course } = await createTestCourse()
+
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('participation'),
+        username: usernameFor('participation'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('participation'),
+      email: emailFor('participation'),
+    })
+
+    const result = await loginParticipantWithLti(
+      { signedLtiData, courseId: course.id },
+      createCtx()
+    )
+
+    expect(result?.participant?.id).toBe(participant.id)
+
+    const participation = await prisma.participation.findUnique({
+      where: {
+        courseId_participantId: {
+          courseId: course.id,
+          participantId: participant.id,
+        },
+      },
+    })
+    expect(participation).not.toBeNull()
+  })
+
+  it('reuses existing ParticipantAccount when same ssoType but different ssoId matches by email', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('reuse-sso'),
+        username: usernameFor('reuse-sso'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+      },
+    })
+
+    const firstAccount = await prisma.participantAccount.create({
+      data: {
+        ssoId: ssoIdFor('reuse-sso-old'),
+        ssoType: 'LTI1.3',
+        ssoEmail: emailFor('reuse-sso'),
+        participant: { connect: { id: participant.id } },
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('reuse-sso-new'),
+      email: emailFor('reuse-sso'),
+      scope: 'LTI1.3',
+    })
+
+    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(result?.participant?.id).toBe(participant.id)
+
+    const updatedAccount = await prisma.participantAccount.findUnique({
+      where: { id: firstAccount.id },
+    })
+    expect(updatedAccount?.ssoId).toBe(ssoIdFor('reuse-sso-new'))
+
+    const allAccounts = await prisma.participantAccount.findMany({
+      where: { participantId: participant.id, ssoType: 'LTI1.3' },
+    })
+    expect(allAccounts).toHaveLength(1)
   })
 
   it('rejects non-LTI account creation when email already exists in another auth mode', async () => {

--- a/packages/graphql/test/accountLtiLinking.test.ts
+++ b/packages/graphql/test/accountLtiLinking.test.ts
@@ -1,0 +1,278 @@
+import { prisma as prismaClient } from '@klicker-uzh/prisma'
+import { PrismaClient } from '@klicker-uzh/prisma/client'
+import { signJWT } from '@klicker-uzh/util'
+import bcrypt from 'bcryptjs'
+import { EventEmitter } from 'events'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import type { Context } from '../src/lib/context.js'
+import {
+  createParticipantAccount,
+  loginParticipantWithLti,
+} from '../src/services/accounts.js'
+
+const TEST_PREFIX = `codex-lti-${Date.now()}`
+const emailFor = (label: string) => `${TEST_PREFIX}-${label}@example.com`
+const usernameFor = (label: string) => `${TEST_PREFIX}-${label}`.slice(0, 48)
+const ssoIdFor = (label: string) => `${TEST_PREFIX}-${label}`
+
+let prisma: PrismaClient
+
+function createCtx(): Context {
+  return {
+    prisma: prisma as any,
+    req: { locals: {} } as any,
+    res: { cookie: vi.fn() } as any,
+    redisExec: {} as any,
+    redisAssessmentExec: {} as any,
+    pubSub: {} as any,
+    emitter: new EventEmitter(),
+    hatchet: {} as any,
+    tasks: {} as any,
+  } as Context
+}
+
+async function createSignedLtiData({
+  sub,
+  email,
+  scope = 'LTI1.3',
+}: {
+  sub: string
+  email?: string
+  scope?: 'LTI1.1' | 'LTI1.3'
+}) {
+  return signJWT(
+    {
+      sub,
+      email,
+      scope,
+    },
+    process.env.APP_SECRET as string,
+    {
+      algorithm: 'HS256',
+      expiresIn: '5m',
+      issuer: process.env.APP_ORIGIN_PWA,
+    }
+  )
+}
+
+async function cleanupTestData() {
+  const participants = await prisma.participant.findMany({
+    where: {
+      OR: [
+        { username: { startsWith: TEST_PREFIX } },
+        { email: { startsWith: TEST_PREFIX } },
+      ],
+    },
+    select: { id: true },
+  })
+
+  const participantIds = participants.map((participant) => participant.id)
+
+  await prisma.participantAccount.deleteMany({
+    where:
+      participantIds.length > 0
+        ? {
+            OR: [
+              { participantId: { in: participantIds } },
+              { ssoId: { startsWith: TEST_PREFIX } },
+            ],
+          }
+        : { ssoId: { startsWith: TEST_PREFIX } },
+  })
+
+  if (participantIds.length > 0) {
+    await prisma.participant.deleteMany({
+      where: { id: { in: participantIds } },
+    })
+  }
+}
+
+describe('LTI participant linking and creation', () => {
+  beforeAll(async () => {
+    process.env.APP_SECRET = process.env.APP_SECRET ?? 'test-app-secret'
+    process.env.APP_ORIGIN_API =
+      process.env.APP_ORIGIN_API ?? 'https://api.klicker.test'
+    process.env.APP_ORIGIN_PWA =
+      process.env.APP_ORIGIN_PWA ?? 'https://pwa.klicker.test'
+
+    prisma = prismaClient
+    await prisma.$connect()
+    await cleanupTestData()
+  }, 60000)
+
+  afterEach(async () => {
+    await cleanupTestData()
+  })
+
+  afterAll(async () => {
+    await cleanupTestData()
+    await prisma.$disconnect()
+  }, 60000)
+
+  it('links an existing manual participant to first-time LTI launch on exact normalized email match', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('manual-link'),
+        username: usernameFor('manual-link'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('manual-link'),
+      email: emailFor('manual-link').toUpperCase(),
+    })
+
+    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(result?.participant?.id).toBe(participant.id)
+    expect(result?.participantToken).toBeDefined()
+
+    const linkedAccount = await prisma.participantAccount.findUnique({
+      where: { ssoId: ssoIdFor('manual-link') },
+    })
+    expect(linkedAccount?.participantId).toBe(participant.id)
+    expect(linkedAccount?.ssoEmail).toBe(emailFor('manual-link'))
+
+    const unchangedParticipant = await prisma.participant.findUnique({
+      where: { id: participant.id },
+    })
+    expect(unchangedParticipant?.isSSOAccount).toBe(false)
+  })
+
+  it('is idempotent on repeated LTI launches with the same ssoId', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('idempotent'),
+        username: usernameFor('idempotent'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('idempotent'),
+      email: emailFor('idempotent'),
+    })
+
+    const first = await loginParticipantWithLti({ signedLtiData }, createCtx())
+    const second = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(first?.participant?.id).toBe(participant.id)
+    expect(second?.participant?.id).toBe(participant.id)
+
+    const accounts = await prisma.participantAccount.findMany({
+      where: { ssoId: ssoIdFor('idempotent') },
+    })
+    expect(accounts).toHaveLength(1)
+  })
+
+  it('returns null for LTI login when no existing participant can be matched and auto-create is disabled', async () => {
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('no-match'),
+      email: emailFor('no-match'),
+    })
+
+    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(result).toBeNull()
+  })
+
+  it('creates a new SSO participant from LTI create flow when no match exists', async () => {
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('create-new'),
+      email: emailFor('create-new'),
+    })
+
+    const result = await createParticipantAccount(
+      {
+        email: emailFor('unused'),
+        username: usernameFor('create-new'),
+        password: 'password123',
+        isProfilePublic: true,
+        signedLtiData,
+      },
+      createCtx()
+    )
+
+    expect(result?.participantToken).toBeDefined()
+    expect(result?.participant?.email).toBe(emailFor('create-new'))
+    expect(result?.participant?.isSSOAccount).toBe(true)
+
+    const account = await prisma.participantAccount.findUnique({
+      where: { ssoId: ssoIdFor('create-new') },
+      include: { participant: true },
+    })
+    expect(account?.participant.email).toBe(emailFor('create-new'))
+  })
+
+  it('fails closed on ambiguous duplicate normalized email matches across auth modes', async () => {
+    await prisma.participant.create({
+      data: {
+        email: emailFor('ambiguous'),
+        username: usernameFor('ambiguous-manual'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+      },
+    })
+    await prisma.participant.create({
+      data: {
+        email: emailFor('ambiguous'),
+        username: usernameFor('ambiguous-sso'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: true,
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('ambiguous'),
+      email: emailFor('ambiguous'),
+    })
+
+    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(result).toBeNull()
+
+    const account = await prisma.participantAccount.findUnique({
+      where: { ssoId: ssoIdFor('ambiguous') },
+    })
+    expect(account).toBeNull()
+  })
+
+  it('rejects non-LTI account creation when email already exists in another auth mode', async () => {
+    await prisma.participant.create({
+      data: {
+        email: emailFor('cross-mode'),
+        username: usernameFor('cross-mode-existing'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: true,
+      },
+    })
+
+    const result = await createParticipantAccount(
+      {
+        email: emailFor('cross-mode').toUpperCase(),
+        username: usernameFor('cross-mode-new'),
+        password: 'password123',
+        isProfilePublic: true,
+      },
+      createCtx()
+    )
+
+    expect(result).toBeNull()
+
+    const created = await prisma.participant.findUnique({
+      where: { username: usernameFor('cross-mode-new') },
+    })
+    expect(created).toBeNull()
+  })
+})

--- a/packages/i18n/messages/de.ts
+++ b/packages/i18n/messages/de.ts
@@ -928,6 +928,8 @@ Da die KlickerUZH-App noch nicht im iOS-App-Store verfügbar ist, folgen Sie die
       editProfile: 'Profil editieren',
       editProfileFailed:
         'Leider ist beim Speichern der Änderungen ein Fehler aufgetreten. Möglicherweise ist der von Ihnen gewählte Nutzername bereits vergeben. Bitte überprüfen Sie Ihre Eingaben und versuchen es nochmal.',
+      createProfileFailed:
+        'Leider konnte Ihr Konto nicht erstellt oder verknüpft werden. Bitte überprüfen Sie Ihre Eingaben und versuchen Sie es erneut.',
       editProfileSuccess: 'Ihr Profil wurde erfolgreich aktualisiert.',
       achievements: 'Errungenschaften',
       myProfile: 'Mein Profil',

--- a/packages/i18n/messages/en.ts
+++ b/packages/i18n/messages/en.ts
@@ -926,6 +926,8 @@ Since the KlickerUZH app is not yet available in the iOS App Store, follow these
       editProfile: 'Edit profile',
       editProfileFailed:
         'Unfortunately, an error occurred while saving the changes. The username you have chosen may already be taken. Please check your entries and try again.',
+      createProfileFailed:
+        'Unfortunately, your account could not be created or linked. Please check your entries and try again.',
       editProfileSuccess: 'Your profile has been updated successfully.',
       achievements: 'Achievements',
       myProfile: 'My Profile',

--- a/packages/prisma-data/src/scripts/2026-02-17_report_participant_email_duplicates.ts
+++ b/packages/prisma-data/src/scripts/2026-02-17_report_participant_email_duplicates.ts
@@ -1,0 +1,119 @@
+import { prisma } from '@klicker-uzh/prisma'
+import { normalizeEmail } from '@klicker-uzh/util'
+
+interface ParticipantDuplicateReportEntry {
+  participantId: string
+  username: string
+  isSSOAccount: boolean
+  lastLoginAt: string | null
+  participationCount: number
+  accounts: Array<{
+    ssoType: string
+    ssoId: string
+    ssoEmail: string | null
+  }>
+}
+
+interface DuplicateGroupReport {
+  normalizedEmail: string
+  participants: ParticipantDuplicateReportEntry[]
+}
+
+async function run() {
+  const participants = await prisma.participant.findMany({
+    select: {
+      id: true,
+      email: true,
+      username: true,
+      isSSOAccount: true,
+      lastLoginAt: true,
+      participations: {
+        select: { id: true },
+      },
+      accounts: {
+        select: {
+          ssoType: true,
+          ssoId: true,
+          ssoEmail: true,
+        },
+        orderBy: {
+          ssoType: 'asc',
+        },
+      },
+    },
+  })
+
+  const groups = new Map<string, typeof participants>()
+
+  for (const participant of participants) {
+    const normalizedEmail = normalizeEmail(participant.email ?? undefined)
+    if (!normalizedEmail) continue
+
+    const existing = groups.get(normalizedEmail) ?? []
+    existing.push(participant)
+    groups.set(normalizedEmail, existing)
+  }
+
+  const duplicateGroups: DuplicateGroupReport[] = []
+
+  for (const [normalizedEmail, groupedParticipants] of groups.entries()) {
+    if (groupedParticipants.length < 2) continue
+
+    duplicateGroups.push({
+      normalizedEmail,
+      participants: groupedParticipants.map((participant) => ({
+        participantId: participant.id,
+        username: participant.username,
+        isSSOAccount: participant.isSSOAccount,
+        lastLoginAt: participant.lastLoginAt?.toISOString() ?? null,
+        participationCount: participant.participations.length,
+        accounts: participant.accounts.map((account) => ({
+          ssoType: account.ssoType,
+          ssoId: account.ssoId,
+          ssoEmail: account.ssoEmail ?? null,
+        })),
+      })),
+    })
+  }
+
+  duplicateGroups.sort((a, b) =>
+    a.normalizedEmail.localeCompare(b.normalizedEmail)
+  )
+
+  console.log(
+    `Found ${duplicateGroups.length} normalized email(s) with duplicate participant records.`
+  )
+
+  for (const duplicateGroup of duplicateGroups) {
+    console.log(
+      `\n[${duplicateGroup.normalizedEmail}] participants=${duplicateGroup.participants.length}`
+    )
+
+    for (const participant of duplicateGroup.participants) {
+      console.log(
+        `- participantId=${participant.participantId} username=${participant.username} isSSOAccount=${participant.isSSOAccount} lastLoginAt=${participant.lastLoginAt ?? 'null'} participations=${participant.participationCount}`
+      )
+
+      if (participant.accounts.length === 0) {
+        console.log('  accounts: none')
+        continue
+      }
+
+      for (const account of participant.accounts) {
+        console.log(
+          `  account: ssoType=${account.ssoType} ssoId=${account.ssoId} ssoEmail=${account.ssoEmail ?? 'null'}`
+        )
+      }
+    }
+  }
+
+  console.log('\nJSON_REPORT_START')
+  console.log(JSON.stringify(duplicateGroups, null, 2))
+  console.log('JSON_REPORT_END')
+}
+
+try {
+  await run()
+} finally {
+  await prisma.$disconnect()
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved LTI-based account linking/creation and course participation linking
  * Updated participant-token handling and redirect flows after account creation

* **Bug Fixes**
  * Enhanced email collision detection across authentication modes
  * Better user-facing errors for conflicting accounts and failed profile creation

* **Tests**
  * New test suite covering LTI participant linking and creation scenarios

* **Documentation**
  * Added guidance on participant email uniqueness across auth modes

* **Chores**
  * Environment setup now runs install + build
  * Added duplicate-email reporting script and new i18n entries (EN/DE)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->