### PR TITLE
fix(markdown): harden external video embeds

### DIFF
--- a/.github/workflows/test-markdown.yml
+++ b/.github/workflows/test-markdown.yml
@@ -1,0 +1,43 @@
+name: Test markdown package functionalities
+
+on:
+  push:
+    branches: ['v3', 'v3*']
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-markdown:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for changes
+        id: filter
+        uses: ./.github/actions/changed-paths
+        with:
+          pattern: '^(packages/markdown/|package\.json|pnpm-lock\.yaml|tsconfig\.json|\.github/workflows/test-markdown\.yml|\.github/actions/changed-paths/)'
+
+      - name: Define node version
+        if: steps.filter.outputs.should_run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - uses: pnpm/action-setup@v4
+        if: steps.filter.outputs.should_run == 'true'
+        with:
+          version: 11.5.0
+          run_install: true
+
+      - name: Test markdown package
+        if: steps.filter.outputs.should_run == 'true'
+        run: pnpm --filter @klicker-uzh/markdown test

--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -2,7 +2,7 @@
 type: Frontend Conventions
 title: Frontend Conventions
 description: Shared conventions for manage, pwa, control, and auth — design system, Apollo with generated ops, i18n, Formik, data-cy, and CSP rules.
-timestamp: '2026-07-08'
+timestamp: '2026-07-15'
 tags:
   - frontend
 ---
@@ -22,9 +22,10 @@ Scope: `frontend-manage`, `frontend-pwa`, `frontend-control`, `auth` — all Nex
 
 ## Markdown and Video Embeds
 
-- **Link Interception for Videos**: Links in markdown fields (`@klicker-uzh/markdown`) with a plain, unformatted text label of `video` or `embed` (case-insensitive, trimmed) targeting YouTube or UZH Kaltura (SWITCHcast) are automatically intercepted and rendered as responsive `<iframe />` players via `VideoEmbed`.
-- **Kaltura PlaykitJs Bypass**: To prevent frame-based third-party cookie login loops, Kaltura embeds resolve the video's `entryId` (requires the standard `0_` or `1_` prefix followed by 8 alphanumeric characters) and parse `partnerId` (defaults to `106`) and `uiConfId` (defaults to `23449004`) to render using the PlaykitJs secure embed structure:
-  `https://api.cast.switch.ch/p/${partnerId}/embedPlaykitJs/uiconf_id/${uiConfId}/partner_id/${partnerId}?iframeembed=true&playerId=kaltura_player&entry_id=${entryId}`
+- **Plain-link trigger**: Any plain, unformatted markdown link labelled `video` or `embed` (case-insensitive, trimmed) with a supported URL is rendered as a responsive iframe. The player uses a block-styled phrasing wrapper so links keep the original interception behavior inside paragraphs, lists, headings, and tables without producing invalid `<p><div>` markup. Formatted labels, unsupported hosts, malformed IDs, and other link labels stay regular links.
+- **YouTube URLs**: Allowlisted `youtube.com/watch`, `youtu.be`, and `youtube.com/embed` links are supported. Video IDs must contain exactly 11 valid characters.
+- **Kaltura URLs**: MediaSpace, legacy `entryId` / `partner_id` / `uiConfId`, and PlayKit `/p/{partnerId}` / `/uiconf_id/{uiConfId}` forms are supported. Entry IDs require `0_` or `1_` plus 8 alphanumeric characters; partner/UI configuration defaults to `106` / `23449004`. Generic Kaltura origins intentionally normalize to the UZH SWITCHcast player for now.
+- **Player behavior**: YouTube and Kaltura render immediately with the original 16:9 responsive dimensions, accessible provider title, lazy loading, and fullscreen support.
 
 ## Data fetching
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-07-15
+
+- **Update**: [frontend-conventions](./frontend-conventions.md) and [testing](./testing.md) document valid-DOM video-link rendering, the supported YouTube/Kaltura forms, and editor/mobile overflow coverage.
+
 ## 2026-07-08
 
 - **Update**: [frontend-conventions](./frontend-conventions.md) updated with Markdown link interception behavior and Kaltura PlaykitJs bypass player details.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 type: Testing Guide
 title: Testing
 description: Which test level to use when, what runs safely without services, the two e2e stacks and their seeds, and the CI test matrix.
-timestamp: '2026-07-07'
+timestamp: '2026-07-15'
 tags:
   - testing
   - ci
@@ -14,11 +14,11 @@ tags:
 
 ## Which level for which change
 
-| Change                                                     | Test level                                                                                 | Command                                                                                            |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| Pure logic (grading, util, export, word-cloud, chat logic) | package vitest — **safe without any services**                                             | `pnpm --filter @klicker-uzh/grading test` (etc.)                                                   |
-| GraphQL services/resolvers                                 | `packages/graphql` vitest — needs REAL Postgres + Redis + Hatchet + `HATCHET_CLIENT_TOKEN` | `pnpm --filter @klicker-uzh/graphql test:local` (one-command bootstrap: `test/run-tests-local.sh`) |
-| UI / user flows                                            | Playwright e2e (new specs); Cypress only for legacy maintenance                            | see routing below                                                                                  |
+| Change                                                               | Test level                                                                                 | Command                                                                                            |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Pure logic (grading, util, export, word-cloud, markdown, chat logic) | package vitest — **safe without any services**                                             | `pnpm --filter @klicker-uzh/grading test` (etc.)                                                   |
+| GraphQL services/resolvers                                           | `packages/graphql` vitest — needs REAL Postgres + Redis + Hatchet + `HATCHET_CLIENT_TOKEN` | `pnpm --filter @klicker-uzh/graphql test:local` (one-command bootstrap: `test/run-tests-local.sh`) |
+| UI / user flows                                                      | Playwright e2e (new specs); Cypress only for legacy maintenance                            | see routing below                                                                                  |
 
 **Never run root `pnpm run test:run` blind** — the turbo fan-out includes Cypress, which needs a running, seeded stack. The graphql vitest config forces `pool: forks, singleFork: true` (serialized specs sharing DB state) — don't parallelize it.
 
