### PR TITLE
feat(devcontainer): add lti and chat apps (phase 2 tier 2 & 3)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -29,7 +29,7 @@ dev up && dev tls install   # Traefik + the shared `devnet` + mkcert CA
 
 ```bash
 devpod up . --ide none         # builds image, starts infra, installs, builds, seeds
-for a in api auth pwa manage control olat-api response-api db; do dev app run "$a"; done   # register routes
+for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done   # register routes
 ```
 
 Open <https://manage.klicker.localhost> and log in as **`lecturer` / `abcd`**
@@ -51,6 +51,8 @@ container's internal port — no published host ports.
 | Control           | `https://control.klicker.localhost`      | `klicker-app:3003` |
 | OLAT API          | `https://olat-api.klicker.localhost`     | `klicker-app:3030` |
 | Response API      | `https://response-api.klicker.localhost` | `klicker-app:7078` |
+| LTI Service       | `https://lti.klicker.localhost`          | `klicker-app:4000` |
+| Chat App          | `https://chat.klicker.localhost`         | `klicker-app:3004` |
 | Postgres          | `db.klicker.localhost:5432`              | `klicker-db:5432`  |
 
 The two Hatchet workers (`hatchet-worker-general`, `hatchet-worker-response-processor`)
@@ -79,6 +81,7 @@ every app is served under `*.klicker.localhost` and the cookie domain resolves t
 
 `backend` needs a `HATCHET_CLIENT_TOKEN`, minted per Hatchet instance. The
 `hatchet_token` sidecar mints one to a shared volume; `post-create` writes it to
+| `litellm` | `ghcr.io/berriai/litellm` | LLM proxy for chat (port 4000 intra-net) |
 `.devcontainer/.hatchet.env` (gitignored) and `post-start` sources it. The
 backend **requires** it to boot — its `HatchetClient.init` runs at module load
 (not lazy), so without the token the API crashes at startup and never serves.
@@ -101,6 +104,7 @@ hatchet DB migrations finishing. If the API is down, check
 | `mailhog`                           | `mailhog/mailhog`                           | dev SMTP sink                                          |
 | `hatchet`                           | `hatchet-lite:v0.73.1`                      | workflow engine (gRPC :7077)                           |
 | `hatchet_token`                     | `hatchet-lite:v0.73.1`                      | one-shot: mint the client token                        |
+| `litellm`                           | `ghcr.io/berriai/litellm`                   | LLM proxy for chat (port 4000 intra-net)               |
 
 Environment lives in `devcontainer.env` (committed, dev-only). Lifecycle:
 `post-create.sh` (install + build packages + prisma reset/push/seed + token) then
@@ -114,4 +118,4 @@ Environment lives in `devcontainer.env` (committed, dev-only). Lifecycle:
 - `response-api` + both workers run `tsx --watch --env-file=.env`; node 20 errors
   if `.env` is missing, so `post-create` seeds an **empty** `.env` in each dir
   (the container env from `devcontainer.env` is what actually applies).
-- Tier 2 (`lti`) and Tier 3 (`chat` + LiteLLM, needs an upstream LLM key) are still pending.
+- Tier 3 (`chat`) needs an upstream LLM key: set `UPSTREAM_OPENAI_API_KEY`.

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -91,3 +91,21 @@ CORS_ALLOWED_ORIGINS=https://pwa.klicker.localhost
 # --- Trust the local mkcert CA (mounted in docker-compose.yml) so any server-side
 # HTTPS fetch to a *.klicker.localhost host verifies cleanly. (GOTCHAS #16) ---
 NODE_EXTRA_CA_CERTS=/etc/devrouter/mkcert-rootCA.pem
