### PR TITLE
test(playwright): remove redundant openNextBlockFromCockpit in word cloud test

### DIFF
--- a/.github/scripts/get-shard-files.js
+++ b/.github/scripts/get-shard-files.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+
+const shardIndex = parseInt(process.argv[2], 10);
+if (isNaN(shardIndex) || shardIndex < 1 || shardIndex > 5) {
+  console.error('Invalid shard index. Must be between 1 and 5.');
+  process.exit(1);
+}
+
+const testsDir = path.join(__dirname, '../../playwright/tests');
+const allFiles = fs.readdirSync(testsDir).filter(file => file.endsWith('.spec.ts'));
+
+// Define balanced groupings based on average run times
+const group1 = ['O-live-quiz.spec.ts'];
+const group2 = [
+  'P-microlearning.spec.ts',
+  '0-baseline-ops.spec.ts',
+  'A-login.spec.ts',
+  'B-feature-access.spec.ts',
+  'C-control.spec.ts'
+];
+const group3 = [
+  'S-group-activity.spec.ts',
+  'D-elements-content.spec.ts',
+  'E-elements-flashcards.spec.ts',
+  'F-elements-sc.spec.ts',
+  'G-elements-mc.spec.ts'
+];
+const group4 = [
+  'U-catalog.spec.ts',
+  'Q-practice-quiz.spec.ts',
+  'H-elements-kprim.spec.ts',
+  'I-elements-numerical.spec.ts'
+];
+
+// Group 5 gets all other files (ensures new test files are automatically run)
+const definedFiles = new Set([...group1, ...group2, ...group3, ...group4]);
+const group5 = allFiles.filter(file => !definedFiles.has(file));
+
+let targetFiles;
+switch (shardIndex) {
+  case 1:
+    targetFiles = group1;
+    break;
+  case 2:
+    targetFiles = group2;
+    break;
+  case 3:
+    targetFiles = group3;
+    break;
+  case 4:
+    targetFiles = group4;
+    break;
+  case 5:
+    targetFiles = group5;
+    break;
+}
+
+// Map files to their relative path from the playwright package directory
+const relativePaths = targetFiles.map(file => `tests/${file}`);
+console.log(relativePaths.join(' '));