@@ -43,10 +43,11 @@ For authoring specifics, helper patterns, and failure triage, use the skills —
 
 - Tests that **publish, schedule, or end activities** need the Hatchet **general worker** running on top of the test stack — otherwise mutations fail with `workflow not found`. The worker needs `DATABASE_URL` pointed at the test DB ([Async & Workers](./async-and-workers.md)).
 - **Live-quiz response tests** additionally need `response-api` + the response processor with the same `APP_SECRET`/Redis/Postgres settings — otherwise the UI accepts answers that never reach cockpit/evaluation.
+- Markdown video integration is covered on genuine Manage element-editor and mobile PWA live-quiz surfaces in `playwright/tests/0-video-embed.spec.ts`. The spec verifies immediate YouTube/Kaltura iframes, ordinary-link behavior, and the absence of horizontal overflow.
 - Cypress `cy.loginStudent()`/`cy.loginStudentPassword()` clear localforage by default; continuation tests that rely on stored answers pass `{ preserveClientState: true }`.
 
 ## CI matrix
 
-Path-filtered unit workflows: `test-grading`, `test-util` (package-only, no services), `test-graphql` (spins Postgres ×2 + hatchet-lite + Redis), `test-olat-api` (docker compose test stack). Playwright tests use a path-scoped filter and compile once in a `build-and-compile` job before running the 8 shards. All path-skipped workflows report through `-status` gates to satisfy branch protection. Cypress CI signal quirk: the merge-group check can show a rising failed count while `cypress-run-cloud` is still in progress — wait for cloud completion before reading logs.
+Path-filtered unit workflows: `test-grading`, `test-util`, `test-markdown` (package-only, no services), `test-graphql` (spins Postgres ×2 + hatchet-lite + Redis), `test-olat-api` (docker compose test stack). Playwright tests use a path-scoped filter and compile once in a `build-and-compile` job before running the 8 shards. All path-skipped workflows report through `-status` gates to satisfy branch protection. Cypress CI signal quirk: the merge-group check can show a rising failed count while `cypress-run-cloud` is still in progress — wait for cloud completion before reading logs.
 
 **Git hooks run no tests** (pre-commit = `check:all`, pre-push = `build`). The expectation before a PR: `check:all` + build + targeted vitest for touched logic + browser evidence for UI changes; CI is the real e2e gate.

--- a/packages/markdown/src/Markdown.tsx
+++ b/packages/markdown/src/Markdown.tsx
@@ -15,13 +15,8 @@ import remarkRehype from 'remark-rehype'
 import { twMerge } from 'tailwind-merge'
 import { unified } from 'unified'
 import ImgWithModal from './ImgWithModal.js'
