### PR TITLE
enhance(devcontainer): improve support for parallel worktrees with devrouter and add fallback overlay for localhost

### DIFF
--- a/.agents/skills/klicker-environment-doctor/SKILL.md
+++ b/.agents/skills/klicker-environment-doctor/SKILL.md
@@ -53,7 +53,9 @@ If `apps/analytics` complains about schema drift or a schema edit isn't visible:
 lsof -nP -iTCP:5432 -sTCP:LISTEN   # repeat for 6379 6380 6381 7077 8888 80 443
 ```
 
-`Bind for :::5432 failed: port is already allocated` means another stack holds the port — stop it or don't start the colliding service. Worktrees get **parallel compose projects** (project name = directory name) but fight over the same host ports; only one stack variant runs per machine.
+`Bind for :::5432 failed: port is already allocated` means another stack holds the port — stop it or don't start the colliding service. Plain localhost and legacy host-based paths publish fixed ports, so only one such stack runs per machine. For parallel devcontainer worktrees, keep the base `.devcontainer/docker-compose.yml` port-free and use `.devcontainer/docker-compose.devrouter.yml`, which exposes `${WORKSPACE:-klicker-uzh}-app` / `${WORKSPACE:-klicker-uzh}-db` aliases on `devnet`. Start/register linked worktrees with the same token, e.g. `WORKSPACE=<slug> devpod up .` and `devrouter app run <app> --workspace <slug>`. Use `.devcontainer/docker-compose.localhost.yml` only for the one-at-a-time localhost fallback.
+
+If manage media uploads fail with an Azure Blob CORS error while GraphQL auth still works, check the storage account before changing app CORS. The media library uploads directly from the browser to Azure Blob Storage via SAS, so the Blob service CORS rule must allow the actual devrouter origin (`https://manage.klicker.localhost` or `https://manage.klicker.<workspace>.localhost`). Use exact origins for production/staging accounts; for a dedicated dev storage account, a dev-only `https://*.localhost` rule keeps parallel worktrees usable.
 
 ## Check 6 — infra bring-up / server status (headless-safe)
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -19,11 +19,11 @@ Hatchet, install + build + seed, `turbo dev`);
 
 You can run the devcontainer in two modes:
 
-### Mode 1: Plain localhost (Default & Self-Contained)
+### Mode 1: Plain localhost (Fallback)
 
 Use this if you are running in a headless cloud server or want to avoid installing Traefik/mkcert on your host:
 
-1. Ensure `.devcontainer/devcontainer.json` specifies only `docker-compose.yml` (default).
+1. Edit `.devcontainer/devcontainer.json` to use `["docker-compose.yml", "docker-compose.localhost.yml"]`.
 2. Start the devcontainer (`devpod up .` or via VS Code).
 3. The applications are exposed directly on your host's ports:
    - Student PWA: `http://localhost:3001`
@@ -36,30 +36,45 @@ Use this if you are running in a headless cloud server or want to avoid installi
    - Hatchet Dashboard: `http://localhost:8888`
    - Postgres DB: `localhost:5432`
 
-### Mode 2: devrouter (Routed HTTPS domains)
+### Mode 2: devrouter (Default Routed HTTPS domains)
 
 Use this to mirror production domain behaviors and test cookie-sharing over HTTPS:
 
