### PR TITLE
docs(agents): pre-commit data-hygiene rule + ignore internal PM/PII artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,11 @@ output/
 .devcontainer/.hatchet.env
 playwright/playwright-report/
 playwright/test-results/
+
+# One-off course data pulls (contain real participant data — never commit)
+packages/prisma-data/summerschool_*
+packages/prisma-data/src/data/summerschool_*
+
+# Internal PM/business artifacts — public repo, keep local only (roadmap,
+# backlog/ClickUp dumps, triage records, product strategy/vision briefs)
+project/_local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,8 @@ Traefik reverse proxy serves the apps on `*.klicker.com` domains (needs `/etc/ho
 - **Task tracking**: ClickUp is the source of truth; GitHub Issues are not actively used.
 - Dev scripts use `./util/_run_with_infisical.sh` for secret injection. Avoid starting dev servers unless explicitly asked.
 - If you add or rename an Infisical-managed env var/secret, also update `turbo.json` `globalEnv` so Turborepo sees it during task execution and cache invalidation.
-- Never commit secrets, `.env` files, or credentials.
+- Never commit secrets, `.env` files, or credentials. **This repo is public** — anything committed on any branch, once pushed, is permanent public history that deleting the file later does not remove.
+- **Data hygiene before every commit.** Review staged content (`git diff --cached`, and open any staged data file) for secrets _and_ real personal data — participant/student names, email addresses, matriculation/Studi-IDs, raw response exports, course rosters. Be especially wary of bulk data files (`.csv`, `.json`, `.sql` dumps): these are the highest-risk carriers and are easy to sweep in with `git add .`. Real course-data pulls belong outside the repo (add a `.gitignore` rule); if such data must be versioned, it goes in a private location with direct identifiers removed first. Pseudonymous ids (participant UUIDs) are lower-risk but still get the same scrutiny. When in doubt, do not commit — ask.
 - Keep changes small, follow existing patterns in the touched app/package.
 - Don't add/update dependencies unless required for the task.
 - Feature branches from `v3`. Conventional commits preferred.


### PR DESCRIPTION
## What

A pre-commit data-hygiene guardrail, plus `.gitignore` rules that keep two classes of never-commit content out of this **public** repo. No application code, no committed artifacts.

## Why

This repo is public and its history is permanent. Two near-misses during backlog work motivated this:

1. A real course-data CSV (full participant names) ended up staged-adjacent — one careless `git add .` from a PII leak.
2. Internal PM/business material (roadmap, ClickUp/backlog dumps, product strategy) is fine to keep locally but should never enter public history.

## Changes

- `AGENTS.md` — extends the "never commit secrets" note: the repo is public and permanent, plus a **"Data hygiene before every commit"** bullet (review `git diff --cached` and any staged data file for names/emails/matriculation IDs/exports/rosters; treat `.csv`/`.json`/`.sql` dumps as highest-risk; keep real course-data pulls out of the repo; when in doubt, don't commit).
- `.gitignore` — ignore (a) one-off `packages/prisma-data/summerschool_*` course-data pulls, and (b) `project/_local/` for internal PM/business artifacts kept local-only.

## Notes

- The internal PM artifacts that an earlier revision of this PR committed (backlog ledger, roadmap timeline, triage records, strategy briefs) have been removed — they live under the now-ignored `project/_local/` locally and are not part of this branch. The branch was force-pushed to drop those commits.
- `.gitignore` (a) is redundant with the broader `packages/prisma-data/.gitignore` glob landed in #5160; kept as a self-documenting belt-and-suspenders for the real-PII case.
- Passes `util/check-agents-md.mjs` (zero warnings), `prettier --check`, and `gitleaks`.
