### PR TITLE
fix(cypress): stabilize local cypress seed + F-elements-sc typing

### DIFF
--- a/cypress/cypress/e2e/F-elements-sc-workflow.cy.ts
+++ b/cypress/cypress/e2e/F-elements-sc-workflow.cy.ts
@@ -185,7 +185,7 @@ describe('Test creation and editing functionalities, validation, etc. for Single
       cy.get('[data-cy="save-new-question"]').should('be.disabled')
       cy.get(`[data-cy="insert-answer-feedback-${ix}"]`)
         .realClick()
-        .type(feedback)
+        .realType(feedback)
       cy.get(`[data-cy="insert-answer-feedback-${ix}"]`).contains(feedback)
     })
     cy.get('[data-cy="save-new-question"]').should('not.be.disabled')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,13 @@ services:
       POSTGRES_USER: klicker-prod
       POSTGRES_PASSWORD: klicker
       POSTGRES_DB: klicker-prod
+    command:
+      - 'postgres'
+      # Auto-kill sessions stuck "idle in transaction" after 5 minutes.
+      # Prevents cascading cypress failures when a run is interrupted mid-seed
+      # and leaves a BEGIN transaction holding locks on klicker-prod.
+      - '-c'
+      - 'idle_in_transaction_session_timeout=300000'
     ports:
       - 5432:5432
     networks:
@@ -264,7 +271,11 @@ services:
       - './util/litellm/config.yaml:/app/config.yaml'
     command: ['--config', '/app/config.yaml', '--port', '4000']
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:4000/health/liveliness']
+      test:
+        - 'CMD'
+        - 'python'
+        - '-c'
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:4000/health/liveliness').status == 200 else 1)"
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

Three local-dev fixes that unblock `pnpm run start:test` after cascading postgres
lock contention from interrupted cypress seed runs. CI and staging/prod are unaffected.

- **`docker-compose.yml` (litellm healthcheck)** — the `ghcr.io/berriai/litellm-database`
  image ships without `curl`, so the `curl -f ...` healthcheck added in #5036 left the
  container permanently `unhealthy` (`FailingStreak > 90`). Replaced with a python
  one-liner (python is already in the image). Verified healthy locally.
- **`docker-compose.yml` (postgres idle timeout)** — set
  `idle_in_transaction_session_timeout=5min` on the local postgres. The cypress
  `seedDatabase` task uses `prisma.$transaction([...])` with many upserts; if a run is
  interrupted (Ctrl+C, crash, retry race) the `BEGIN` transaction stays
  `idle in transaction` forever because the default is unlimited. Those zombie
  transactions hold locks and the next run's seed fails with `Transaction API error:
  Unable to start a transaction in the given time`. 5 minutes auto-heals leaks without
  affecting legitimate Prisma/Hatchet transactions.
- **`F-elements-sc-workflow.cy.ts:188`** — change `.type(feedback)` to
  `.realType(feedback)` so the whole "Edit SC question and add answer feedbacks" test
  consistently uses `cypress-real-events` CDP input, matching the same pattern already
  used on lines 200 and 204. Pure consistency fix — `.type()` synthesizes keyboard
  events that occasionally race Slate's `onChange` before the `.contains()` assertion.

## Local verification

- Three fixes applied; diff only touches `docker-compose.yml` and one cypress test line.
- `docker compose up -d --force-recreate postgres` → `SHOW idle_in_transaction_session_timeout`
  returns `5min`; `pg_stat_activity` shows zero `idle in transaction` sessions.
- litellm container reports `healthy`, `failing_streak=0`.
- All 5 `start:test` app HTTP endpoints responding on their local ports.
- Pre-commit hook (`check:all` — typecheck + format + lint + syncpack) and pre-push
  hook (`build` across all 19 packages) both passed against this branch.

## Known follow-ups (not in this PR)

Local cypress still has two pre-existing flakes that are **not caused by this PR** and
that the plan explicitly deferred to a targeted debug session:

1. **`cy.validateElement` modal-close race** — after `save-new-question.click({force:true}) + wait(1000)`,
   `validateElement` calls `.clear()` on `elements-search-input` which lives behind the
   create/edit modal. If the modal takes >1000ms to close, `.clear()` fails on a
   non-actionable element. Repro'd on this branch in Create-SC and Edit-SC-sample-solution
   tests. Proper fix is to wait for the modal to disappear before interacting with the
   background page (either inside `validateElement` or at each caller). Needs interactive
   debugging, not speculation.
2. **`O-live-quiz-workflow.cy.ts:1065`** — `answerCaseStudy` on mobile viewport races
   the next-question render against the submit click. Same category — deferred.

Neither flake blocks `start:test` startup, and neither is introduced by this PR.

## Test plan

- [ ] Verify CI `cypress-run-cloud` stays green on this branch (CI runs in a clean
      container, so leaked-transaction cascades don't apply — any regression from the
      postgres `command:` override or the litellm healthcheck change would surface here).
- [ ] Local reproduction check: `./_down.sh && ./_run_app_dependencies.sh cypress`,
      then run any cypress spec with Ctrl+C partway through, then a second spec — should
      no longer cascade into `Transaction API error`.
- [ ] Sanity-check litellm health: `docker inspect <litellm-container> | jq '.[0].State.Health'`
      → should be `healthy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database session management configuration
  * Enhanced service health monitoring for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->