-import {
-  VideoEmbed,
-  getKalturaId,
-  getKalturaPartnerId,
-  getKalturaUiConfId,
-  getYoutubeId,
-} from './VideoEmbed.js'
+import { VideoEmbed } from './VideoEmbed.js'
+import { parseVideoEmbedUrl } from './VideoEmbedUrl.js'
 
 export interface MarkdownProps {
   className?: {
@@ -155,27 +150,11 @@ function Markdown({
                     : ''
                 const isVideoLabel =
                   labelText === 'video' || labelText === 'embed'
-                const youtubeId =
-                  href && isVideoLabel ? getYoutubeId(href) : null
-                const kalturaId =
-                  href && isVideoLabel ? getKalturaId(href) : null
-                const kalturaPartnerId =
-                  href && kalturaId ? getKalturaPartnerId(href) : null
-                const kalturaUiConfId =
-                  href && kalturaId ? getKalturaUiConfId(href) : null
+                const video =
+                  href && isVideoLabel ? parseVideoEmbedUrl(href) : null
 
-                if (youtubeId) {
-                  return <VideoEmbed provider="youtube" videoId={youtubeId} />
-                }
-                if (kalturaId) {
-                  return (
-                    <VideoEmbed
-                      provider="kaltura"
-                      videoId={kalturaId}
-                      partnerId={kalturaPartnerId}
-                      uiConfId={kalturaUiConfId}
-                    />
-                  )
+                if (video) {
+                  return <VideoEmbed {...video} />
                 }
 
                 if (withLinkButtons) {
@@ -191,11 +170,11 @@ function Markdown({
                       rel={rel}
                       {...rest}
                     >
-                      <div>
+                      <span>
                         {isExcel && <FontAwesomeIcon icon={faFileExcel} />}
                         {isPDF && <FontAwesomeIcon icon={faFilePdf} />}
-                      </div>
-                      <div>{children}</div>
+                      </span>
+                      <span>{children}</span>
                     </a>
                   )
                 }

--- a/packages/markdown/src/VideoEmbed.tsx
+++ b/packages/markdown/src/VideoEmbed.tsx
@@ -1,153 +1,21 @@
 import React from 'react'
+import { getVideoEmbedSrc, type VideoEmbedDescriptor } from './VideoEmbedUrl.js'
 
-export function getYoutubeId(url: string): string | null {
-  try {
-    const parsed = new URL(url)
-    const host = parsed.hostname.toLowerCase()
-    const isYoutubeHost =
-      host === 'youtube.com' ||
-      host.endsWith('.youtube.com') ||
-      host === 'youtu.be' ||
-      host.endsWith('.youtu.be')
-    if (!isYoutubeHost) {
-      return null
-    }
-
-    if (host.endsWith('youtu.be')) {
-      const id = parsed.pathname.slice(1)
-      if (/^[a-zA-Z0-9_-]{11}$/.test(id)) {
-        return id
-      }
-    }
-    if (parsed.pathname.startsWith('/embed/')) {
-      const id = parsed.pathname.split('/')[2]
-      if (id && /^[a-zA-Z0-9_-]{11}$/.test(id)) {
-        return id
-      }
-    }
-    const v = parsed.searchParams.get('v')
-    if (v && /^[a-zA-Z0-9_-]{11}$/.test(v)) {
-      return v
-    }
-
-    const regExp =
-      /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
-    const match = url.match(regExp)
-    const id = match?.[2]
-    return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null
-  } catch {
-    // Ignore URL parse error for relative/broken URLs
-    return null
-  }
-}
-
-export function getKalturaId(url: string): string | null {
-  try {
-    const parsedUrl = new URL(url)
-    const host = parsedUrl.hostname.toLowerCase()
-    const isKalturaHost =
-      host === 'kaltura.com' ||
-      host.endsWith('.kaltura.com') ||
-      host === 'cast.switch.ch' ||
-      host.endsWith('.cast.switch.ch')
-    if (!isKalturaHost) {
-      return null
-    }
-
-    const mediaSpaceMatch = url.match(
-      /\/media\/(?:t\/|[^/]+\/)?([01]_[a-zA-Z0-9]{8})(?:[/?#]|$)/
-    )
-    if (mediaSpaceMatch && mediaSpaceMatch[1]) {
-      return mediaSpaceMatch[1]
-    }
-
-    const entryIdPathMatch = url.match(
-      /\/entryId\/([01]_[a-zA-Z0-9]{8})(?:[/?#]|$)/i
-    )
-    if (entryIdPathMatch && entryIdPathMatch[1]) {
-      return entryIdPathMatch[1]
-    }
-
-    const entryId = parsedUrl.searchParams.get('entry_id')
-    if (entryId && /^[01]_[a-zA-Z0-9]{8}$/.test(entryId)) {
-      return entryId
-    }
-  } catch {
-    // Ignore URL parse error
-  }
-  return null
-}
-
-export function getKalturaUiConfId(url: string): string {
-  try {
-    const pathMatch = url.match(/\/uiConfId\/(\d+)/i)
-    if (pathMatch && pathMatch[1]) {
-      return pathMatch[1]
-    }
-    const parsedUrl = new URL(url)
-    const queryId =
-      parsedUrl.searchParams.get('uiconf_id') ||
-      parsedUrl.searchParams.get('uiConfId')
-    if (queryId && /^\d+$/.test(queryId)) {
-      return queryId
-    }
-  } catch {
-    // Ignore URL parse error
-  }
-  return '23449004'
-}
-
-export function getKalturaPartnerId(url: string): string {
-  try {
-    const pathMatch = url.match(/\/partner_id\/(\d+)/i)
-    if (pathMatch && pathMatch[1]) {
-      return pathMatch[1]
-    }
-    const parsedUrl = new URL(url)
-    const queryId =
-      parsedUrl.searchParams.get('partner_id') ||
-      parsedUrl.searchParams.get('partnerId')
-    if (queryId && /^\d+$/.test(queryId)) {
-      return queryId
-    }
-  } catch {
-    // Ignore URL parse error
-  }
-  return '106'
-}
-
-interface VideoEmbedProps {
-  provider: 'youtube' | 'kaltura'
-  videoId: string
-  partnerId?: string | null
-  uiConfId?: string | null
-}
-
-export function VideoEmbed({
-  provider,
-  videoId,
-  partnerId,
-  uiConfId,
-}: VideoEmbedProps): React.ReactElement {
-  const src =
-    provider === 'youtube'
-      ? `https://www.youtube.com/embed/${videoId}`
-      : `https://api.cast.switch.ch/p/${partnerId || '106'}/embedPlaykitJs/uiconf_id/${uiConfId || '23449004'}/partner_id/${partnerId || '106'}?iframeembed=true&playerId=kaltura_player&entry_id=${videoId}`
+export function VideoEmbed(
+  descriptor: VideoEmbedDescriptor
+): React.ReactElement {
+  const providerName = descriptor.provider === 'youtube' ? 'YouTube' : 'Kaltura'
 
   return (
-    <div className="my-4 aspect-video w-full overflow-hidden rounded-md border border-slate-200">
+    <span className="my-4 block aspect-video w-full overflow-hidden rounded-md border border-slate-200">
       <iframe
-        title={
-          provider === 'youtube'
-            ? 'YouTube video player'
-            : 'Kaltura video player'
-        }
-        src={src}
+        title={`${providerName} video player`}
+        src={getVideoEmbedSrc(descriptor)}
         className="h-full w-full border-0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
         loading="lazy"
       />
-    </div>
+    </span>
   )
 }

--- a/packages/markdown/src/VideoEmbedUrl.ts
+++ b/packages/markdown/src/VideoEmbedUrl.ts
@@ -1,0 +1,152 @@
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/
+const KALTURA_ENTRY_ID_PATTERN = /^[01]_[a-zA-Z0-9]{8}$/
+const NUMERIC_ID_PATTERN = /^\d+$/
+const KALTURA_MEDIA_PATH_PATTERN =
+  /\/media\/(?:t\/|[^/]+\/)?([01]_[a-zA-Z0-9]{8})(?:\/|$)/
+const KALTURA_ENTRY_PATH_PATTERN = /\/entryId\/([01]_[a-zA-Z0-9]{8})(?:\/|$)/i
+const KALTURA_PARTNER_PATH_PATTERNS = [
+  /\/p\/(\d+)(?:\/|$)/i,
+  /\/partner_id\/(\d+)(?:\/|$)/i,
+]
+const KALTURA_UI_CONF_PATH_PATTERNS = [
+  /\/uiconf_id\/(\d+)(?:\/|$)/i,
+  /\/uiConfId\/(\d+)(?:\/|$)/i,
+]
+
+export const DEFAULT_KALTURA_PARTNER_ID = '106'
+export const DEFAULT_KALTURA_UI_CONF_ID = '23449004'
+
+export type VideoEmbedDescriptor =
+  | {
+      provider: 'youtube'
+      videoId: string
+    }
+  | {
+      provider: 'kaltura'
+      videoId: string
+      partnerId: string
+      uiConfId: string
+    }
+
+function isHostOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`)
+}
+
+function getPathMatch(
+  pathname: string,
+  patterns: RegExp[]
+): string | undefined {
+  for (const pattern of patterns) {
+    const match = pathname.match(pattern)?.[1]
+    if (match) {
+      return match
+    }
+  }
+
+  return undefined
+}
+
+function getNumericQueryValue(url: URL, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = url.searchParams.get(name)
+    if (value && NUMERIC_ID_PATTERN.test(value)) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+function getYoutubeVideoId(url: URL): string | undefined {
+  const hostname = url.hostname.toLowerCase()
+
+  if (isHostOrSubdomain(hostname, 'youtu.be')) {
+    const videoId = url.pathname.match(/^\/([^/]+)\/?$/)?.[1]
+    return videoId && YOUTUBE_VIDEO_ID_PATTERN.test(videoId)
+      ? videoId
+      : undefined
+  }
+
+  if (!isHostOrSubdomain(hostname, 'youtube.com')) {
+    return undefined
+  }
+
+  const pathVideoId =
+    url.pathname.match(/^\/(?:embed|v)\/([^/]+)\/?$/)?.[1] ??
+    url.pathname.match(/^\/u\/[^/]+\/([^/]+)\/?$/)?.[1]
+  if (pathVideoId && YOUTUBE_VIDEO_ID_PATTERN.test(pathVideoId)) {
+    return pathVideoId
+  }
+
+  const queryVideoId = url.searchParams.get('v')
+  return queryVideoId && YOUTUBE_VIDEO_ID_PATTERN.test(queryVideoId)
+    ? queryVideoId
+    : undefined
+}
+
+function getKalturaVideoId(url: URL): string | undefined {
+  const mediaId = url.pathname.match(KALTURA_MEDIA_PATH_PATTERN)?.[1]
+  if (mediaId) {
+    return mediaId
+  }
+
+  const entryPathId = url.pathname.match(KALTURA_ENTRY_PATH_PATTERN)?.[1]
+  if (entryPathId) {
+    return entryPathId
+  }
+
+  const queryId = url.searchParams.get('entry_id')
+  return queryId && KALTURA_ENTRY_ID_PATTERN.test(queryId) ? queryId : undefined
+}
+
+export function parseVideoEmbedUrl(value: string): VideoEmbedDescriptor | null {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      return null
+    }
+
+    const youtubeId = getYoutubeVideoId(url)
+    if (youtubeId) {
+      return { provider: 'youtube', videoId: youtubeId }
+    }
+
+    const hostname = url.hostname.toLowerCase()
+    const isKalturaHost =
+      isHostOrSubdomain(hostname, 'kaltura.com') ||
+      isHostOrSubdomain(hostname, 'cast.switch.ch')
+    if (!isKalturaHost) {
+      return null
+    }
+
+    const kalturaId = getKalturaVideoId(url)
+    if (!kalturaId) {
+      return null
+    }
+
+    return {
+      provider: 'kaltura',
+      videoId: kalturaId,
+      partnerId:
+        getPathMatch(url.pathname, KALTURA_PARTNER_PATH_PATTERNS) ??
+        getNumericQueryValue(url, ['partner_id', 'partnerId']) ??
+        DEFAULT_KALTURA_PARTNER_ID,
+      uiConfId:
+        getPathMatch(url.pathname, KALTURA_UI_CONF_PATH_PATTERNS) ??
+        getNumericQueryValue(url, ['uiconf_id', 'uiConfId']) ??
+        DEFAULT_KALTURA_UI_CONF_ID,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function getVideoEmbedSrc(descriptor: VideoEmbedDescriptor): string {
+  if (descriptor.provider === 'youtube') {
+    return `https://www.youtube.com/embed/${descriptor.videoId}`
+  }
+
+  // Generic Kaltura links intentionally use the UZH SWITCHcast player for now.
+  // Tenant-specific Kaltura origins are not preserved by this integration.
+  return `https://api.cast.switch.ch/p/${descriptor.partnerId}/embedPlaykitJs/uiconf_id/${descriptor.uiConfId}/partner_id/${descriptor.partnerId}?iframeembed=true&playerId=kaltura_player&entry_id=${descriptor.videoId}`
+}

--- a/packages/markdown/test/VideoEmbed.test.ts
+++ b/packages/markdown/test/VideoEmbed.test.ts
@@ -1,147 +1,218 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import Markdown from '../src/Markdown.js'
 import {
-  getKalturaId,
-  getKalturaPartnerId,
-  getKalturaUiConfId,
-  getYoutubeId,
-} from '../src/VideoEmbed.js'
+  DEFAULT_KALTURA_PARTNER_ID,
+  DEFAULT_KALTURA_UI_CONF_ID,
+  getVideoEmbedSrc,
+  parseVideoEmbedUrl,
+} from '../src/VideoEmbedUrl.js'
 
-describe('VideoEmbed parsing utilities', () => {
-  describe('getYoutubeId', () => {
-    it('extracts ID from standard watch URLs', () => {
-      expect(getYoutubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
-        'dQw4w9WgXcQ'
-      )
-      expect(
-        getYoutubeId('https://youtube.com/watch?v=dQw4w9WgXcQ&feature=share')
-      ).toBe('dQw4w9WgXcQ')
-      expect(getYoutubeId('https://m.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
-        'dQw4w9WgXcQ'
-      )
-    })
+const YOUTUBE_ID = 'dQw4w9WgXcQ'
+const KALTURA_ID = '0_um01ms1s'
 
-    it('extracts ID from shortened URLs', () => {
-      expect(getYoutubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
-      expect(getYoutubeId('https://www.youtu.be/dQw4w9WgXcQ?t=12')).toBe(
-        'dQw4w9WgXcQ'
-      )
-    })
+function renderMarkdown(
+  content: string,
+  props: Partial<React.ComponentProps<typeof Markdown>> = {}
+): string {
+  return renderToStaticMarkup(
+    React.createElement(Markdown, { content, ...props })
+  )
+}
 
-    it('extracts ID from embed URLs', () => {
-      expect(getYoutubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(
-        'dQw4w9WgXcQ'
-      )
-      expect(
-        getYoutubeId('https://youtube.com/embed/dQw4w9WgXcQ?autoplay=1')
-      ).toBe('dQw4w9WgXcQ')
-    })
-
-    it('returns null for unapproved hosts', () => {
-      expect(
-        getYoutubeId('https://evil.example/watch?v=dQw4w9WgXcQ')
-      ).toBeNull()
-      expect(
-        getYoutubeId('https://youtube.com.evil.example/watch?v=dQw4w9WgXcQ')
-      ).toBeNull()
-      expect(
-        getYoutubeId('https://notyoutube.com/embed/dQw4w9WgXcQ')
-      ).toBeNull()
-    })
-
-    it('returns null for relative or broken URLs', () => {
-      expect(getYoutubeId('/embed/dQw4w9WgXcQ')).toBeNull()
-      expect(getYoutubeId('watch?v=dQw4w9WgXcQ')).toBeNull()
-      expect(getYoutubeId('')).toBeNull()
-    })
-
-    it('returns null for invalid or malformed YouTube IDs', () => {
-      expect(getYoutubeId('https://youtube.com/watch?v=tooShort')).toBeNull()
-      expect(
-        getYoutubeId('https://youtube.com/watch?v=tooLong12345')
-      ).toBeNull()
-      expect(getYoutubeId('https://youtube.com/watch?v=hasSpecial!')).toBeNull()
+describe('parseVideoEmbedUrl', () => {
+  it.each([
+    `https://www.youtube.com/watch?v=${YOUTUBE_ID}`,
+    `https://m.youtube.com/watch?v=${YOUTUBE_ID}&feature=share`,
+    `https://youtu.be/${YOUTUBE_ID}?t=12`,
+    `https://www.youtube.com/embed/${YOUTUBE_ID}?autoplay=1`,
+    `https://www.youtube.com/v/${YOUTUBE_ID}`,
+    `https://www.youtube.com/u/1/${YOUTUBE_ID}`,
+    `https://www.youtube.com/legacy-player?v=${YOUTUBE_ID}`,
+  ])('parses supported YouTube URL %s', (url) => {
+    expect(parseVideoEmbedUrl(url)).toEqual({
+      provider: 'youtube',
+      videoId: YOUTUBE_ID,
     })
   })
 
-  describe('getKalturaId', () => {
-    it('extracts ID from hosted Kaltura URLs', () => {
-      expect(
-        getKalturaId(
-          'https://uzh.mediaspace.cast.switch.ch/media/10+Untersuchung+Kopf+beim+Hund/0_ipqc15ga/124135'
-        )
-      ).toBe('0_ipqc15ga')
-      expect(
-        getKalturaId(
-          'https://uzh.mediaspace.cast.switch.ch/media/some-title/0_um01ms1s'
-        )
-      ).toBe('0_um01ms1s')
-    })
-
-    it('extracts ID from raw embed iframe URLs', () => {
-      expect(
-        getKalturaId(
-          'https://uzh.mediaspace.cast.switch.ch/embed/secure/iframe/entryId/0_um01ms1s/uiConfId/23449004/st/0'
-        )
-      ).toBe('0_um01ms1s')
-    })
-
-    it('returns null for unapproved Kaltura hosts', () => {
-      expect(
-        getKalturaId('https://evil.example/media/some-title/0_um01ms1s')
-      ).toBeNull()
-    })
-
-    it('returns null for relative or invalid paths', () => {
-      expect(getKalturaId('/media/some-title/0_um01ms1s')).toBeNull()
-      expect(
-        getKalturaId(
-          'https://uzh.mediaspace.cast.switch.ch/media/some-title/invalid_id'
-        )
-      ).toBeNull()
-    })
+  it.each([
+    `https://evil.example/watch?v=${YOUTUBE_ID}`,
+    `https://youtube.com.evil.example/watch?v=${YOUTUBE_ID}`,
+    `ftp://youtube.com/watch?v=${YOUTUBE_ID}`,
+    `/embed/${YOUTUBE_ID}`,
+    'https://youtube.com/watch?v=tooShort',
+    `https://youtube.com/shorts/${YOUTUBE_ID}`,
+  ])('rejects unsupported or malformed YouTube URL %s', (url) => {
+    expect(parseVideoEmbedUrl(url)).toBeNull()
   })
 
-  describe('getKalturaPartnerId', () => {
-    it('extracts partner ID from hosted URLs if present or defaults to 106', () => {
-      expect(
-        getKalturaPartnerId(
-          'https://uzh.mediaspace.cast.switch.ch/media/title/0_um01ms1s'
-        )
-      ).toBe('106')
-    })
-
-    it('extracts partner ID from iframe embed query string', () => {
-      expect(
-        getKalturaPartnerId(
-          'https://uzh.mediaspace.cast.switch.ch/embed/secure/iframe/entryId/0_um01ms1s?partnerId=123'
-        )
-      ).toBe('123')
-    })
+  it.each([
+    [
+      'https://uzh.mediaspace.cast.switch.ch/media/10+Untersuchung+Kopf+beim+Hund/0_ipqc15ga/124135',
+      {
+        provider: 'kaltura',
+        videoId: '0_ipqc15ga',
+        partnerId: DEFAULT_KALTURA_PARTNER_ID,
+        uiConfId: DEFAULT_KALTURA_UI_CONF_ID,
+      },
+    ],
+    [
+      `https://uzh.mediaspace.cast.switch.ch/embed/secure/iframe/entryId/${KALTURA_ID}/uiConfId/987654/st/0?partnerId=123`,
+      {
+        provider: 'kaltura',
+        videoId: KALTURA_ID,
+        partnerId: '123',
+        uiConfId: '987654',
+      },
+    ],
+    [
+      `https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654?iframeembed=true&entry_id=${KALTURA_ID}`,
+      {
+        provider: 'kaltura',
+        videoId: KALTURA_ID,
+        partnerId: '123',
+        uiConfId: '987654',
+      },
+    ],
+    [
+      `https://www.kaltura.com/index.php?entry_id=${KALTURA_ID}&partner_id=321&uiconf_id=456`,
+      {
+        provider: 'kaltura',
+        videoId: KALTURA_ID,
+        partnerId: '321',
+        uiConfId: '456',
+      },
+    ],
+  ])('parses supported Kaltura URL %s', (url, expected) => {
+    expect(parseVideoEmbedUrl(url)).toEqual(expected)
   })
 
-  describe('getKalturaUiConfId', () => {
-    it('extracts uiConfId from raw embed path', () => {
-      expect(
-        getKalturaUiConfId(
-          'https://uzh.mediaspace.cast.switch.ch/embed/secure/iframe/entryId/0_um01ms1s/uiConfId/23449004/st/0'
-        )
-      ).toBe('23449004')
+  it.each([
+    `https://evil.example/media/title/${KALTURA_ID}`,
+    `https://cast.switch.ch.evil.example/media/title/${KALTURA_ID}`,
+    `ftp://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654?entry_id=${KALTURA_ID}`,
+    'https://uzh.mediaspace.cast.switch.ch/media/title/invalid_id',
+  ])('rejects unsupported or malformed Kaltura URL %s', (url) => {
+    expect(parseVideoEmbedUrl(url)).toBeNull()
+  })
+})
+
+describe('getVideoEmbedSrc', () => {
+  it('builds the original YouTube embed URL', () => {
+    expect(getVideoEmbedSrc({ provider: 'youtube', videoId: YOUTUBE_ID })).toBe(
+      `https://www.youtube.com/embed/${YOUTUBE_ID}`
+    )
+  })
+
+  it('builds the Kaltura PlayKit URL with the parsed configuration', () => {
+    expect(
+      getVideoEmbedSrc({
+        provider: 'kaltura',
+        videoId: KALTURA_ID,
+        partnerId: '123',
+        uiConfId: '987654',
+      })
+    ).toBe(
+      `https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654/partner_id/123?iframeembed=true&playerId=kaltura_player&entry_id=${KALTURA_ID}`
+    )
+  })
+})
+
+describe('Markdown video embed rendering', () => {
+  it('renders a standalone YouTube link as an immediate iframe in valid DOM', () => {
+    const html = renderMarkdown(
+      `[video](https://www.youtube.com/watch?v=${YOUTUBE_ID})`
+    )
+
+    expect(html).toContain(`<iframe title="YouTube video player"`)
+    expect(html).toContain(`src="https://www.youtube.com/embed/${YOUTUBE_ID}"`)
+    expect(html).toContain('loading="lazy"')
+    expect(html).toContain('aspect-video')
+    expect(html).not.toContain('<p><div')
+    expect(html).not.toContain('</div></p>')
+    expect(html).toContain('<p><span class="my-4 block')
+  })
+
+  it('renders Kaltura with its partner and UI configuration', () => {
+    const html = renderMarkdown(
+      `[embed](https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654?iframeembed=true&entry_id=${KALTURA_ID})`
+    )
+
+    expect(html).toContain(`<iframe title="Kaltura video player"`)
+    expect(html).toContain(
+      `src="https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654/partner_id/123?iframeembed=true&amp;playerId=kaltura_player&amp;entry_id=${KALTURA_ID}"`
+    )
+  })
+
+  it('keeps unsupported video-labelled links as regular links', () => {
+    const html = renderMarkdown(
+      `[video](https://evil.example/watch?v=${YOUTUBE_ID})`
+    )
+
+    expect(html).toContain(`href="https://evil.example/watch?v=${YOUTUBE_ID}"`)
+    expect(html).not.toContain('<iframe')
+  })
+
+  it('promotes video-labelled links inside a paragraph and preserves its text', () => {
+    const html = renderMarkdown(
+      [
+        `[video](https://www.youtube.com/watch?v=${YOUTUBE_ID})`,
+        '. YouTube description',
+        '[embed](https://uzh.mediaspace.cast.switch.ch/media/10+Untersuchung+Kopf+beim+Hund/0_ipqc15ga/124135)',
+        '. Hosted Kaltura description',
+        `[embed](https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654?iframeembed=true&entry_id=${KALTURA_ID})`,
+        '. Custom Kaltura description',
+        '[Link to YouTube](https://youtube.com)',
+      ].join('\n'),
+      { withLinkButtons: true }
+    )
+
+    expect(html.match(/<iframe /g)).toHaveLength(3)
+    expect(html).toContain('. YouTube description')
+    expect(html).toContain('. Hosted Kaltura description')
+    expect(html).toContain('. Custom Kaltura description')
+    expect(html.match(/<a /g)).toHaveLength(1)
+    expect(html).toContain('href="https://youtube.com"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('<span>Link to YouTube</span>')
+    expect(html).not.toContain('<p><div')
+    expect(html).not.toContain('</div></p>')
+    expect(html.match(/<p><span class="my-4 block/g)).toHaveLength(1)
+  })
+
+  it('preserves video-link interception in headings and lists', () => {
+    const html = renderMarkdown(
+      [
+        `## [video](https://www.youtube.com/watch?v=${YOUTUBE_ID})`,
+        '',
+        `- [embed](https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654?iframeembed=true&entry_id=${KALTURA_ID})`,
+      ].join('\n')
+    )
+
+    expect(html.match(/<iframe /g)).toHaveLength(2)
+    expect(html).toContain('<h2><span class="my-4 block')
+    expect(html).toContain('<li><span class="my-4 block')
+    expect(html).not.toContain('<h2><div')
+    expect(html).not.toContain('<li><div')
+  })
+
+  it('keeps formatted video labels as regular links', () => {
+    const html = renderMarkdown(
+      `[**video**](https://www.youtube.com/watch?v=${YOUTUBE_ID})`
+    )
+
+    expect(html).toContain('<strong>video</strong>')
+    expect(html).not.toContain('<iframe')
+  })
+
+  it('uses inline children for link-button markup', () => {
+    const html = renderMarkdown('[YouTube](https://youtube.com)', {
+      withLinkButtons: true,
     })
 
-    it('extracts uiConfId from query parameter if present', () => {
-      expect(
-        getKalturaUiConfId(
-          'https://uzh.mediaspace.cast.switch.ch/embed/secure/iframe/entryId/0_um01ms1s?uiConfId=987654'
-        )
-      ).toBe('987654')
-    })
-
-    it('returns default uiConfId if not present', () => {
-      expect(
-        getKalturaUiConfId(
-          'https://uzh.mediaspace.cast.switch.ch/media/title/0_um01ms1s'
-        )
-      ).toBe('23449004')
-    })
+    expect(html).toContain('<span></span><span>YouTube</span>')
+    expect(html).not.toMatch(/<a[^>]*><div/)
   })
 })

--- a/packages/markdown/vitest.config.ts
+++ b/packages/markdown/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    exclude: [...configDefaults.exclude, '.rollup.cache/**'],
     testTimeout: 30000,
     silent: false,
     reporters: ['verbose'],

--- a/playwright/tests/0-video-embed.spec.ts
+++ b/playwright/tests/0-video-embed.spec.ts
@@ -1,0 +1,125 @@
+import type { Page } from '@playwright/test'
+import { COURSE_ID_TEST, USER_ID_TEST } from '../util/constants.js'
+import { expect, test } from '../util/fixtures.js'
+import {
+  createLiveQuiz,
+  deleteLiveQuiz,
+  publishLiveQuiz,
+} from '../util/fixtures/manage.js'
+import { openStudentLiveQuiz } from '../util/workflow.js'
+
+const YOUTUBE_ID = 'dQw4w9WgXcQ'
+const KALTURA_ID = '0_ipqc15ga'
+const YOUTUBE_EMBED = `https://www.youtube.com/embed/${YOUTUBE_ID}`
+const KALTURA_EMBED =
+  `https://api.cast.switch.ch/p/106/embedPlaykitJs/uiconf_id/23449004/partner_id/106` +
+  `?iframeembed=true&playerId=kaltura_player&entry_id=${KALTURA_ID}`
+const CUSTOM_KALTURA_EMBED =
+  'https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654/partner_id/123' +
+  '?iframeembed=true&playerId=kaltura_player&entry_id=0_um01ms1s'
+const VIDEO_MARKDOWN = [
+  `[video](https://www.youtube.com/watch?v=${YOUTUBE_ID})`,
+  '. It should render a responsive player wrapper with the YouTube iframe.',
+  'Embed a Kaltura video using the hosted portal URL layout',
+  '[embed](https://uzh.mediaspace.cast.switch.ch/media/10+Untersuchung+Kopf+beim+Hund/0_ipqc15ga/124135)',
+  '. It should resolve the entryId and render the Kaltura player iframe.',
+  'Embed a Kaltura video using the raw embed code iframe URL',
+  '[video](https://api.cast.switch.ch/p/123/embedPlaykitJs/uiconf_id/987654?iframeembed=true&entry_id=0_um01ms1s)',
+  '. It should preserve the correct uiConfId and render the player.',
+  'Ensure other link configurations, e.g.,',
+  `[YouTube link](https://www.youtube.com/watch?v=${YOUTUBE_ID})`,
+].join('\n')
+
+async function blockPlayers(page: Page) {
+  await page.route('https://www.youtube.com/**', (route) => route.abort())
+  await page.route('https://api.cast.switch.ch/**', (route) => route.abort())
+}
+
+test.describe('Markdown video embeds', () => {
+  test('renders valid, responsive players in the element editor', async ({
+    loginLecturer,
+    page,
+  }) => {
+    await blockPlayers(page)
+    await loginLecturer()
+    await page.getByTestId('create-question').click()
+
+    const editor = page.getByTestId('insert-question-text')
+    await editor.fill(VIDEO_MARKDOWN)
+    await expect(editor).toContainText('YouTube link')
+
+    const preview = page.getByTestId('student-element-preview')
+    const players = preview.locator('iframe')
+    await expect(players).toHaveCount(3)
+    await expect(players.nth(0)).toHaveAttribute('src', YOUTUBE_EMBED)
+    await expect(players.nth(0)).toHaveAttribute(
+      'title',
+      'YouTube video player'
+    )
+    await expect(players.nth(1)).toHaveAttribute('src', KALTURA_EMBED)
+    await expect(players.nth(2)).toHaveAttribute('src', CUSTOM_KALTURA_EMBED)
+    const ordinaryLink = preview.getByRole('link', { name: 'YouTube link' })
+    await expect(preview.locator('a')).toHaveCount(1)
+    await expect(ordinaryLink).toBeVisible()
+    await expect(ordinaryLink).toHaveAttribute('target', '_blank')
+    await expect(preview.locator('p > span > iframe')).toHaveCount(3)
+    await expect(preview.locator('p > div')).toHaveCount(0)
+
+    const dimensions = await preview.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }))
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth)
+  })
+
+  test('renders both providers without horizontal overflow in the mobile PWA', async ({
+    loginStudent,
+    page,
+  }, testInfo) => {
+    const suffix = `${testInfo.workerIndex}-${Date.now()}`
+    const name = `Video Embed PWA ${suffix}`
+    let liveQuizId: string | undefined
+
+    await blockPlayers(page)
+    try {
+      liveQuizId = await createLiveQuiz({
+        name,
+        displayName: name,
+        description: VIDEO_MARKDOWN,
+        courseId: COURSE_ID_TEST,
+        ownerId: USER_ID_TEST,
+        elementNames: [],
+      })
+      await publishLiveQuiz(liveQuizId)
+
+      await page.setViewportSize({ width: 375, height: 812 })
+      await loginStudent()
+      await openStudentLiveQuiz(page, name)
+
+      const description = page.getByTestId('live-quiz-description')
+      const players = description.locator('iframe')
+      await expect(players).toHaveCount(3)
+      await expect(players.nth(0)).toHaveAttribute('src', YOUTUBE_EMBED)
+      await expect(players.nth(1)).toHaveAttribute('src', KALTURA_EMBED)
+      const ordinaryLink = description.getByRole('link', {
+        name: 'YouTube link',
+      })
+      await expect(description.locator('a')).toHaveCount(1)
+      await expect(ordinaryLink).toBeVisible()
+      await expect(ordinaryLink).toHaveAttribute('target', '_blank')
+      await expect(description.locator('p > span > iframe')).toHaveCount(3)
+      await expect(description.locator('p > div')).toHaveCount(0)
+
+      const overflow = await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth -
+          document.documentElement.clientWidth
+      )
+      expect(overflow).toBeLessThanOrEqual(0)
+    } finally {
+      if (liveQuizId) {
+        await deleteLiveQuiz(liveQuizId)
+      }
+    }
+  })
+})

--- a/playwright/util/fixtures/manage.ts
+++ b/playwright/util/fixtures/manage.ts
@@ -175,12 +175,14 @@ export async function createLiveQuizFixture(
 export async function createLiveQuiz({
   name,
   displayName,
+  description,
   courseId,
   ownerId,
   elementNames,
 }: {
   name: string
   displayName: string
+  description?: string
   courseId?: string
   ownerId: string
   elementNames: string[]
@@ -219,6 +221,7 @@ export async function createLiveQuiz({
       data: {
         name,
         displayName,
+        description,
         courseId: courseId ?? null,
         ownerId,
         blocks: {
@@ -272,6 +275,19 @@ export async function createLiveQuiz({
   } catch (error) {
     throw error
   }
+}
+
+export async function publishLiveQuiz(id: string) {
+  const prisma = await getPrisma()
+  await prisma.liveQuiz.update({
+    where: { id },
+    data: { status: 'PUBLISHED' },
+  })
+}
+
+export async function deleteLiveQuiz(id: string) {
+  const prisma = await getPrisma()
+  await prisma.liveQuiz.delete({ where: { id } })
 }
 
 export async function removeSoftDeletedLiveQuiz({


### PR DESCRIPTION
## Summary

Stacked remediation PR for #5147, targeting `embed-external-video-support`. It hardens the YouTube/Kaltura markdown embed feature with a typed, allowlisted URL parser, fixes an invalid-HTML nesting bug, and adds unit-test and E2E coverage.

> **Note:** This description was rewritten on 2026-07-17 to match the current branch head (`87955b90a`). The branch was force-pushed after the original description was written; earlier claims about click-to-load privacy placeholders, `youtube-nocookie.com` URLs, timestamp support, localization, focus management, and Playwright cookie/save-helper fixes do not apply to the current diff and have been removed. Existing review comments referencing commit `29c042f0` describe code that is no longer on this branch.

## Changes

### Markdown rendering and parsing

- Extracts URL parsing into a new typed, allowlisted parser (`packages/markdown/src/VideoEmbedUrl.ts`): exact-or-subdomain host checks for `youtube.com`, `youtu.be`, `kaltura.com`, and `cast.switch.ch`; strict character-class validation of video/entry IDs and numeric partner/uiConf IDs before they are interpolated into the iframe `src`; protocol restricted to `http(s)`.
- Preserves Kaltura partner and uiConf configuration where present in the source URL.
- Fixes invalid `<p><div>…</div></p>` markup by rendering the video wrapper and the link-button icon wrapper as `<span>` (valid phrasing content). Only strict standalone video links are transformed; ordinary inline links remain unchanged.
- Simplifies `VideoEmbed` to consume a parsed descriptor directly.

### Tests and CI

- Unit tests covering supported and rejected URL forms, embed URL generation, and valid rendered DOM structure (`packages/markdown/test/VideoEmbed.test.ts`).
- New Playwright spec (`playwright/tests/0-video-embed.spec.ts`): iframe rendering, ordinary-link preservation, and absence of horizontal overflow, with third-party domains blocked via route aborts and ID-scoped `try/finally` fixture cleanup.
- Additive fixture helpers (`publishLiveQuiz`, `deleteLiveQuiz`, optional live-quiz `description`) in `playwright/util/fixtures/manage.ts`.
- Dedicated markdown unit-test workflow (`.github/workflows/test-markdown.yml`), following the branch-filter convention of the sibling package workflows.
- Documentation updates in `docs/` reflecting the actual embed behavior (players render immediately).

## Known limitations / follow-ups (not in this PR)

- Embeds still load third-party iframes immediately on render; a click-to-load privacy gate remains open work.
- YouTube embeds use `youtube.com/embed`, not `youtube-nocookie.com`.
- Timestamp parameters (`?t=`, `&start=`) are parsed away and not forwarded to the player.
- Generic Kaltura links without explicit partner configuration normalize to the UZH SWITCHcast tenant (accepted for current scope).