+
+# --- PHASE 2 Tier 2 (LTI) ---
+APP_ORIGIN_LTI=https://lti.klicker.localhost
+LTI_PORT=4000
+LTI_DB_TYPE=postgres
+LTI_DB_HOST=postgres
+LTI_DB_PORT=5432
+LTI_DB_USER=klicker-prod-lti
+LTI_DB_PASS=klicker
+LTI_DB_NAME=klicker-prod-lti
+LTI_ENCRYPTION_KEY=abcdabcdabcdabcdabcdabcdabcdabcd
+LTI_DEV_MODE=true
+
+# --- PHASE 2 Tier 3 (Chat) ---
+# NOTE: Set UPSTREAM_OPENAI_API_KEY in your local environment to enable chat.
+NEXT_PUBLIC_CHAT_URL=https://chat.klicker.localhost
+APP_ORIGIN_CHAT=https://chat.klicker.localhost
+OPENAI_BASE_URL=http://litellm:4000

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -138,6 +138,8 @@ services:
       - 'control.klicker.localhost:host-gateway'
       - 'olat-api.klicker.localhost:host-gateway'
       - 'response-api.klicker.localhost:host-gateway'
+      - 'lti.klicker.localhost:host-gateway'
+      - 'chat.klicker.localhost:host-gateway'
     networks:
       default: {}
       devnet:
@@ -168,3 +170,17 @@ volumes:
   node_modules_root:
   hatchet_lite_config:
   hatchet_token:
+
+  # --- LiteLLM for Chat (Tier 3) ---
+  litellm:
+    image: ghcr.io/berriai/litellm:main-v1.61.12
+    volumes:
+      - ../util/litellm/config.yaml:/app/config.yaml:ro
+    command:
+      - --config=/app/config.yaml
+      - --port=4000
+    networks:
+      default: {}
+    environment:
+      # Supplied by the user in their local env or .devcontainer.env to enable chat
+      - UPSTREAM_OPENAI_API_KEY=${UPSTREAM_OPENAI_API_KEY:-}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -43,7 +43,7 @@ pnpm install --no-frozen-lockfile
 # (compile on the fly) so they are NOT pre-built. (GOTCHAS: build the graph
 # before any dev server.)
 echo "[post-create] Building workspace packages + backend (turbo)..."
-pnpm exec turbo run build --filter='./packages/*' --filter=@klicker-uzh/backend-docker
+pnpm exec turbo run build --filter='./packages/*' --filter=@klicker-uzh/backend-docker --filter=@klicker-uzh/lti-service
 
 # Prepare the database. klicker's prisma:reset prompts (and the non-interactive
 # variants wrap Infisical), so call prisma directly with --force. A brand-new

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -37,6 +37,8 @@ DEV_CMD='pnpm exec turbo run dev \
   --filter=@klicker-uzh/frontend-control \
   --filter=@klicker-uzh/olat-api \
   --filter=@klicker-uzh/response-api \
+  --filter=@klicker-uzh/lti-service \
+  --filter=@klicker-uzh/chat \
   --filter=@klicker-uzh/hatchet-worker-general \
   --filter=@klicker-uzh/hatchet-worker-response-processor \
   --concurrency 30'
@@ -52,7 +54,9 @@ cat <<'EOF'
 [post-start]   Control      -> https://control.klicker.localhost
 [post-start]   OLAT API     -> https://olat-api.klicker.localhost  (/health, /api-docs; bearer OLAT_API_KEY)
 [post-start]   Response API -> https://response-api.klicker.localhost
+[post-start]   LTI Service  -> https://lti.klicker.localhost
+[post-start]   Chat         -> https://chat.klicker.localhost (requires UPSTREAM_OPENAI_API_KEY)
 [post-start]   Workers      -> hatchet-worker-general + -response-processor (no URL; consume hatchet queue)
-[post-start] Routes  -> on the host: for a in api auth pwa manage control olat-api response-api db; do dev app run "$a"; done
+[post-start] Routes  -> on the host: for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
 [post-start] Logs    -> tail -f /tmp/dev.log
 EOF

--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -7,7 +7,7 @@
 #
 # Usage: `dev up` + `dev tls install` (creates devnet + the mkcert CA), THEN
 # bring the devcontainer up, then:
-#   for a in api auth pwa manage control olat-api response-api db; do dev app run "$a"; done
+#   for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
 #
 # PHASE 1: core apps. PHASE 2 Tier 1 adds olat-api (3030) + response-api (7078);
 # the two hatchet workers run in the same container with no port/route. Remaining
@@ -77,3 +77,17 @@ apps:
     tcpProtocol: postgres
     runtime: proxy
     upstream: klicker-db:5432
+
+  # lti-service: pre-built, runs on 4000. Full LTI launch requires external LMS.
+  - name: lti
+    host: lti.klicker.localhost
+    protocol: http
+    runtime: proxy
+    upstream: klicker-app:4000
+
+  # chat: needs UPSTREAM_OPENAI_API_KEY. runs on 3004.
+  - name: chat
+    host: chat.klicker.localhost
+    protocol: http
+    runtime: proxy
+    upstream: klicker-app:3004

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,13 +153,13 @@ devpod up .            # builds image, starts services, installs, builds, seeds,
 devpod ssh klicker-uzh # shell inside the container
 ```
 
-The dev servers auto-start in the background (`tail -f /tmp/dev.log`; first compile takes ~1min). Re-run lifecycle by hand inside the container: `bash .devcontainer/post-create.sh` / `bash .devcontainer/post-start.sh`. Covers the core apps (backend, auth, frontend-pwa/manage/control) plus olat-api, response-api, and the two Hatchet workers (Phase 2 Tier 1; workers have no port/route); `lti` and `chat` are still pending. See `.devcontainer/README.md`.
+The dev servers auto-start in the background (`tail -f /tmp/dev.log`; first compile takes ~1min). Re-run lifecycle by hand inside the container: `bash .devcontainer/post-create.sh` / `bash .devcontainer/post-start.sh`. Covers the core apps (backend, auth, frontend-pwa/manage/control) plus olat-api, response-api, and the two Hatchet workers (Phase 2 Tier 1; workers have no port/route); All runnable apps are included (no analytics/office-addin/docs). See `.devcontainer/README.md`.
 
 **Routing (devrouter — when available):** nothing is published on the host; [devrouter](https://github.com/rschlaefli/devrouter) (≥ 0.0.21) fronts the stack over the shared `devnet` network and routes each `*.klicker.localhost` host to the one container's internal port. One-time host setup **before** the container starts:
 
 ```bash
 dev up && dev tls install                                       # Traefik + devnet + mkcert CA
-for a in api auth pwa manage control olat-api response-api db; do dev app run "$a"; done
+for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
 ```
 
 Apps at `https://{api,auth,pwa,manage,control,olat-api,response-api}.klicker.localhost`; Postgres for host tooling at `db.klicker.localhost:5432` (`sslmode=require sslnegotiation=direct`). Login as `lecturer`/`abcd` (see test credentials below). Env in `.devcontainer/devcontainer.env` (committed, dev-only — no real secrets).


### PR DESCRIPTION
This PR completes Phase 2 of the devcontainer implementation by adding the remaining apps (LTI Service and Chat App) to the unified `turbo dev` + devrouter stack.

### Tier 2 (LTI Service)
- Added LTI Service to `post-create.sh` pre-build to fix the build race.
- Added `LTI_*` environment variables and `APP_ORIGIN_LTI` to `devcontainer.env`.
- Added routing for `lti.klicker.localhost -> 4000`.

### Tier 3 (Chat App)
- Added `litellm` proxy to `docker-compose.yml`.
- Added routing for `chat.klicker.localhost -> 3004`.
- Added `NEXT_PUBLIC_CHAT_URL`, `APP_ORIGIN_CHAT`, and `OPENAI_BASE_URL` to `devcontainer.env`.
- Updated `README.md` and `AGENTS.md` to document the new hosts and the `UPSTREAM_OPENAI_API_KEY` requirement for chat.

---
*PR created automatically by Jules for task [14041998572947525425](https://jules.google.com/task/14041998572947525425) started by @rschlaefli*