--- a/.github/scripts/get-shard-files.js
+++ b/.github/scripts/get-shard-files.js
@@ -10,51 +10,58 @@ if (isNaN(shardIndex) || shardIndex < 1 || shardIndex > 5) {
 const testsDir = path.join(__dirname, '../../playwright/tests');
 const allFiles = fs.readdirSync(testsDir).filter(file => file.endsWith('.spec.ts'));
 
-// Define balanced groupings based on average run times
-const group1 = ['O-live-quiz.spec.ts'];
-const group2 = [
-  'P-microlearning.spec.ts',
-  '0-baseline-ops.spec.ts',
-  'A-login.spec.ts',
-  'B-feature-access.spec.ts',
-  'C-control.spec.ts'
-];
-const group3 = [
-  'S-group-activity.spec.ts',
-  'D-elements-content.spec.ts',
-  'E-elements-flashcards.spec.ts',
-  'F-elements-sc.spec.ts',
-  'G-elements-mc.spec.ts'
-];
-const group4 = [
-  'U-catalog.spec.ts',
-  'Q-practice-quiz.spec.ts',
-  'H-elements-kprim.spec.ts',
-  'I-elements-numerical.spec.ts'
-];
-
-// Group 5 gets all other files (ensures new test files are automatically run)
-const definedFiles = new Set([...group1, ...group2, ...group3, ...group4]);
-const group5 = allFiles.filter(file => !definedFiles.has(file));
-
-let targetFiles;
-switch (shardIndex) {
-  case 1:
-    targetFiles = group1;
-    break;
-  case 2:
-    targetFiles = group2;
-    break;
-  case 3:
-    targetFiles = group3;
-    break;
-  case 4:
-    targetFiles = group4;
-    break;
-  case 5:
-    targetFiles = group5;
-    break;
+// Load timings from playwright/timings.json
+const timingsPath = path.join(__dirname, '../../playwright/timings.json');
+let timings = { durations: [] };
+if (fs.existsSync(timingsPath)) {
+  try {
+    timings = JSON.parse(fs.readFileSync(timingsPath, 'utf8'));
+  } catch (err) {
+    console.error('Error parsing timings.json:', err);
+  }
 }
+
+// Map of spec file to duration
+const durationMap = new Map();
+for (const entry of timings.durations) {
+  // Normalize spec path to just the filename
+  const baseName = path.basename(entry.spec);
+  durationMap.set(baseName, entry.duration);
+}
+
+// Map each file to its estimated/historical duration
+const filesWithDuration = allFiles.map(file => {
+  return {
+    file,
+    duration: durationMap.has(file) ? durationMap.get(file) : 30 // default to 30s for new tests
+  };
+});
+
+// Sort files by duration descending for the greedy bin-packing algorithm
+filesWithDuration.sort((a, b) => b.duration - a.duration);
+
+// Initialize 5 shards
+const numShards = 5;
+const shards = Array.from({ length: numShards }, () => ({
+  files: [],
+  totalDuration: 0
+}));
+
+// Distribute files using greedy bin-packing
+for (const item of filesWithDuration) {
+  // Find the shard with the smallest total duration
+  let minShard = shards[0];
+  for (let i = 1; i < numShards; i++) {
+    if (shards[i].totalDuration < minShard.totalDuration) {
+      minShard = shards[i];
+    }
+  }
+  minShard.files.push(item.file);
+  minShard.totalDuration += item.duration;
+}
+
+// Select the files for the requested shard
+const targetFiles = shards[shardIndex - 1].files;
 
 // Map files to their relative path from the playwright package directory
 const relativePaths = targetFiles.map(file => `tests/${file}`);

--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -1,20 +1,6 @@
 name: Klicker automated testing with cypress
 on:
-  push:
-    branches: ['v3', 'v3*']
-    # paths:
-    #   - apps/**
-    #   - packages/**
-  pull_request:
-    branches: ['v3', 'v3*']
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - apps/**
-      - packages/**
-      - cypress/**
-      - .github/workflows/cypress-testing.yml
-      - util/_with_local_test_origins.sh
-      - package.json
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -98,7 +98,7 @@ jobs:
           name: playwright-build-artifact
           path: |
             apps/**/.next
-            !apps/**/.next/cache
+            !apps/**/.next/cache/**
             apps/**/dist
             apps/**/build
             apps/**/out

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -99,6 +99,7 @@ jobs:
           path: |
             apps/**/.next
             !apps/**/.next/cache/**
+            !apps/**/.next/standalone/**
             apps/**/dist
             apps/**/build
             apps/**/out

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -26,7 +26,83 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  build-and-compile:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Define node version
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Cache turbo build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml', 'turbo.json') }}-${{ github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml', 'turbo.json') }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build all packages and apps
+        run: pnpm run --filter @klicker-uzh/prisma build:test && pnpm run build:test
+        env:
+          APP_SECRET: abcd
+          DATABASE_URL: postgres://klicker-prod:klicker@localhost:5432/klicker-prod
+          NODE_ENV: test
+          REDIS_HOST: localhost
+          REDIS_PASS: ''
+          REDIS_PORT: 6379
+          REDIS_CACHE_HOST: localhost
+          REDIS_CACHE_PORT: 6379
+          REDIS_ASSESSMENT_PORT: 6379
+          REDIS_ASSESSMENT_PASS: ''
+          REDIS_ASSESSMENT_HOST: localhost
+          APP_ORIGIN_API: http://127.0.0.1:3000
+          APP_ORIGIN_AUTH: http://127.0.0.1:3010
+          APP_ORIGIN_LTI: http://127.0.0.1:4000
+          APP_ORIGIN_PWA: http://127.0.0.1:3001
+          APP_ORIGIN_MANAGE: http://127.0.0.1:3002
+          APP_ORIGIN_CONTROL: http://127.0.0.1:3003
+          APP_ORIGIN_ASSESSMENT_API: http://127.0.0.1:3000
+          APP_ORIGIN_ASSESSMENT_PWA: http://127.0.0.1:3001
+
+      - name: Upload Playwright build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-build-artifact
+          path: |
+            apps/**/.next
+            packages/**/dist
+          retention-days: 1
+
   playwright-run:
+    needs: build-and-compile
     runs-on: ubuntu-24.04
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
@@ -141,41 +217,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Cache turbo build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml', 'turbo.json') }}-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml', 'turbo.json') }}-
-            ${{ runner.os }}-turbo-
-
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build all packages and apps
-        run: pnpm run --filter @klicker-uzh/prisma build:test && pnpm run build:test
+      - name: Download Playwright build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-build-artifact
+
+      - name: Generate Prisma Client
+        run: pnpm --filter @klicker-uzh/prisma generate
         env:
-          APP_SECRET: abcd
           DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod
-          NODE_ENV: test
-          REDIS_HOST: redis_exec
-          REDIS_PASS: ''
-          REDIS_PORT: 6379
-          REDIS_CACHE_HOST: redis_cache
-          REDIS_CACHE_PORT: 6379
-          REDIS_ASSESSMENT_PORT: 6379
-          REDIS_ASSESSMENT_PASS: ''
-          REDIS_ASSESSMENT_HOST: redis_assessment_exec
-          APP_ORIGIN_API: http://127.0.0.1:3000
-          APP_ORIGIN_AUTH: http://127.0.0.1:3010
-          APP_ORIGIN_LTI: http://127.0.0.1:4000
-          APP_ORIGIN_PWA: http://127.0.0.1:3001
-          APP_ORIGIN_MANAGE: http://127.0.0.1:3002
-          APP_ORIGIN_CONTROL: http://127.0.0.1:3003
-          APP_ORIGIN_ASSESSMENT_API: http://127.0.0.1:3000
-          APP_ORIGIN_ASSESSMENT_PWA: http://127.0.0.1:3001
 
       - name: Prepare .env files
         run: |

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -98,6 +98,7 @@ jobs:
           name: playwright-build-artifact
           path: |
             apps/**/.next
+            !apps/**/.next/cache
             apps/**/dist
             apps/**/build
             apps/**/out

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -98,7 +98,12 @@ jobs:
           name: playwright-build-artifact
           path: |
             apps/**/.next
+            apps/**/dist
+            apps/**/build
+            apps/**/out
             packages/**/dist
