### PR TITLE
chore(deploy): route chat through shared litellm aliases

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -190,7 +190,7 @@ chat:
   priorityClassName: production-workload
 
   openai:
-    baseUrl: 'http://litellm:4000/v1'
+    baseUrl: 'http://litellm.prd-litellm.svc.cluster.local:4000/v1'
 
   replicaCount: 1
 
@@ -198,12 +198,12 @@ chat:
     enabled: false
 
   automaticModels:
-    primaryId: gpt-4.1
+    primaryId: gpt-5.1
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
     - id: gpt-4.1
-      deploymentId: gpt-4.1
+      deploymentId: klickeruzh/azure/gpt-4.1
       name: GPT-4.1
       description: OpenAI model
       fallback: false
@@ -211,7 +211,7 @@ chat:
         input: 2.0
         output: 8.0
     - id: gpt-5.1
-      deploymentId: gpt-5.1
+      deploymentId: klickeruzh/azure/gpt-5.1
       name: GPT-5.1
       description: OpenAI reasoning model
       fallback: false
@@ -219,7 +219,7 @@ chat:
         input: 1.25
         output: 10.0
     - id: gpt-4.1-mini
-      deploymentId: gpt-4.1-mini
+      deploymentId: klickeruzh/azure/gpt-4.1-mini
       name: GPT-4.1 Mini
       description: Small OpenAI model
       fallback: true

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -152,15 +152,15 @@ chat:
   priorityClassName: staging-workload
 
   openai:
-    baseUrl: 'http://litellm:4000/v1'
+    baseUrl: 'http://litellm.stg-litellm.svc.cluster.local:4000/v1'
 
   automaticModels:
-    primaryId: gpt-4.1
+    primaryId: gpt-5.1
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
     - id: gpt-4.1
-      deploymentId: gpt-4.1
+      deploymentId: klickeruzh/azure/gpt-4.1
       name: GPT-4.1
       description: OpenAI model
       fallback: false
@@ -168,7 +168,7 @@ chat:
         input: 2.0
         output: 8.0
     - id: gpt-5.1
-      deploymentId: gpt-5.1
+      deploymentId: klickeruzh/azure/gpt-5.1
       name: GPT-5.1
       description: OpenAI reasoning model
       fallback: false
@@ -176,7 +176,7 @@ chat:
         input: 1.25
         output: 10.0
     - id: gpt-4.1-mini
-      deploymentId: gpt-4.1-mini
+      deploymentId: klickeruzh/azure/gpt-4.1-mini
       name: GPT-4.1 Mini
       description: Small OpenAI model
       fallback: true


### PR DESCRIPTION
## Summary
- point the chat app at the shared LiteLLM service using the verified cross-namespace FQDNs for staging and production
- keep only the three approved Klicker-facing model IDs while routing their `deploymentId` values to the shared LiteLLM aliases
- update automatic model selection to use `gpt-5.1` as primary and `gpt-4.1-mini` as fallback

## Test Plan
- [x] `helm template app-klicker deploy/charts/klicker-uzh-v3 -f deploy/env-uzh-stg/values.yaml | rg -n \"OPENAI_BASE_URL|CHAT_MODEL_REGISTRY_JSON|CHAT_PRIMARY_MODEL_ID|CHAT_FALLBACK_MODEL_ID|app-klicker-klicker-uzh-v2-config-chat|klickeruzh/azure/\"`
- [x] `helm template app-klicker deploy/charts/klicker-uzh-v3 -f deploy/env-uzh-prd/values.yaml | rg -n \"OPENAI_BASE_URL|CHAT_MODEL_REGISTRY_JSON|CHAT_PRIMARY_MODEL_ID|CHAT_FALLBACK_MODEL_ID|app-klicker-klicker-uzh-v2-config-chat|klickeruzh/azure/\"`