### PR TITLE
docs(solutions): refresh production seed lesson

### DIFF
--- a/.agents/skills/df-safe-database-scripting/SKILL.md
+++ b/.agents/skills/df-safe-database-scripting/SKILL.md
@@ -14,6 +14,7 @@ This skill establishes the **Safe Mutation Protocol** for creating, executing, o
 > [!CRITICAL] > **Strict PII Refusal**: The agent **MUST REFUSE** to process or parse any input files (Excel, CSV, JSON) containing personally identifiable information (such as personal names, email addresses, birthdates, or nationalities).
 >
 > - **Action**: Instruct the operator to sanitize the list locally first, providing only Klicker usernames, points, or achievements.
+> - **Schema enforcement**: Allowlist the expected sanitized input fields and reject unknown columns or properties instead of silently discarding them.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,8 @@ Traefik reverse proxy serves the apps on `*.klicker.com` domains (needs `/etc/ho
 
 Ground truth for working on this codebase is the agent-facing wiki at **[docs/index.md](docs/index.md)** (not to be confused with `apps/docs`, the user-facing site). Read the relevant page before working in an unfamiliar area, and keep it current — **any PR that changes behavior must update the affected wiki pages in `docs/` and relevant skills in `.agents/skills/` within the same PR.** The former `project/CODEBASE_NOTES.md` is a retired pointer stub.
 
+Retrospective fixes and durable lessons live in `docs/solutions/`; check them before re-deriving a solved problem.
+
 ## AI Assistance (Skills)
 
 Skills live in `.agents/skills/` (the canonical location); `.claude/skills` and `.github/skills` symlink to it, so Claude Code and GitHub stay in sync. Task-shaped `klicker-*` skills cover the feature lifecycle — environment diagnosis (`klicker-environment-doctor`), design (`klicker-feature-design`), API (`klicker-graphql-api`), schema/data (`klicker-data-model`), UI (`klicker-frontend-ui`), testing/verification (`klicker-testing-verification`), e2e (`klicker-cypress-e2e`, `klicker-playwright-e2e`), and wiki upkeep (`klicker-wiki-maintenance`); the routing table lives in [docs/index.md](docs/index.md).

--- a/docs/solutions/best-practice/repeat-production-seeds-use-prior-state.md
+++ b/docs/solutions/best-practice/repeat-production-seeds-use-prior-state.md
@@ -33,8 +33,9 @@ Use this pattern for follow-up points, XP, achievement, or correction batches th
 
 ## Examples
 
-- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:151` queries participation for warnings without treating it as the only source of truth.
-- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:186` reads the leaderboard, XP, and achievement state that the operation extends.
-- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:227` fails if the expected existing course leaderboard record is absent.
-- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:328` blocks completed runs before querying production.
-- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:334` hashes the validated payload; lines 353-378 protect the payload-bound before snapshot before any write, and lines 380-407 check it again inside the transaction.
+- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:166` queries participation for warnings without treating it as the only source of truth.
+- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:200` reads the leaderboard, XP, and achievement state that the operation extends.
+- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:241` fails if the expected existing course leaderboard record is absent.
+- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:342` blocks completed runs before querying production.
+- `packages/prisma-data/src/data/seedSummerSchoolPortfolio2026.ts:348` hashes the validated payload; lines 367-374 protect the payload-bound before snapshot before any write, and lines 384-400 check it again before and inside the transaction.
+- [PR #5180](https://github.com/uzh-bf/klicker-uzh/pull/5180) records the production evidence, review hardening, and verification for the reference implementation.


### PR DESCRIPTION
## What

Refreshes the production-seed lesson captured after PR #5180 and makes solution documents easier to find.

## Changes

- moves the lesson into the schema-correct `docs/solutions/best-practice/` category
- repairs code references that shifted during the final privacy review and links the source PR
- adds the review lesson to `df-safe-database-scripting`: sanitized batch inputs must reject unknown fields
- points agents to `docs/solutions/` before they re-derive an already solved problem

## Branch coverage

- Base: `v3`
- Head: `e73afd3bd`
- Reviewed: 3 commits, 3 files, 9 insertions, 5 deletions
- Covered: solution-doc schema and citation refresh, workflow lesson routing, and discoverability

## Review focus

- confirm the solution category matches `problem_type: best_practice`
- confirm each cited source line still supports the claim beside it
- confirm the input-field allowlist rule belongs in the PII refusal guardrail

## Verification

Current head:

- full pre-commit suite: 23 of 23 typecheck tasks passed, plus formatting, lint, syncpack, Prisma sync, and AGENTS.md validation
- full pre-push production build: 21 of 21 tasks passed
- Prettier on all changed files: passed
- final maintainability review: no structural or maintainability findings

Failed or warning:

- the first solution-doc commit attempt hit a transient parallel Prisma generation race while backend typechecking read `ChatThread.d.ts`; rebuilding Prisma and rerunning the backend check repaired the generated output, and the unchanged commit then passed the full hook

## Security and privacy

This branch contains documentation and agent guidance only. It adds no source datasets, participant identifiers, audit dumps, or secrets.

## Blocking before merge

None.

## Follow-up after merge

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Strengthened guidance for safely handling sanitized data by requiring explicit validation of accepted fields and rejection of unexpected inputs.
  - Added a reference to the Engineering Wiki for finding relevant retrospectives and established solutions.
  - Updated example references in production seeding guidance to keep documentation aligned with the current implementation and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->