-1. **Host prerequisite**: Install [devrouter](https://github.com/rschlaefli/devrouter) (≥ 0.0.21) and start it:
+1. **Host prerequisite**: Install [devrouter](https://github.com/rschlaefli/devrouter) (≥ 0.0.23 recommended; ≥ 0.0.21 required) and start it:
    ```bash
-   dev up && dev tls install   # Traefik + the shared `devnet` + mkcert CA
+   devrouter up && devrouter tls install   # Traefik + the shared `devnet` + mkcert CA
    ```
-2. Edit `.devcontainer/devcontainer.json` to include the devrouter overlay:
+2. Ensure `.devcontainer/devcontainer.json` includes the devrouter overlay:
    ```json
    "dockerComposeFile": ["docker-compose.yml", "docker-compose.devrouter.yml"]
    ```
 3. Start the devcontainer (`devpod up .` or via VS Code).
 4. Run the routing registrar command on your host:
    ```bash
-   for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
+   for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a"; done
    ```
 5. Open `https://manage.klicker.localhost` (credentials: `lecturer` / `abcd`).
+
+For a parallel git worktree, use one workspace token consistently so Docker
+aliases, devrouter upstreams, and public hostnames line up:
+
+```bash
+WORKSPACE=my-branch devpod up . --ide none
+for a in api auth pwa manage control olat-api response-api lti chat db; do
+  devrouter app run "$a" --workspace my-branch
+done
+```
+
+That worktree is then served at
+`https://manage.klicker.my-branch.localhost`, with API/auth/PWA/control using the
+same inserted workspace label. `devrouter workspace up <branch>` performs the
+same token plumbing when you let devrouter create/start the worktree.
 
 ## Run with DevPod
 
 ```bash
 devpod up . --ide none         # builds image, starts infra, installs, builds, seeds
-for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done   # register routes
+for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a"; done   # register routes
 ```
 
 Open <https://manage.klicker.localhost> and log in as **`lecturer` / `abcd`**
@@ -68,22 +83,26 @@ Open <https://manage.klicker.localhost> and log in as **`lecturer` / `abcd`**
 
 ## How routing works
 
-The monorepo runs **all apps in the one `klicker-app` container** via
-`turbo dev`; devrouter's Traefik (on `devnet`) routes each hostname to that
-container's internal port — no published host ports.
+The monorepo runs **all apps in one `app` container** via `turbo dev`;
+devrouter's Traefik (on `devnet`) routes each hostname to that container's
+internal port — no published host ports. The devrouter overlay exposes
+`${WORKSPACE:-klicker-uzh}-app` and `${WORKSPACE:-klicker-uzh}-db` aliases.
+`.devrouter.yml` uses `${WORKSPACE}` in each proxy upstream, so the primary
+checkout routes to `klicker-uzh-app` / `klicker-uzh-db`, while a worktree with
+`WORKSPACE=my-branch` routes to `my-branch-app` / `my-branch-db`.
 
-| What              | Host                                     | Upstream (devnet)  |
-| ----------------- | ---------------------------------------- | ------------------ |
-| API (GraphQL)     | `https://api.klicker.localhost`          | `klicker-app:3000` |
-| Auth              | `https://auth.klicker.localhost`         | `klicker-app:3010` |
-| PWA (student)     | `https://pwa.klicker.localhost`          | `klicker-app:3001` |
-| Manage (lecturer) | `https://manage.klicker.localhost`       | `klicker-app:3002` |
-| Control           | `https://control.klicker.localhost`      | `klicker-app:3003` |
-| OLAT API          | `https://olat-api.klicker.localhost`     | `klicker-app:3030` |
-| Response API      | `https://response-api.klicker.localhost` | `klicker-app:7078` |
-| LTI Service       | `https://lti.klicker.localhost`          | `klicker-app:4000` |
-| Chat App          | `https://chat.klicker.localhost`         | `klicker-app:3004` |
-| Postgres          | `db.klicker.localhost:5432`              | `klicker-db:5432`  |
+| What              | Host                                                   | Upstream (devnet)       |
+| ----------------- | ------------------------------------------------------ | ----------------------- |
+| API (GraphQL)     | `https://api.klicker[.<workspace>].localhost`          | `${WORKSPACE}-app:3000` |
+| Auth              | `https://auth.klicker[.<workspace>].localhost`         | `${WORKSPACE}-app:3010` |
+| PWA (student)     | `https://pwa.klicker[.<workspace>].localhost`          | `${WORKSPACE}-app:3001` |
+| Manage (lecturer) | `https://manage.klicker[.<workspace>].localhost`       | `${WORKSPACE}-app:3002` |
+| Control           | `https://control.klicker[.<workspace>].localhost`      | `${WORKSPACE}-app:3003` |
+| OLAT API          | `https://olat-api.klicker[.<workspace>].localhost`     | `${WORKSPACE}-app:3030` |
+| Response API      | `https://response-api.klicker[.<workspace>].localhost` | `${WORKSPACE}-app:7078` |
+| LTI Service       | `https://lti.klicker[.<workspace>].localhost`          | `${WORKSPACE}-app:4000` |
+| Chat App          | `https://chat.klicker[.<workspace>].localhost`         | `${WORKSPACE}-app:3004` |
+| Postgres          | `db.klicker[.<workspace>].localhost:5432`              | `${WORKSPACE}-db:5432`  |
 
 The two Hatchet workers (`hatchet-worker-general`, `hatchet-worker-response-processor`)
 also run in the `app` container but have **no port/route** — they consume the
@@ -103,9 +122,41 @@ psql "host=db.klicker.localhost port=5432 user=klicker-prod password=klicker \
 EduID is replaced by klicker's own **credentials login** (no OIDC mock needed).
 Seeded users (`packages/prisma-data`): `lecturer`/`abcd` (ADMIN), `free`/`abcd`,
 `pro1..3`/`abcd`, and `testuser1..50`/`abcdabcd`. Cross-app sessions work because
-every app is served under `*.klicker.localhost` and the cookie domain resolves to
-`klicker.localhost` (from `NEXTAUTH_URL`); the `AUTH_*_ALLOWED_HOSTS` env adds the
-`*.klicker.localhost` hosts that the hardcoded defaults (only `klicker.com`) miss.
+every app is served under the same `klicker*.localhost` parent and the cookie
+domain resolves to that parent (`klicker.localhost` for the primary checkout,
+`klicker.<workspace>.localhost` for linked worktrees). `post-start.sh` rewrites
+the public origins and `AUTH_*_ALLOWED_HOSTS` when `WORKSPACE` is set, because
+the hardcoded defaults only know `klicker.com`.
+
+## Azure Blob CORS for media uploads
+
+The manage media library uploads images directly from the browser to Azure Blob
+Storage via a SAS URL. That browser request is evaluated by the storage
+account's Blob service CORS rules, not by the Klicker backend. If a dev storage
+account only allows production origins such as `https://manage.klicker.com`, an
+upload from `https://manage.klicker.localhost` or
+`https://manage.klicker.<workspace>.localhost` will fail before the PUT request
+is sent.
+
+For a dedicated development storage account, add a Blob service CORS rule that
+covers local devrouter origins. Azure Storage requires exact origin matches, but
+also supports `*` as an origin wildcard or subdomain wildcard:
+
+```bash
+az storage account blob-service-properties cors-rule add \
+  --account-name <dev-storage-account> \
+  --resource-group <resource-group> \
+  --allowed-origins "https://*.localhost" \
+  --allowed-methods PUT GET HEAD \
+  --allowed-headers "*" \
+  --exposed-headers "*" \
+  --max-age 3600
+```
+
+Keep production storage accounts on exact production/staging origins. If policy
+does not allow the `*.localhost` wildcard even on a dev account, add the exact
+worktree origin currently in use, for example
+`https://manage.klicker.my-branch.localhost`.
 
 ## Hatchet token
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "name": "klicker-uzh",
-  "dockerComposeFile": ["docker-compose.yml"],
-  "forwardPorts": [
-    3000, 3001, 3002, 3003, 3004, 3010, 3030, 4000, 7078, 8025, 8888, 5432
-  ],
+  "dockerComposeFile": ["docker-compose.yml", "docker-compose.devrouter.yml"],
   "service": "app",
   "workspaceFolder": "/workspaces/klicker-uzh",
   "overrideCommand": false,

--- a/.devcontainer/docker-compose.devrouter.yml
+++ b/.devcontainer/docker-compose.devrouter.yml
@@ -1,13 +1,19 @@
 # Overlay to enable devrouter routing (https://*.klicker.localhost) and local trust of mkcert root CA.
-version: '3.8'
+# The aliases match `.devrouter.yml`'s `${WORKSPACE}-app` / `${WORKSPACE}-db`
+# upstreams. For the primary checkout, devrouter substitutes `${WORKSPACE}` with
+# the project name (`klicker-uzh`), so the compose defaults use that same value.
 
 services:
   postgres:
     networks:
       devnet:
-        aliases: [klicker-db]
+        aliases: ['${WORKSPACE:-klicker-uzh}-db']
 
   app:
+    environment:
+      # Empty in the primary checkout; set by `devrouter workspace up` or by
+      # `WORKSPACE=<slug> devpod up ...` for linked worktrees.
+      WORKSPACE: '${WORKSPACE:-}'
     extra_hosts:
       - 'api.klicker.localhost:host-gateway'
       - 'auth.klicker.localhost:host-gateway'
@@ -18,13 +24,21 @@ services:
       - 'response-api.klicker.localhost:host-gateway'
       - 'lti.klicker.localhost:host-gateway'
       - 'chat.klicker.localhost:host-gateway'
+      - 'api.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'auth.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'pwa.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'manage.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'control.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'olat-api.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'response-api.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'lti.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
+      - 'chat.klicker.${WORKSPACE:-klicker-uzh}.localhost:host-gateway'
     networks:
       devnet:
-        aliases: [klicker-app]
+        aliases: ['${WORKSPACE:-klicker-uzh}-app']
     volumes:
       # Local mkcert root CA (created by `dev tls install`) for server-side TLS trust.
       - '${DEVROUTER_MKCERT_CAROOT:-${HOME}/Library/Application Support/mkcert}/rootCA.pem:/etc/devrouter/mkcert-rootCA.pem:ro'
-
 networks:
   devnet:
     external: true

--- a/.devcontainer/docker-compose.localhost.yml
+++ b/.devcontainer/docker-compose.localhost.yml
@@ -1,0 +1,32 @@
+# Fallback overlay for running the devcontainer without devrouter.
+# This publishes fixed host ports, so only one localhost-mode stack can run per
+# machine. For parallel worktrees, use docker-compose.devrouter.yml instead.
+
+services:
+  postgres:
+    ports:
+      - '5432:5432'
+
+  mailhog:
+    ports:
+      - '8025:8025'
+
+  hatchet:
+    ports:
+      - '8888:8888'
+      - '7077:7077'
+
+  app:
+    ports:
+      - '3000:3000' # api / assessment-api
+      - '3001:3001' # pwa / assessment-pwa
+      - '3002:3002' # manage
+      - '3003:3003' # control
+      - '3004:3004' # chat
+      - '3010:3010' # auth
+      - '3030:3030' # olat-api
+      - '7078:7078' # response-api
+
+  litellm:
+    ports:
+      - '4000:4000'

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,11 +3,9 @@
 # the legacy per-repo Traefik + the `full`-profile prebuilt images). A single compose
 # project directory (.devcontainer) avoids relative-path ambiguity. (GOTCHAS #13)
 #
-# By default, this stack runs in self-contained localhost port-based mode:
-# - postgres on db.klicker.localhost -> host port 5432
-# - mailhog UI -> host port 8025
-# - hatchet dashboard -> host port 8888
-# - all web applications published on localhost ports (3000-3010, 3030, 7078)
+# The base stack publishes no host ports. Add exactly one routing overlay:
+# - docker-compose.devrouter.yml: HTTPS/TCP routing through devrouter/devnet
+# - docker-compose.localhost.yml: fixed localhost ports for fallback use
 #
 # To route through Traefik devrouter (https://*.klicker.localhost), use the
 # overlay file: `docker-compose.devrouter.yml`.
@@ -24,8 +22,6 @@ services:
       interval: 5s
       timeout: 3s
       retries: 20
-    ports:
-      - '5432:5432'
     networks:
       - default
     volumes:
@@ -49,8 +45,6 @@ services:
   # --- fake SMTP for dev email ---
   mailhog:
     image: mailhog/mailhog:latest
-    ports:
-      - '8025:8025'
     networks: [default]
 
   # --- Hatchet workflow engine (gRPC :7077, http :8888). Reached at hatchet:7077
@@ -69,9 +63,6 @@ services:
       SERVER_URL: http://hatchet:8888
       SERVER_AUTH_SET_EMAIL_VERIFIED: 't'
       SERVER_DEFAULT_ENGINE_VERSION: 'V1'
-    ports:
-      - '8888:8888'
-      - '7077:7077'
     volumes:
       - hatchet_lite_config:/config
     networks: [default]
@@ -126,15 +117,6 @@ services:
     init: true # tini PID1 reaps the dev servers' zombie children (GOTCHAS #10)
     env_file:
       - devcontainer.env
-    ports:
-      - '3000:3000' # api / assessment-api
-      - '3001:3001' # pwa / assessment-pwa
-      - '3002:3002' # manage
-      - '3003:3003' # control
-      - '3004:3004' # chat
-      - '3010:3010' # auth
-      - '3030:3030' # olat-api
-      - '7078:7078' # response-api
     networks:
       - default
     volumes:
@@ -154,8 +136,6 @@ services:
   # --- LiteLLM for Chat (Tier 3) ---
   litellm:
     image: ghcr.io/berriai/litellm:main-v1.61.12
-    ports:
-      - '4000:4000'
     volumes:
       - ../util/litellm/config.yaml:/app/config.yaml:ro
     command:

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -35,6 +35,35 @@ if [ ! -f /etc/devrouter/mkcert-rootCA.pem ]; then
   export NEXT_PUBLIC_CHAT_URL=http://localhost:3004
   export CORS_ALLOWED_ORIGINS=http://localhost:3001
   export NODE_EXTRA_CA_CERTS=""
+elif [ -n "${WORKSPACE:-}" ]; then
+  # devrouter namespaces route hosts for linked worktrees:
+  # manage.klicker.localhost -> manage.klicker.<workspace>.localhost.
+  DEVROUTER_DOMAIN="klicker.${WORKSPACE}.localhost"
+  export APP_ORIGIN_API="https://api.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_AUTH="https://auth.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_PWA="https://pwa.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_MANAGE="https://manage.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_CONTROL="https://control.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_ASSESSMENT_API="https://api.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_ASSESSMENT_PWA="https://pwa.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_LTI="https://lti.${DEVROUTER_DOMAIN}"
+  export APP_ORIGIN_CHAT="https://chat.${DEVROUTER_DOMAIN}"
+  export APP_MANAGE_SUBDOMAIN="manage.${DEVROUTER_DOMAIN}"
+  export APP_STUDENT_SUBDOMAIN="pwa.${DEVROUTER_DOMAIN}"
+  export APP_CONTROL_SUBDOMAIN="control.${DEVROUTER_DOMAIN}"
+  export NEXTAUTH_URL="https://auth.${DEVROUTER_DOMAIN}"
+  export AUTH_LECTURER_ALLOWED_HOSTS="manage.${DEVROUTER_DOMAIN},127.0.0.1:3002"
+  export AUTH_STUDENT_ALLOWED_HOSTS="pwa.${DEVROUTER_DOMAIN},127.0.0.1:3001"
+  export COOKIE_DOMAIN="${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_API_URL="https://api.${DEVROUTER_DOMAIN}/api/graphql"
+  export NEXT_PUBLIC_AUTH_URL="https://auth.${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_MANAGE_URL="https://manage.${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_PWA_URL="https://pwa.${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_ASSESSMENT_URL="https://pwa.${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_CONTROL_URL="https://control.${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_ADD_RESPONSE_URL="https://response-api.${DEVROUTER_DOMAIN}"
+  export NEXT_PUBLIC_CHAT_URL="https://chat.${DEVROUTER_DOMAIN}"
+  export CORS_ALLOWED_ORIGINS="https://pwa.${DEVROUTER_DOMAIN}"
 fi
 
 # No-TTY pnpm hardening (see post-create.sh). (GOTCHAS #18)
@@ -72,19 +101,19 @@ setsid bash -c "$DEV_CMD" >/tmp/dev.log 2>&1 </dev/null &
 disown 2>/dev/null || true
 
 if [ -f /etc/devrouter/mkcert-rootCA.pem ]; then
-  cat <<'EOF'
+cat <<EOF
 [post-start] Apps (via devrouter; first compile can take a minute):
-[post-start]   API          -> https://api.klicker.localhost
-[post-start]   Auth         -> https://auth.klicker.localhost
-[post-start]   PWA          -> https://pwa.klicker.localhost
-[post-start]   Manage       -> https://manage.klicker.localhost   (login: lecturer / abcd)
-[post-start]   Control      -> https://control.klicker.localhost
-[post-start]   OLAT API     -> https://olat-api.klicker.localhost  (/health, /api-docs; bearer OLAT_API_KEY)
-[post-start]   Response API -> https://response-api.klicker.localhost
-[post-start]   LTI Service  -> https://lti.klicker.localhost
-[post-start]   Chat         -> https://chat.klicker.localhost (requires UPSTREAM_OPENAI_API_KEY)
+[post-start]   API          -> ${APP_ORIGIN_API}
+[post-start]   Auth         -> ${APP_ORIGIN_AUTH}
+[post-start]   PWA          -> ${APP_ORIGIN_PWA}
+[post-start]   Manage       -> ${APP_ORIGIN_MANAGE}   (login: lecturer / abcd)
+[post-start]   Control      -> ${APP_ORIGIN_CONTROL}
+[post-start]   OLAT API     -> https://olat-api.${COOKIE_DOMAIN}  (/health, /api-docs; bearer OLAT_API_KEY)
+[post-start]   Response API -> ${NEXT_PUBLIC_ADD_RESPONSE_URL}
+[post-start]   LTI Service  -> ${APP_ORIGIN_LTI}
+[post-start]   Chat         -> ${NEXT_PUBLIC_CHAT_URL} (requires UPSTREAM_OPENAI_API_KEY)
 [post-start]   Workers      -> hatchet-worker-general + -response-processor (no URL; consume hatchet queue)
-[post-start] Routes  -> on the host: for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
+[post-start] Routes  -> on the host: for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "\$a"; done
 [post-start] Logs    -> tail -f /tmp/dev.log
 EOF
 else

--- a/.devrouter.yml
+++ b/.devrouter.yml
@@ -1,8 +1,9 @@
-# Proxy-only routing over the shared external `devnet` network by container name
-# (NO published host ports). The monorepo runs every app in the ONE `klicker-app`
-# container via `turbo dev`; each hostname routes to that container's internal
-# port. devrouter's Traefik fronts everything on the shared :443 / :5432, so
-# klicker coexists with the other devcontainers with zero collisions.
+# Proxy-only routing over the shared external `devnet` network by container
+# alias (NO published host ports in devrouter mode). The monorepo runs every app
+# in one container via `turbo dev`; each hostname routes to that container's
+# internal port. `${WORKSPACE}` is substituted by devrouter at runtime so
+# parallel worktrees target distinct aliases (`<workspace>-app` / `<workspace>-db`)
+# instead of all sharing one `klicker-app`.
 # Full walkthrough: devrouter docs/DEVCONTAINER.md.
 #
 # Usage: `dev up` + `dev tls install` (creates devnet + the mkcert CA), THEN
@@ -14,7 +15,7 @@
 # Phase 2: lti (4000) and chat (3004).
 version: 1
 devrouter:
-  version: 0.0.21 # proxy + protocol: tcp requires >= 0.0.21
+  version: 0.0.23 # workspace-aware proxy upstreams require >= 0.0.21
 project:
   name: klicker-uzh
 apps:
@@ -23,51 +24,51 @@ apps:
     host: api.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3000
+    upstream: ${WORKSPACE}-app:3000
 
   # auth (NextAuth; credentials login as lecturer/abcd, no EduID needed)
   - name: auth
     host: auth.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3010
+    upstream: ${WORKSPACE}-app:3010
 
   # student PWA
   - name: pwa
     host: pwa.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3001
+    upstream: ${WORKSPACE}-app:3001
 
   # lecturer management UI
   - name: manage
     host: manage.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3002
+    upstream: ${WORKSPACE}-app:3002
 
   # live-quiz control UI
   - name: control
     host: control.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3003
+    upstream: ${WORKSPACE}-app:3003
 
   # OLAT inbound REST API (dev port 3030; bearer OLAT_API_KEY). /health + /api-docs.
   - name: olat-api
     host: olat-api.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3030
+    upstream: ${WORKSPACE}-app:3030
 
   # response-api: receives live-quiz responses from the PWA, pushes hatchet events.
   - name: response-api
     host: response-api.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:7078
+    upstream: ${WORKSPACE}-app:7078
 
-  # Postgres: db.klicker.localhost:5432 -> `klicker-db` (SNI). Connect with
+  # Postgres: db.klicker.localhost:5432 -> `${WORKSPACE}-db` (SNI). Connect with
   # direct-SSL so the ClientHello carries the SNI (libpq 17+): psql
   # "host=db.klicker.localhost port=5432 user=klicker-prod password=klicker
   # dbname=klicker-prod sslmode=require sslnegotiation=direct"  (GOTCHAS #17)
@@ -76,18 +77,18 @@ apps:
     protocol: tcp
     tcpProtocol: postgres
     runtime: proxy
-    upstream: klicker-db:5432
+    upstream: ${WORKSPACE}-db:5432
 
   # lti-service: pre-built, runs on 4000. Full LTI launch requires external LMS.
   - name: lti
     host: lti.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:4000
+    upstream: ${WORKSPACE}-app:4000
 
   # chat: needs UPSTREAM_OPENAI_API_KEY. runs on 3004.
   - name: chat
     host: chat.klicker.localhost
     protocol: http
     runtime: proxy
-    upstream: klicker-app:3004
+    upstream: ${WORKSPACE}-app:3004

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,14 +132,16 @@ devpod ssh klicker-uzh # shell inside the container
 
 The dev servers auto-start in the background (`tail -f /tmp/dev.log`; first compile takes ~1min). Re-run lifecycle by hand inside the container: `bash .devcontainer/post-create.sh` / `bash .devcontainer/post-start.sh`. Covers the core apps (backend, auth, frontend-pwa/manage/control) plus olat-api, response-api, and the two Hatchet workers (Phase 2 Tier 1; workers have no port/route); All runnable apps are included (no analytics/office-addin/docs). See `.devcontainer/README.md`.
 
-**Routing (devrouter — when available):** nothing is published on the host; [devrouter](https://github.com/rschlaefli/devrouter) (≥ 0.0.21) fronts the stack over the shared `devnet` network and routes each `*.klicker.localhost` host to the one container's internal port. One-time host setup **before** the container starts:
+**Routing (devrouter — when available):** nothing is published on the host; [devrouter](https://github.com/rschlaefli/devrouter) (≥ 0.0.23 recommended; ≥ 0.0.21 required) fronts the stack over the shared `devnet` network and routes each `*.klicker.localhost` host to the one container's internal port. The devrouter overlay uses `${WORKSPACE}-app` / `${WORKSPACE}-db` aliases, so parallel worktrees must use one stable token for both DevPod and route registration (`WORKSPACE=<slug> devpod up .`, then `devrouter app run <app> --workspace <slug>`). One-time host setup **before** the container starts:
 
 ```bash
-dev up && dev tls install                                       # Traefik + devnet + mkcert CA
-for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
+devrouter up && devrouter tls install                           # Traefik + devnet + mkcert CA
+for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a"; done
 ```
 
-Apps at `https://{api,auth,pwa,manage,control,olat-api,response-api}.klicker.localhost`; Postgres for host tooling at `db.klicker.localhost:5432` (`sslmode=require sslnegotiation=direct`). Login as `lecturer`/`abcd` (see test credentials below). Env in `.devcontainer/devcontainer.env` (committed, dev-only — no real secrets).
+Apps at `https://{api,auth,pwa,manage,control,olat-api,response-api}.klicker.localhost` for the primary checkout, or `https://{app}.klicker.<workspace>.localhost` for a linked worktree; Postgres for host tooling at `db.klicker[.<workspace>].localhost:5432` (`sslmode=require sslnegotiation=direct`). Login as `lecturer`/`abcd` (see test credentials below). Env in `.devcontainer/devcontainer.env` (committed, dev-only — no real secrets).
+
+**Media uploads and Blob CORS:** the manage media library uploads directly from the browser to Azure Blob Storage with a SAS URL. The storage account's Blob service CORS must allow the actual local origin (`https://manage.klicker.localhost` or `https://manage.klicker.<workspace>.localhost`), not only production origins such as `https://manage.klicker.com`. For a dedicated dev storage account, use a dev-only rule like `https://*.localhost`; keep production storage accounts exact.
 
 ### Legacy host-based stack
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 type: Guide
 title: Getting Started
 description: Toolchain, first-time setup, infrastructure bring-up, dev-server paths, and the exact failure signatures a fresh clone produces.
-timestamp: '2026-07-07'
+timestamp: '2026-07-08'
 tags:
   - environment
   - onboarding
@@ -30,17 +30,32 @@ Clone-and-run via a self-contained devcontainer — no Infisical, no external Ed
    devpod ssh klicker-uzh # shell inside the container
    ```
 2. **Accessing the apps:**
-   - **Mode 1 (Plain localhost - default):** Exposed directly on host ports: Student PWA at `http://localhost:3001`, Lecturer UI at `http://localhost:3002` (login: `lecturer`/`abcd`).
-   - **Mode 2 (devrouter overlay):** Routes local traffic over HTTPS: `https://manage.klicker.localhost`. Requires:
-     1. Edit `.devcontainer/devcontainer.json` to include the devrouter overlay:
+   - **Mode 1 (Plain localhost fallback):** Exposed directly on host ports after editing `.devcontainer/devcontainer.json` to use `["docker-compose.yml", "docker-compose.localhost.yml"]`: Student PWA at `http://localhost:3001`, Lecturer UI at `http://localhost:3002` (login: `lecturer`/`abcd`).
+   - **Mode 2 (devrouter overlay):** Routes local traffic over HTTPS: `https://manage.klicker.localhost` for the primary checkout and `https://manage.klicker.<workspace>.localhost` for linked worktrees. Requires:
+     1. Ensure `.devcontainer/devcontainer.json` includes the devrouter overlay:
         ```json
         "dockerComposeFile": ["docker-compose.yml", "docker-compose.devrouter.yml"]
         ```
-     2. Start the devcontainer (`devpod up .`).
-     3. Install `devrouter` on host and register the application routes:
+     2. Start devrouter on the host (`devrouter up && devrouter tls install`).
+     3. Start the devcontainer (`devpod up .`) or, for a parallel worktree, start it with a stable token (`WORKSPACE=<slug> devpod up .`).
+     4. Register the application routes with the same workspace token:
         ```bash
-        for a in api auth pwa manage control olat-api response-api lti chat db; do dev app run "$a"; done
+        for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a"; done
+        # linked worktree variant:
+        for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a" --workspace <slug>; done
         ```
+     5. If you use Azure Blob media uploads in manage, configure the **dev** storage account's Blob service CORS for local devrouter origins. The browser uploads directly to Blob Storage via SAS, so a storage rule that only allows `https://manage.klicker.com` will reject `https://manage.klicker.localhost` and `https://manage.klicker.<workspace>.localhost`. For a dedicated dev account, allow local devrouter origins with:
+        ```bash
+        az storage account blob-service-properties cors-rule add \
+          --account-name <dev-storage-account> \
+          --resource-group <resource-group> \
+          --allowed-origins "https://*.localhost" \
+          --allowed-methods PUT GET HEAD \
+          --allowed-headers "*" \
+          --exposed-headers "*" \
+          --max-age 3600
+        ```
+        Keep production storage accounts on exact production/staging origins; if wildcard localhost is not allowed by policy, add the exact active worktree origin instead.
 3. **Logs:** The dev servers auto-start inside the container. View logs via `tail -f /tmp/dev.log`.
 
 ### Path B: Host-based Setup (Legacy)
@@ -83,7 +98,7 @@ Order matters: on a fresh clone, `pnpm run check` fails in ~19 packages until `p
 
 Two traps:
 
-- **The compose project name derives from the directory name.** A git worktree therefore gets its own parallel container/volume set — but the same host ports. Only one stack variant can run per machine.
+- **The legacy/localhost paths publish fixed host ports.** A git worktree gets its own parallel container/volume set, but these modes still fight over host ports. Use the devrouter overlay for parallel worktrees: it keeps host ports unpublished and routes through `${WORKSPACE}-app` / `${WORKSPACE}-db` aliases on `devnet`.
 - **`_run_app_dependencies.sh` is interactive and self-destructing for agents.** It has two `confirm` prompts, a foreground `docker compose logs -f`, and `trap cleanup INT TERM HUP EXIT` that runs `./_down.sh` — a headless agent running it will hang, then tear down the stack it just started on shell exit. Headless path: run its steps individually (`./util/sync-schema.sh` → certs on macOS → `docker compose up -d <services>` → `.github/scripts/wait-for-infra.sh` → hatchet token → `prisma:push`).
 
 ## Running the apps (config-derived — not executed in the wiki engagement; verify on your machine)

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## 2026-07-08
+
+- **Update**: [getting-started](./getting-started.md) documents parallel devrouter worktrees. The base devcontainer compose file no longer publishes host ports; devrouter mode uses `${WORKSPACE}`-scoped app/DB aliases, while fixed localhost ports moved to a dedicated fallback overlay.
+
+- **Update**: devcontainer docs now call out direct Azure Blob media uploads as a storage-account CORS concern. Parallel devrouter worktrees need the dev Blob service to allow local origins such as `https://manage.klicker.<workspace>.localhost`; production accounts should keep exact origin rules.
+
 ## 2026-07-07
 
 - **Update**: migration-in-flight banners added to [graphql-api-layer](./graphql-api-layer.md), [architecture-overview](./architecture-overview.md) (GraphQL→tRPC, PR #5132), and [chat-platform](./chat-platform.md) (AI-SDK→Mastra, PRs #5126/#5129) — pages stay authoritative until those PRs merge.


### PR DESCRIPTION
## Description

Makes the devcontainer/devrouter setup usable across multiple parallel Klicker worktrees without host-port or route collisions.

ClickUp Task: N/A

## Proposed Changes

- Switch devcontainer routing to devrouter mode by default and move fixed localhost port publishing into a dedicated fallback overlay.
- Update `.devrouter.yml` to use workspace-aware upstreams (`${WORKSPACE}-app`, `${WORKSPACE}-db`) so each worktree routes to its own container aliases.
- Add `WORKSPACE`-aware devcontainer aliases and internal host mappings for namespaced devrouter hosts.
- Update `post-start.sh` to rewrite app/auth/cookie/public origins for linked worktrees, e.g. `https://manage.klicker.<workspace>.localhost`.
- Document the parallel worktree workflow and the one-at-a-time localhost fallback.
- Document the Azure Blob Storage CORS caveat for manage media uploads: browser-side SAS uploads need the dev storage account to allow the actual local origin, e.g. `https://manage.klicker.<workspace>.localhost` or a dev-only `https://*.localhost` rule.

## How to Test & Verification Evidence

### Automated Verification

- [ ] Run `pnpm run check:all` (linting, typechecking, formatting, syncpack)
- [ ] Run target unit tests (`pnpm --filter <package> test`)
- [x] Ran Prettier on touched docs/config files
- [x] Ran `bash -n .devcontainer/post-start.sh`
- [x] Rendered Docker Compose config for devrouter mode
- [x] Rendered Docker Compose config with `WORKSPACE=parallel-a`
- [x] Rendered Docker Compose config for localhost fallback overlay
- [x] Ran `devrouter repo devcontainer verify --json`
  - Result: `5 ok, 0 warn, 0 error`
- [x] Ran `git diff --check`

### Manual/Visual Verification

- No UI-facing app changes; no screenshots required.
- Repro for parallel setup:
  ```bash
  devrouter up && devrouter tls install

  # Primary checkout
  devpod up .
  for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a"; done

  # Linked worktree
  WORKSPACE=my-branch devpod up .
  for a in api auth pwa manage control olat-api response-api lti chat db; do devrouter app run "$a" --workspace my-branch; done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace-aware devcontainer workflow for running parallel checkouts with unique local URLs.
  * Added a fallback localhost mode for simpler single-stack development.

* **Bug Fixes**
  * Reduced port conflicts by removing fixed host port publishing from the main dev setup.
  * Improved media upload troubleshooting by documenting required Azure Blob CORS settings for local dev origins.

* **Documentation**
  * Updated setup and routing guides to reflect the new HTTPS/devrouter flow and worktree-based access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->