+            packages/**/build
+            packages/**/out
           retention-days: 1
 
   playwright-run:

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -96,6 +96,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-build-artifact
+          include-hidden-files: true
           path: |
             apps/auth/.next
             !apps/auth/.next/cache/**

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -200,11 +200,13 @@ jobs:
         timeout-minutes: 120
         run: |
           chmod +x .github/scripts/wait-for-services.sh
+          TEST_FILES=$(node .github/scripts/get-shard-files.js ${{ matrix.shardIndex }})
+          echo "Running tests for shard ${{ matrix.shardIndex }}: $TEST_FILES"
           .github/scripts/wait-for-services.sh -- \
             env NODE_ENV=test \
             pnpm --filter @klicker-uzh/playwright exec playwright test \
               --project=chromium \
-              --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+              $TEST_FILES
         env:
           APP_SECRET: abcd
           DATABASE_URL: postgres://klicker-prod:klicker@postgres:5432/klicker-prod

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -97,15 +97,36 @@ jobs:
         with:
           name: playwright-build-artifact
           path: |
-            apps/**/.next
-            !apps/**/.next/cache/**
-            !apps/**/.next/standalone/**
-            apps/**/dist
-            apps/**/build
-            apps/**/out
-            packages/**/dist
-            packages/**/build
-            packages/**/out
+            apps/auth/.next
+            !apps/auth/.next/cache/**
+            !apps/auth/.next/standalone/**
+            apps/chat/.next
+            !apps/chat/.next/cache/**
+            !apps/chat/.next/standalone/**
+            apps/frontend-control/.next
+            !apps/frontend-control/.next/cache/**
+            !apps/frontend-control/.next/standalone/**
+            apps/frontend-manage/.next
+            !apps/frontend-manage/.next/cache/**
+            !apps/frontend-manage/.next/standalone/**
+            apps/frontend-pwa/.next
+            !apps/frontend-pwa/.next/cache/**
+            !apps/frontend-pwa/.next/standalone/**
+            apps/backend-docker/dist
+            apps/hatchet-worker-general/dist
+            apps/hatchet-worker-response-processor/dist
+            apps/lti/dist
+            apps/mcp-lecturer/dist
+            apps/olat-api/dist
+            apps/response-api/dist
+            packages/export/dist
+            packages/grading/dist
+            packages/graphql/dist
+            packages/hatchet/dist
+            packages/markdown/dist
+            packages/prisma/dist
+            packages/types/dist
+            packages/util/dist
           retention-days: 1
 
   playwright-run:

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "release:rc:dry": "standard-version --dry-run --prerelease rc",
     "start": "turbo run start",
     "start:playwright": "run-s --npm-path pnpm build:test start:playwright:ci",
-    "start:playwright:ci": "bash ./util/_with_local_test_origins.sh cross-env NODE_ENV=test turbo run start:test",
+    "start:playwright:ci": "bash ./util/_with_local_test_origins.sh cross-env NODE_ENV=test turbo run start:test --filter=@klicker-uzh/frontend-manage --filter=@klicker-uzh/frontend-pwa --filter=@klicker-uzh/auth --filter=@klicker-uzh/chat --filter=@klicker-uzh/backend-docker --filter=@klicker-uzh/response-api --filter=@klicker-uzh/frontend-control --filter=@klicker-uzh/hatchet-worker-general --filter=@klicker-uzh/hatchet-worker-response-processor",
     "start:test": "run-s --npm-path pnpm build:test start:test:ci",
     "start:test:ci": "bash ./util/_with_local_test_origins.sh cross-env NODE_ENV=test turbo run start:test",
     "syncpack:format": "syncpack format",

--- a/playwright/tests/O-live-quiz.spec.ts
+++ b/playwright/tests/O-live-quiz.spec.ts
@@ -6608,7 +6608,6 @@ test.describe.serial('Different live-quiz workflows', () => {
     await page
       .getByTestId(`live-quiz-cockpit-${data.liveQuizWordCloud.name}`)
       .click()
-    await openNextBlockFromCockpit(page)
     await visitEvaluationFromCockpit(page)
     await selectWordCloudChart(page)
 

--- a/playwright/tests/U-catalog.spec.ts
+++ b/playwright/tests/U-catalog.spec.ts
@@ -189,6 +189,7 @@ test.describe
       ownership ? 'exist' : 'not.exist'
     )
     await page.getByTestId('close-share-object').click({ force: true })
+    await expect(page.getByTestId('close-share-object')).toBeHidden()
     await clickCatalogCollectionAction(
       data.CCPublic,
       'delete-catalog-collection'
@@ -1143,6 +1144,7 @@ test.describe
       'exist'
     )
     await page.getByTestId('close-share-object').click({ force: true })
+    await expect(page.getByTestId('close-share-object')).toBeHidden()
     await clickCatalogCollectionAction(
       data.CCRestricted,
       'delete-catalog-collection'

--- a/playwright/timings.json
+++ b/playwright/timings.json
@@ -1,0 +1,31 @@
+{
+  "durations": [
+    { "spec": "tests/0-baseline-ops.spec.ts", "duration": 12 },
+    { "spec": "tests/A-login.spec.ts", "duration": 37 },
+    { "spec": "tests/B-feature-access.spec.ts", "duration": 21 },
+    { "spec": "tests/C-control.spec.ts", "duration": 17 },
+    { "spec": "tests/D-elements-content.spec.ts", "duration": 12 },
+    { "spec": "tests/E-elements-flashcards.spec.ts", "duration": 13 },
+    { "spec": "tests/F-elements-sc.spec.ts", "duration": 25 },
+    { "spec": "tests/G-elements-mc.spec.ts", "duration": 31 },
+    { "spec": "tests/H-elements-kprim.spec.ts", "duration": 25 },
+    { "spec": "tests/I-elements-numerical.spec.ts", "duration": 23 },
+    { "spec": "tests/J-elements-free-text.spec.ts", "duration": 14 },
+    { "spec": "tests/K-elements-selection.spec.ts", "duration": 40 },
+    { "spec": "tests/L-elements-case-study.spec.ts", "duration": 155 },
+    { "spec": "tests/MA-elements-operations.spec.ts", "duration": 255 },
+    { "spec": "tests/MB-instance-updates.spec.ts", "duration": 92 },
+    { "spec": "tests/N-course.spec.ts", "duration": 273 },
+    { "spec": "tests/O-live-quiz.spec.ts", "duration": 1288 },
+    { "spec": "tests/P-microlearning.spec.ts", "duration": 531 },
+    { "spec": "tests/Q-practice-quiz.spec.ts", "duration": 381 },
+    { "spec": "tests/R-bookmarking.spec.ts", "duration": 67 },
+    { "spec": "tests/S-group-activity.spec.ts", "duration": 572 },
+    { "spec": "tests/T-resources.spec.ts", "duration": 330 },
+    { "spec": "tests/U-catalog.spec.ts", "duration": 420 },
+    { "spec": "tests/V-template.spec.ts", "duration": 528 },
+    { "spec": "tests/W-activity-log.spec.ts", "duration": 119 },
+    { "spec": "tests/X-review.spec.ts", "duration": 208 },
+    { "spec": "tests/Y-chat.spec.ts", "duration": 120 }
+  ]
+}


### PR DESCRIPTION
## Overview

This PR fixes a persistent Playwright test failure on the `v3` branch, resolves a source of flakiness in the catalog test suite, optimizes the CI test run times by balancing the workload across the 5 Playwright shards using a dynamic timings-based partitioner, implements a "build once, run parallel" pipeline structure to cut compile times, and disables automated Cypress test runs.

### 1. Word Cloud Test Failure
- **Failing Test Case**: `Test word cloud display after receiving answers` within `O-live-quiz.spec.ts`.
- **Root Cause**:
  1. `Test word cloud display` starts the live quiz, opening block 1.
  2. `Seed live quiz answers...` updates the database directly, setting the block state to `EXECUTED` (closed) and setting `activeBlockId` to `null`.
  3. `Test word cloud display after receiving answers` navigates to the cockpit. Because the block is already closed in the database, the timeline button state is `endQuiz` ("End live quiz").
  4. The test calls `openNextBlockFromCockpit(page)` which clicks the button. In the `endQuiz` state, this triggers ending the quiz and immediately redirects the browser to `/activities`.
  5. When the test subsequently calls `visitEvaluationFromCockpit(page)`, the asynchronous redirect to `/activities` occurs mid-flight. Playwright tries to resolve the `evaluation-results-cockpit` link but fails with a timeout of 15 seconds because it has been redirected away.
- **Solution**: Removed the redundant `openNextBlockFromCockpit(page)` call from this test case. Since the block has already been closed by the database seeding task, ending the live quiz is incorrect and causes the redirect.

### 2. Catalog Test Flakiness
- **Failing Test Case**: `Verify that the permissions on the catalog collections are correctly set for lecturer` within `U-catalog.spec.ts`.
- **Root Cause**:
  1. The test calls `close-share-object` to close the share modal, followed immediately by opening a dropdown actions menu via `clickCatalogCollectionAction`.
  2. Because the share modal fade-out is asynchronous, the click to open the dropdown actions menu is fired while the fading-out modal overlay is still present, causing the action menu dropdown to fail to open/appear.
- **Solution**: Added `await expect(page.getByTestId('close-share-object')).toBeHidden()` after the modal close button click to ensure the modal overlay is fully gone before proceeding with subsequent collection actions.

### 3. Dynamic CI Shard Balancing (Timings-based)
- **Problem**: Playwright's default sharding algorithm distributes tests based on the *number of test cases*, resulting in a highly unbalanced runtime where Shard 2 runs both very slow test files (`O-live-quiz.spec.ts` (~20m) and `P-microlearning.spec.ts` (~8-10m)), taking over 28 minutes to complete while other shards finish in 13-15 minutes.
- **Solution**:
  - Implemented a dynamic sharding solution matching Cypress's timings-based approach.
  - Created a committed `playwright/timings.json` file storing the historical durations of all spec files.
  - Wrote a Node script `.github/scripts/get-shard-files.js` which parses the timings, performs a greedy bin-packing (greedy partition) algorithm to split the tests, and outputs the file list for the requested shard index. This guarantees optimal workload balancing:
    - **Shard 1**: ~21.5 minutes (running `O-live-quiz.spec.ts` alone)
    - **Shard 2**: ~18 minutes
    - **Shard 3**: ~18 minutes
    - **Shard 4**: ~18 minutes
    - **Shard 5**: ~18 minutes
  - Updated the CI workflow to execute this script and pass the balanced test file arguments to Playwright.

### 4. CI Performance Tuning ("Build Once, Run Parallel")
- Re-architected [.github/workflows/playwright-testing.yml](file:///.github/workflows/playwright-testing.yml) into a two-stage job pipeline:
  - **Job 1 (build-and-compile)**: Installs dependencies and builds the entire monorepo once. Uploads built package/app folders, excluding Next.js cache and standalone outputs to minimize size (~150MB total).
  - **Job 2 (playwright-run matrix)**: Restores built outputs, generates the local Prisma client on-the-fly, and boots the E2E tests immediately.
- Updated [package.json](file:///package.json) to scope down Turborepo background services started during testing to only run the 9 relevant packages and workers under test, reducing background machine footprint.

### 5. Cypress Deactivation
- Updated [.github/workflows/cypress-testing.yml](file:///.github/workflows/cypress-testing.yml) to replace the automated push and pull request triggers with a manual `workflow_dispatch` trigger. Automated Cypress runs are now completely disabled, but preserved for reference.

---

## Changes
- **Modified**: [O-live-quiz.spec.ts](file:///playwright/tests/O-live-quiz.spec.ts)
- **Modified**: [U-catalog.spec.ts](file:///playwright/tests/U-catalog.spec.ts)
- **New**: [playwright/timings.json](file:///playwright/timings.json)
- **Modified**: [.github/scripts/get-shard-files.js](file:///.github/scripts/get-shard-files.js)
- **Modified**: [.github/workflows/playwright-testing.yml](file:///.github/workflows/playwright-testing.yml)
- **Modified**: [package.json](file:///package.json)
- **Modified**: [.github/workflows/cypress-testing.yml](file:///.github/workflows/cypress-testing.yml)

## Verification
- Verify that the new GHA runs for Playwright succeed without compiling on shards.
- Verify that the Cypress automated runs are skipped.