### PR TITLE
feat(chat): add Auto (complexity-router) model + lock stg Vorkurs chatbot to Auto

### DIFF
--- a/deploy/env-uzh-prd/values.yaml
+++ b/deploy/env-uzh-prd/values.yaml
@@ -205,6 +205,23 @@ chat:
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
+    # "Auto" routes through the LiteLLM complexity-router, which self-selects the
+    # tier per request (SIMPLE=gpt-4.1, MEDIUM=gpt-5.4-low, COMPLEX=gpt-5.4-medium,
+    # REASONING=gpt-5.5-low). It is a normal selectable model (fallback: false), so
+    # it does NOT change automatic selection for existing chatbots — they still
+    # default to gpt-5.5. A chatbot can be pinned to Auto-only via its DB columns
+    # (modelSelection=false + allowedModelIds=["auto"]).
+    # cost mirrors the gpt-5.4 tier (the typical COMPLEX route); REASONING (gpt-5.5)
+    # is rare. Tune if the routed mix shifts.
+    - id: auto
+      deploymentId: klickeruzh/azure/complexity-router
+      name: Auto
+      description: Automatic model selection (routes to the best model per request)
+      supportsImageAttachments: true
+      fallback: false
+      cost:
+        input: 1.25
+        output: 10.0
     - id: gpt-4.1
       deploymentId: klickeruzh/azure/gpt-4.1
       name: GPT-4.1

--- a/deploy/env-uzh-stg/values.yaml
+++ b/deploy/env-uzh-stg/values.yaml
@@ -173,6 +173,23 @@ chat:
     fallbackId: gpt-4.1-mini
 
   modelRegistry:
+    # "Auto" routes through the LiteLLM complexity-router, which self-selects the
+    # tier per request (SIMPLE=gpt-4.1, MEDIUM=gpt-5.4-low, COMPLEX=gpt-5.4-medium,
+    # REASONING=gpt-5.5-low). It is a normal selectable model (fallback: false), so
+    # it does NOT change automatic selection for existing chatbots — they still
+    # default to gpt-5.5. A chatbot can be pinned to Auto-only via its DB columns
+    # (modelSelection=false + allowedModelIds=["auto"]); see the vorkurs chatbot.
+    # cost mirrors the gpt-5.4 tier (the typical COMPLEX route); REASONING (gpt-5.5)
+    # is rare. Tune if the routed mix shifts.
+    - id: auto
+      deploymentId: klickeruzh/azure/complexity-router
+      name: Auto
+      description: Automatic model selection (routes to the best model per request)
+      supportsImageAttachments: true
+      fallback: false
+      cost:
+        input: 1.25
+        output: 10.0
     - id: gpt-4.1
       deploymentId: klickeruzh/azure/gpt-4.1
       name: GPT-4.1


### PR DESCRIPTION
## What

Add **"Auto"** (the LiteLLM **complexity-router**) as a *selectable* chat model on **stg** and **prd**, and lock the **stg "Vorkurs Rechenfertigkeiten"** chatbot to **Auto only** (no model or reasoning choice).

This does **not** route everything through Auto. Existing chatbots keep their current behaviour — automatic selection still defaults to `gpt-5.5` (fallback `gpt-4.1-mini`), and users on model-selection-enabled chatbots now simply have **one extra option** ("Auto") alongside the existing GPT models.

The router self-selects the tier per request:

| Complexity | Routed model |
|---|---|
| SIMPLE | gpt-4.1 |
| MEDIUM | gpt-5.4 (low) |
| COMPLEX | gpt-5.4 (medium) |
| REASONING | gpt-5.5 (low) |

## Changes

**Helm values (this PR)** — `deploy/env-uzh-stg/values.yaml` + `deploy/env-uzh-prd/values.yaml`:
- Add one `auto` entry to `chat.modelRegistry` (`deploymentId: klickeruzh/azure/complexity-router`, `fallback: false`, image attachments on, no reasoning, cost mirrors the gpt-5.4 tier). Net diff is **+34 lines, 0 deletions** — the 5 existing models and `automaticModels` are untouched.

**stg DB (applied out-of-band, not in this PR)** — Vorkurs chatbot `36316eb1-…`:
- `modelSelection = false` and `allowedModelIds = {auto}`.
- With `modelSelection=false` the UI shows a locked, read-only model (no dropdown); `allowedModelIds=["auto"]` makes the automatic resolution pick `auto`. `auto` has no reasoning efforts, so no reasoning selector renders either → **Auto only, no choices**.

## Why this design

The per-chatbot model list is `allowedModelIds ∪ {fallback models}` (`getModelsForChatbot`), and `getAutomaticModelId` is driven by `allowedModelIds` + the `CHAT_PRIMARY/FALLBACK_MODEL_ID` envs. So keeping `auto` as a normal non-fallback model leaves every other chatbot's defaults and credit-safe fallback (`gpt-4.1-mini`) exactly as-is, while a single chatbot can be pinned to Auto purely via its two DB columns — no global behaviour change.

## Out-of-band prerequisite (already done)

The Klicker LiteLLM virtual key **and** its team allow `klickeruzh/azure/complexity-router` on **stg and prd** (verified end-to-end: a completion through the chat key via the router returned `ok` on both). No LiteLLM change in this PR.

## Deploy ordering / verification

- [x] Net YAML diff is the single `auto` entry on both envs; defaults unchanged.
- [x] stg + prd LiteLLM key + team grant the router model (verified e2e).
- [x] stg Vorkurs chatbot DB: `modelSelection=false`, `allowedModelIds={auto}`.
- [ ] **Deploy stg first** so the registry gains `auto` (until then the locked Vorkurs chatbot resolves to the `gpt-4.1-mini` fallback — inert, not broken). After deploy: Vorkurs shows a locked **"Auto"** with no model/reasoning selector and routes via the complexity-router; a normal chatbot shows "Auto" as one selectable option among the GPT models.

## Notes

- Targets `v3` (default branch). Retarget to `dev` if preferred.
- `auto` cost is set to the gpt-5.4 tier (1.25 / 10.0) as the representative COMPLEX route; REASONING (gpt-5.5, 5/30) is rare. Tunable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **automatic model** option for chat, letting requests be routed to the most appropriate model tier automatically.
  * The new option supports **image attachments** and appears as a selectable model in both staging and production environments.
  * Updated pricing details for this automatic option to reflect per-request input and output costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->