### PR TITLE
fix(analytics): align grading and index rollout

### DIFF
--- a/.github/workflows/test-analytics.yml
+++ b/.github/workflows/test-analytics.yml
@@ -47,4 +47,5 @@ jobs:
               tests/test_chat_topic_clustering_script.py \
               tests/test_course_scope_sql.py \
               tests/test_db_helpers.py \
-              tests/test_participant_analytics_helpers.py
+              tests/test_participant_analytics_helpers.py \
+              tests/test_live_quiz_analytics_sql.py

--- a/.github/workflows/test-analytics.yml
+++ b/.github/workflows/test-analytics.yml
@@ -1,0 +1,49 @@
+name: Test analytics correctness
+
+on:
+  push:
+    branches: ['v3', 'v3*']
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-analytics:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for changes
+        id: filter
+        uses: ./.github/actions/changed-paths
+        with:
+          pattern: '^(apps/analytics/|\.github/workflows/test-analytics\.yml|\.github/actions/changed-paths/)'
+
+      - name: Set up uv
+        if: steps.filter.outputs.should_run == 'true'
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: apps/analytics/uv.lock
+
+      - name: Test analytics correctness
+        if: steps.filter.outputs.should_run == 'true'
+        working-directory: apps/analytics
+        run: |
+          uv run --isolated --no-project \
+            --with pandas==2.2.2 \
+            --with 'psycopg[binary]==3.3.3' \
+            --with pytest==8.4.2 \
+            --with sqlalchemy==2.0.49 \
+            pytest -q \
+              tests/test_analytics_save_timestamps.py \
+              tests/test_chat_topic_clustering_script.py \
+              tests/test_course_scope_sql.py \
+              tests/test_db_helpers.py

--- a/.github/workflows/test-analytics.yml
+++ b/.github/workflows/test-analytics.yml
@@ -46,4 +46,5 @@ jobs:
               tests/test_analytics_save_timestamps.py \
               tests/test_chat_topic_clustering_script.py \
               tests/test_course_scope_sql.py \
-              tests/test_db_helpers.py
+              tests/test_db_helpers.py \
+              tests/test_participant_analytics_helpers.py

--- a/.github/workflows/test-analytics.yml
+++ b/.github/workflows/test-analytics.yml
@@ -23,7 +23,7 @@ jobs:
         id: filter
         uses: ./.github/actions/changed-paths
         with:
-          pattern: '^(apps/analytics/|\.github/workflows/test-analytics\.yml|\.github/actions/changed-paths/)'
+          pattern: '^(apps/analytics/|packages/grading/|\.github/workflows/test-analytics\.yml|\.github/actions/changed-paths/)'
 
       - name: Set up uv
         if: steps.filter.outputs.should_run == 'true'

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -155,6 +155,9 @@ jobs:
         env:
           DATABASE_URL: postgresql://klicker:klicker@localhost:5432/klicker-prod
 
+      - name: Test Hatchet analytics DAG
+        run: pnpm --filter @klicker-uzh/hatchet test
+
       - name: Run tests
         run: |
           set -euo pipefail

--- a/apps/analytics/Dockerfile
+++ b/apps/analytics/Dockerfile
@@ -13,8 +13,3 @@ COPY apps/analytics/pyproject.toml apps/analytics/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY apps/analytics/ .
-COPY packages/prisma/src/prisma/schema/*.prisma prisma/schema/
-RUN rm prisma/schema/js.prisma prisma/schema/datasource.prisma
-COPY apps/analytics/prisma/schema/datasource.prisma prisma/schema/datasource.prisma
-
-RUN uv run --no-sync prisma generate

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -160,15 +160,15 @@ pnpm --filter @klicker-uzh/prisma prisma:deploy:qa
 pnpm --filter @klicker-uzh/prisma prisma:deploy:prod
 ```
 
-`prisma:deploy:raw`, which those commands wrap, first runs `scripts/prepareAnalyticsIndexes.mjs`. On an initialized database the wrapper:
+`prisma:deploy:raw`, which those commands wrap, runs `scripts/prepareAnalyticsIndexes.mjs`. The wrapper acquires the repository migration advisory lock and holds it across the index prebuild, any migration baseline, and the normal Prisma deploy. On an initialized database it:
 
-1. refuses unfinished migrations or named invalid indexes;
+1. refuses partial analytics schemas, unfinished migrations, named invalid indexes, or a same-name index with the wrong table, access method, or ordered columns;
 2. executes `create-analytics-indexes-concurrently.sql` one statement at a time outside a transaction;
-3. validates that every index is ready and valid;
+3. validates that every index has the expected definition and is ready and valid;
 4. baselines the unchanged historical `20260420_analytics_covering_indexes` migration if it is still pending; and
 5. runs the remaining normal Prisma migration chain.
 
-On a fresh empty database the required tables are absent, so the wrapper skips the prebuild and the normal migration chain creates the indexes while the tables are empty. Do not run bare `prisma migrate deploy` against an initialized shared environment because it bypasses this guard.
+Only a database with none of the required analytics tables and no recorded migrations is treated as fresh. In that case the wrapper skips the prebuild and the normal migration chain creates the indexes while the tables are empty. An initialized or partially initialized database fails closed instead. Do not run bare `prisma migrate deploy` against an initialized shared environment because it bypasses this guard.
 
 This follows [Prisma's PostgreSQL migration-safety guidance](https://www.prisma.io/docs/guides/integrations/pgfence), which recommends manually adding `CONCURRENTLY` and running that work outside a transaction.
 

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -82,7 +82,7 @@ Scope (`ANALYTICS_COURSE_IDS`) and window floor (`ANALYTICS_WINDOW_SINCE`, auto-
 
 ### Known limitations
 
-- The in-memory buffer feeds captured writes into the downstream readers used by scripts 1, 2, 5, and 11. Scripts 13 and 99 still read the target database and therefore do not see same-run buffered rows.
+- The in-memory buffer feeds captured writes into the downstream readers used by scripts 1, 2, 5, and 11. Course-scoped dry runs omit platform-wide script 13 and validity-marker script 99.
 - A buffered table replaces that reader's database result; it is not unioned with rows already present in the database. Incremental-window dry runs can therefore under-report downstream aggregates that need both historical rows and rows captured in the current run.
 
 The workbook is a read-only inspection aid, not proof of exact downstream parity for those cases. Use a seeded writable database for end-to-end row comparisons.
@@ -153,11 +153,22 @@ The analytics index migrations cover hot response/event tables:
 - `20260420_analytics_covering_indexes`
 - `20260723180000_analytics_live_quiz_submitted_at_index`
 
-Prisma 6.16 applies these migrations inside a transaction, while PostgreSQL requires `CREATE INDEX CONCURRENTLY` to run outside one. Therefore shared environments use a two-step rollout:
+Prisma 6.16 applies migrations inside a transaction, while PostgreSQL requires `CREATE INDEX CONCURRENTLY` to run outside one. The repository deploy commands enforce the safe ordering:
 
-1. Check whether either migration already ran from an older branch version.
-2. Run `packages/prisma/scripts/create-analytics-indexes-concurrently.sql` with `psql`, without `BEGIN` / `COMMIT`.
-3. Run the normal `prisma migrate deploy`. Its `IF NOT EXISTS` statements see the prebuilt indexes and become no-ops.
+```bash
+pnpm --filter @klicker-uzh/prisma prisma:deploy:qa
+pnpm --filter @klicker-uzh/prisma prisma:deploy:prod
+```
+
+`prisma:deploy:raw`, which those commands wrap, first runs `scripts/prepareAnalyticsIndexes.mjs`. On an initialized database the wrapper:
+
+1. refuses unfinished migrations or named invalid indexes;
+2. executes `create-analytics-indexes-concurrently.sql` one statement at a time outside a transaction;
+3. validates that every index is ready and valid;
+4. baselines the unchanged historical `20260420_analytics_covering_indexes` migration if it is still pending; and
+5. runs the remaining normal Prisma migration chain.
+
+On a fresh empty database the required tables are absent, so the wrapper skips the prebuild and the normal migration chain creates the indexes while the tables are empty. Do not run bare `prisma migrate deploy` against an initialized shared environment because it bypasses this guard.
 
 This follows [Prisma's PostgreSQL migration-safety guidance](https://www.prisma.io/docs/guides/integrations/pgfence), which recommends manually adding `CONCURRENTLY` and running that work outside a transaction.
 
@@ -170,7 +181,7 @@ WHERE migration_name IN (
 );
 ```
 
-Run the prebuild during a lower-traffic window. Concurrent builds preserve writes but still consume database I/O and CPU. Monitor active builds with:
+Run the deploy during a lower-traffic window. Concurrent builds preserve writes but still consume database I/O and CPU. Monitor active builds with:
 
 ```sql
 SELECT relid::regclass AS table_name, index_relid::regclass AS index_name, phase,
@@ -178,4 +189,4 @@ SELECT relid::regclass AS table_name, index_relid::regclass AS index_name, phase
 FROM pg_stat_progress_create_index;
 ```
 
-If a prebuild is interrupted, inspect `pg_index.indisvalid`, drop only the invalid index with `DROP INDEX CONCURRENTLY`, and rerun the prebuild. If Prisma itself later records a failed migration, mark that migration rolled back with `prisma migrate resolve --rolled-back <migration>` before rerunning deploy. The `IF NOT EXISTS` clauses make already-valid indexes safe on retry.
+If a prebuild is interrupted, the next deploy names the invalid index and stops. Inspect `pg_index.indisvalid`, drop only that exact index with `DROP INDEX CONCURRENTLY`, and rerun the repository deploy command. If Prisma itself records a failed migration, resolve that state explicitly before retrying; the wrapper refuses to guess.

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -80,6 +80,13 @@ Running against an environment whose migrations lag behind the current branch is
 
 Scope (`ANALYTICS_COURSE_IDS`) and window floor (`ANALYTICS_WINDOW_SINCE`, auto-set from the course's `startDate`) are applied before the first script runs — the pipeline doesn't iterate daily windows that pre-date the course.
 
+### Known limitations
+
+- The in-memory buffer feeds captured writes into the downstream readers used by scripts 1, 2, 5, and 11. Scripts 13 and 99 still read the target database and therefore do not see same-run buffered rows.
+- A buffered table replaces that reader's database result; it is not unioned with rows already present in the database. Incremental-window dry runs can therefore under-report downstream aggregates that need both historical rows and rows captured in the current run.
+
+The workbook is a read-only inspection aid, not proof of exact downstream parity for those cases. Use a seeded writable database for end-to-end row comparisons.
+
 ### Creating the read-only role (one-time, per env)
 
 Run as a DB admin (Azure: a user with `azure_pg_admin`):
@@ -138,3 +145,37 @@ Configure with these env vars (all registered in root `turbo.json`):
 | `ANALYTICS_ALLOW_FULL`  | Must be `1` for the handler to accept `mode=full`; otherwise `full` dispatches are rejected before any subprocess starts | unset (opt-in)                     |
 
 Together they produce an invocation like `uv run python -m src.scripts.8_initial_chat_analytics` executed with cwd `ANALYTICS_CWD`.
+
+## Deploying analytics indexes
+
+The analytics index migrations cover hot response/event tables:
+
+- `20260420_analytics_covering_indexes`
+- `20260723180000_analytics_live_quiz_submitted_at_index`
+
+Prisma 6.16 applies these migrations inside a transaction, while PostgreSQL requires `CREATE INDEX CONCURRENTLY` to run outside one. Therefore shared environments use a two-step rollout:
+
+1. Check whether either migration already ran from an older branch version.
+2. Run `packages/prisma/scripts/create-analytics-indexes-concurrently.sql` with `psql`, without `BEGIN` / `COMMIT`.
+3. Run the normal `prisma migrate deploy`. Its `IF NOT EXISTS` statements see the prebuilt indexes and become no-ops.
+
+This follows [Prisma's PostgreSQL migration-safety guidance](https://www.prisma.io/docs/guides/integrations/pgfence), which recommends manually adding `CONCURRENTLY` and running that work outside a transaction.
+
+```sql
+SELECT migration_name, finished_at, rolled_back_at
+FROM "_prisma_migrations"
+WHERE migration_name IN (
+  '20260420_analytics_covering_indexes',
+  '20260723180000_analytics_live_quiz_submitted_at_index'
+);
+```
+
+Run the prebuild during a lower-traffic window. Concurrent builds preserve writes but still consume database I/O and CPU. Monitor active builds with:
+
+```sql
+SELECT relid::regclass AS table_name, index_relid::regclass AS index_name, phase,
+       blocks_done, blocks_total
+FROM pg_stat_progress_create_index;
+```
+
+If a prebuild is interrupted, inspect `pg_index.indisvalid`, drop only the invalid index with `DROP INDEX CONCURRENTLY`, and rerun the prebuild. If Prisma itself later records a failed migration, mark that migration rolled back with `prisma migrate resolve --rolled-back <migration>` before rerunning deploy. The `IF NOT EXISTS` clauses make already-valid indexes safe on retry.

--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -6,18 +6,20 @@
     "nodemon": "~3.1.14"
   },
   "scripts": {
-    "analytics:dev": "../../util/_run_with_infisical.sh --env dev nodemon --exec 'uv run poe main' --watch src,prisma --ext py,prisma",
+    "analytics:dev": "../../util/_run_with_infisical.sh --env dev nodemon --exec 'uv run python -m src.main' --watch src,prisma --ext py,prisma",
     "dryrun:dev": "../../util/_run_with_infisical.sh --env dev uv run python -m src.scripts.export_dryrun",
     "dryrun:prod": "../../util/_run_with_infisical.sh --env prd uv run python -m src.scripts.export_dryrun",
     "dryrun:qa": "../../util/_run_with_infisical.sh --env stg uv run python -m src.scripts.export_dryrun",
+    "format": "uv run ruff format .",
     "generate": "../../util/_run_with_infisical.sh --env dev uv run poe generate",
-    "main": "../../util/_run_with_infisical.sh --env dev uv run poe main",
+    "lint": "uv run ruff check . && uv run ruff format --check .",
+    "main": "../../util/_run_with_infisical.sh --env dev uv run python -m src.main",
     "script": "../../util/_run_with_infisical.sh --env dev uv run python -m",
     "script:prod": "../../util/_run_with_infisical.sh --env prd uv run python -m",
     "script:qa": "../../util/_run_with_infisical.sh --env stg uv run python -m"
   },
   "engines": {
-    "node": "=20"
+    "node": "=24"
   },
   "volta": {
     "extends": "../../package.json"

--- a/apps/analytics/prisma/schema/response.prisma
+++ b/apps/analytics/prisma/schema/response.prisma
@@ -144,8 +144,8 @@ model LiveQuizResponse {
 
   @@unique([instanceId, elementBlockExecution, participantId])
   @@index([instanceId, elementBlockExecution])
-  // Supports script 14's first-submission lookup without sorting every response for an instance.
-  @@index([instanceId, submittedAt])
+  // Supports script 14's first/last attempt windows per participant and instance.
+  @@index([instanceId, participantId, submittedAt])
 }
 
 enum PointCorrectionType {

--- a/apps/analytics/prisma/schema/response.prisma
+++ b/apps/analytics/prisma/schema/response.prisma
@@ -144,6 +144,8 @@ model LiveQuizResponse {
 
   @@unique([instanceId, elementBlockExecution, participantId])
   @@index([instanceId, elementBlockExecution])
+  // Supports script 14's first-submission lookup without sorting every response for an instance.
+  @@index([instanceId, submittedAt])
 }
 
 enum PointCorrectionType {

--- a/apps/analytics/pyproject.toml
+++ b/apps/analytics/pyproject.toml
@@ -36,7 +36,6 @@ dev = [
 [tool.poe.tasks]
 # Regenerate models.py from the live dev DB. Run after a Prisma migration lands.
 generate = "sqlacodegen --generator declarative $DATABASE_URL -o src/models.py"
-main = "../../util/_run_with_infisical.sh --env dev python -m src.main"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/apps/analytics/src/db_helpers.py
+++ b/apps/analytics/src/db_helpers.py
@@ -20,6 +20,11 @@ from sqlalchemy.sql import Select
 from sqlalchemy.sql.elements import ColumnElement
 
 
+def utcnow() -> datetime:
+    """Return the current UTC time using the database's naive timestamp convention."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 def bulk_upsert(
     session: Session,
     Model: type[DeclarativeBase],
@@ -37,6 +42,11 @@ def bulk_upsert(
     """
     if not rows:
         return 0
+
+    expected_columns = set(rows[0])
+    for index, row in enumerate(rows[1:], start=1):
+        if set(row) != expected_columns:
+            raise ValueError(f"bulk_upsert row {index} must have the same columns as row 0")
 
     stmt = postgres_insert(Model).values(list(rows))
     effective_update_cols = list(update_cols) if update_cols is not None else [

--- a/apps/analytics/src/dryrun/runner.py
+++ b/apps/analytics/src/dryrun/runner.py
@@ -530,10 +530,6 @@ def run_dryrun(
                 status = "produced"
                 try:
                     module = importlib.import_module(module_name)
-                    # If the script was imported earlier in this process (e.g.
-                    # by a previous run), force a reload so it picks up the
-                    # env vars we just set and the interceptor patches.
-                    module = importlib.reload(module)
                     module.main()
                 except Exception as exc:
                     error = f"{type(exc).__name__}: {exc}"

--- a/apps/analytics/src/modules/aggregated_analytics/save_aggregated_analytics.py
+++ b/apps/analytics/src/modules/aggregated_analytics/save_aggregated_analytics.py
@@ -1,9 +1,7 @@
-from datetime import date, datetime
-
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
-from src.db_helpers import bulk_upsert, coerce_date
+from src.db_helpers import bulk_upsert, coerce_date, utcnow
 from src.models import (
     AggregatedAnalytics,
     ElementStack,
@@ -44,7 +42,8 @@ def save_aggregated_analytics(
     if df_analytics is None or df_analytics.empty:
         return
 
-    computedAt = date.today()
+    now = utcnow()
+    computedAt = now.date()
     timestamp_value = coerce_date(timestamp)
 
     if analytics_type in ("DAILY", "WEEKLY", "MONTHLY"):
@@ -62,8 +61,8 @@ def save_aggregated_analytics(
                 # kept from the pre-migration implementation.
                 "totalElementsAvailable": -1,
                 "courseId": row["courseId"],
-                "createdAt": datetime.now(),
-                "updatedAt": datetime.now(),
+                "createdAt": now,
+                "updatedAt": now,
             }
             for _, row in df_analytics.iterrows()
         ]
@@ -83,8 +82,8 @@ def save_aggregated_analytics(
                     "totalXp": int(row["totalXp"]),
                     "totalElementsAvailable": total_elements,
                     "courseId": row["courseId"],
-                    "createdAt": datetime.now(),
-                    "updatedAt": datetime.now(),
+                    "createdAt": now,
+                    "updatedAt": now,
                 }
             )
     else:

--- a/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics.sql
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics.sql
@@ -154,5 +154,4 @@ ON CONFLICT ("type", "chatbotId", "timestamp") DO UPDATE SET
   "modelDistribution"           = EXCLUDED."modelDistribution",
   "modeDistribution"            = EXCLUDED."modeDistribution",
   "reasoningEffortDistribution" = EXCLUDED."reasoningEffortDistribution",
-  "updatedAt"                   = NOW()
-WHERE "AggregatedChatbotAnalytics"."type" = 'COURSE';
+  "updatedAt"                   = NOW();

--- a/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics_weekly.sql
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics_weekly.sql
@@ -158,4 +158,20 @@ LEFT JOIN mode_counts mc       USING ("chatbotId")
 LEFT JOIN effort_counts ec     USING ("chatbotId")
 LEFT JOIN disclaimer_counts dc USING ("chatbotId")
 LEFT JOIN credit_exhaustion ce USING ("chatbotId")
-ON CONFLICT ("type", "chatbotId", "timestamp") DO NOTHING;
+ON CONFLICT ("type", "chatbotId", "timestamp") DO UPDATE SET
+  "courseId"                    = EXCLUDED."courseId",
+  "activeParticipants"          = EXCLUDED."activeParticipants",
+  "newParticipants"             = EXCLUDED."newParticipants",
+  "returningParticipants"       = EXCLUDED."returningParticipants",
+  "threads"                     = EXCLUDED."threads",
+  "userMessages"                = EXCLUDED."userMessages",
+  "assistantMessages"           = EXCLUDED."assistantMessages",
+  "totalCreditsUsed"            = EXCLUDED."totalCreditsUsed",
+  "creditExhaustionRate"        = EXCLUDED."creditExhaustionRate",
+  "disclaimerAcceptedCount"     = EXCLUDED."disclaimerAcceptedCount",
+  "disclaimerDeclinedCount"     = EXCLUDED."disclaimerDeclinedCount",
+  "hourOfDayDistribution"       = EXCLUDED."hourOfDayDistribution",
+  "modelDistribution"           = EXCLUDED."modelDistribution",
+  "modeDistribution"            = EXCLUDED."modeDistribution",
+  "reasoningEffortDistribution" = EXCLUDED."reasoningEffortDistribution",
+  "updatedAt"                   = NOW();

--- a/apps/analytics/src/modules/chat_analytics/participant_chat_analytics.sql
+++ b/apps/analytics/src/modules/chat_analytics/participant_chat_analytics.sql
@@ -165,5 +165,4 @@ ON CONFLICT ("type", "participantId", "chatbotId", "timestamp") DO UPDATE SET
   "toolCallCount"        = EXCLUDED."toolCallCount",
   "totalCreditsUsed"     = EXCLUDED."totalCreditsUsed",
   "creditsExhausted"     = EXCLUDED."creditsExhausted",
-  "updatedAt"            = NOW()
-WHERE "ParticipantChatAnalytics"."type" = 'COURSE';
+  "updatedAt"            = NOW();

--- a/apps/analytics/src/modules/live_quiz_analytics/aggregated_live_quiz_analytics.sql
+++ b/apps/analytics/src/modules/live_quiz_analytics/aggregated_live_quiz_analytics.sql
@@ -15,9 +15,10 @@ WITH assessment_responses AS (
       PARTITION BY lqr."participantId", lqr."instanceId"
       ORDER BY lqr."submittedAt" ASC, lqr.id ASC
     ) AS attempt_asc,
-    COUNT(*) OVER (
+    ROW_NUMBER() OVER (
       PARTITION BY lqr."participantId", lqr."instanceId"
-    ) AS attempt_count
+      ORDER BY lqr."submittedAt" DESC, lqr.id DESC
+    ) AS attempt_desc
   FROM "LiveQuizResponse" lqr
   JOIN "ElementInstance" ei ON ei.id = lqr."instanceId"
   JOIN "ElementBlock"    eb ON eb.id = ei."elementBlockId"
@@ -44,7 +45,7 @@ rollup AS (
     COUNT(id) AS response_count,
     AVG(CASE WHEN attempt_asc = 1 THEN (correctness = 'CORRECT')::int END)::real
       AS mean_first_correctness,
-    AVG(CASE WHEN attempt_asc = attempt_count THEN (correctness = 'CORRECT')::int END)::real
+    AVG(CASE WHEN attempt_desc = 1 THEN (correctness = 'CORRECT')::int END)::real
       AS mean_last_correctness
   FROM assessment_responses
   GROUP BY "liveQuizId", "courseId"
@@ -52,10 +53,11 @@ rollup AS (
 late_rate AS (
   SELECT
     "liveQuizId",
-    AVG((
-      live_quiz_finished_at IS NOT NULL
-      AND first_submitted_at > live_quiz_finished_at
-    )::int)::real AS late_submitter_rate
+    CASE WHEN COUNT(*) = 0 THEN NULL
+         ELSE SUM(CASE WHEN live_quiz_finished_at IS NOT NULL
+                         AND first_submitted_at > live_quiz_finished_at
+                       THEN 1 ELSE 0 END)::float / COUNT(*)
+    END::real AS late_submitter_rate
   FROM participant_firsts
   GROUP BY "liveQuizId"
 )

--- a/apps/analytics/src/modules/live_quiz_analytics/participant_live_quiz_analytics.sql
+++ b/apps/analytics/src/modules/live_quiz_analytics/participant_live_quiz_analytics.sql
@@ -15,11 +15,11 @@ WITH assessment_responses AS (
     lqr."bonusPoints",
     ROW_NUMBER() OVER (
       PARTITION BY lqr."participantId", ei.id
-      ORDER BY lqr."submittedAt" ASC
+      ORDER BY lqr."submittedAt" ASC, lqr.id ASC
     ) AS attempt_asc,
     ROW_NUMBER() OVER (
       PARTITION BY lqr."participantId", ei.id
-      ORDER BY lqr."submittedAt" DESC
+      ORDER BY lqr."submittedAt" DESC, lqr.id DESC
     ) AS attempt_desc
   FROM "LiveQuizResponse" lqr
   JOIN "ElementInstance" ei ON ei.id = lqr."instanceId"

--- a/apps/analytics/src/modules/participant_analytics/compute_correctness.py
+++ b/apps/analytics/src/modules/participant_analytics/compute_correctness.py
@@ -1,3 +1,5 @@
+from math import isfinite
+
 import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -5,6 +7,10 @@ from sqlalchemy.orm import Session
 from src.models import ElementInstance
 
 _EPSILON = 2.220446049250313e-16
+
+
+def _finite_number(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and isfinite(float(value))
 
 
 def map_element_instance_options(instance: ElementInstance) -> dict:
@@ -154,6 +160,8 @@ def _numerical_correctness(response, options):
         response_value = float(response["value"])
     except (KeyError, TypeError, ValueError):
         return None
+    if not isfinite(response_value):
+        return None
 
     solution_ranges = options.get("solutionRanges") or []
     exact_solutions = options.get("exactSolutions") or []
@@ -161,23 +169,24 @@ def _numerical_correctness(response, options):
         return None
 
     if solution_ranges:
-        defined_ranges = [
-            solution_range
-            for solution_range in solution_ranges
-            if isinstance(solution_range, dict)
-            and (solution_range.get("min") is not None or solution_range.get("max") is not None)
-        ]
+        defined_ranges = []
+        for solution_range in solution_ranges:
+            if not isinstance(solution_range, dict):
+                continue
+
+            min_value = solution_range.get("min")
+            max_value = solution_range.get("max")
+            defined_min = min_value if _finite_number(min_value) else None
+            defined_max = max_value if _finite_number(max_value) else None
+            if defined_min is not None or defined_max is not None:
+                defined_ranges.append((defined_min, defined_max))
+
         if not defined_ranges:
             return None
 
-        for solution_range in defined_ranges:
-            min_value = solution_range.get("min")
-            max_value = solution_range.get("max")
-            try:
-                above_min = min_value is None or response_value >= float(min_value) - _EPSILON
-                below_max = max_value is None or response_value <= float(max_value) + _EPSILON
-            except (TypeError, ValueError):
-                continue
+        for min_value, max_value in defined_ranges:
+            above_min = min_value is None or response_value >= min_value - _EPSILON
+            below_max = max_value is None or response_value <= max_value + _EPSILON
             if above_min and below_max:
                 return "CORRECT"
         return "INCORRECT"

--- a/apps/analytics/src/modules/participant_analytics/compute_correctness.py
+++ b/apps/analytics/src/modules/participant_analytics/compute_correctness.py
@@ -50,8 +50,7 @@ def _case_study_response_map(assessment):
         return {
             str(case_id): {
                 str(item_id): {
-                    str(criterion_id): response_value
-                    for criterion_id, response_value in (criterion_map or {}).items()
+                    str(criterion_id): response_value for criterion_id, response_value in (criterion_map or {}).items()
                 }
                 for item_id, criterion_map in (case_map or {}).items()
             }
@@ -139,11 +138,7 @@ def _case_study_correctness(response, options):
                 if submitted_value >= min_value - _EPSILON and submitted_value <= max_value + _EPSILON:
                     total_correct_cases += 1
 
-    correctness = (
-        0
-        if total_assessment_cases == 0
-        else total_correct_cases / total_assessment_cases
-    )
+    correctness = 0 if total_assessment_cases == 0 else total_correct_cases / total_assessment_cases
     if correctness == 1:
         return "CORRECT"
     if correctness == 0:
@@ -151,10 +146,56 @@ def _case_study_correctness(response, options):
     return "PARTIAL"
 
 
+def _numerical_correctness(response, options):
+    if not isinstance(response, dict) or not isinstance(options, dict):
+        return None
+
+    try:
+        response_value = float(response["value"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    solution_ranges = options.get("solutionRanges") or []
+    exact_solutions = options.get("exactSolutions") or []
+    if not solution_ranges and not exact_solutions:
+        return None
+
+    if solution_ranges:
+        defined_ranges = [
+            solution_range
+            for solution_range in solution_ranges
+            if isinstance(solution_range, dict)
+            and (solution_range.get("min") is not None or solution_range.get("max") is not None)
+        ]
+        if not defined_ranges:
+            return None
+
+        for solution_range in defined_ranges:
+            min_value = solution_range.get("min")
+            max_value = solution_range.get("max")
+            try:
+                above_min = min_value is None or response_value >= float(min_value) - _EPSILON
+                below_max = max_value is None or response_value <= float(max_value) + _EPSILON
+            except (TypeError, ValueError):
+                continue
+            if above_min and below_max:
+                return "CORRECT"
+        return "INCORRECT"
+
+    for solution in exact_solutions:
+        try:
+            numerical_solution = float(solution)
+        except (TypeError, ValueError):
+            continue
+        if numerical_solution - _EPSILON <= response_value <= numerical_solution + _EPSILON:
+            return "CORRECT"
+    return "INCORRECT"
+
+
 def compute_correctness_columns(df_element_instances, row):
-    element_instance = df_element_instances[
-        df_element_instances["elementInstanceId"] == row["elementInstanceId"]
-    ].iloc[0]
+    element_instance = df_element_instances[df_element_instances["elementInstanceId"] == row["elementInstanceId"]].iloc[
+        0
+    ]
     response = row["response"]
     options = element_instance["options"]
 
@@ -163,30 +204,18 @@ def compute_correctness_columns(df_element_instances, row):
 
     elif element_instance["type"] == "SC":
         selected_choice = response["choices"][0]
-        correct_choice = next(
-            (choice["ix"] for choice in options["choices"] if choice["correct"]), None
-        )
+        correct_choice = next((choice["ix"] for choice in options["choices"] if choice["correct"]), None)
         return "CORRECT" if selected_choice == correct_choice else "INCORRECT"
 
     elif element_instance["type"] == "MC" or element_instance["type"] == "KPRIM":
         selected_choices = response["choices"]
-        correct_choices = [
-            choice["ix"] for choice in options["choices"] if choice["correct"]
-        ]
+        correct_choices = [choice["ix"] for choice in options["choices"] if choice["correct"]]
         available_choices = len(options["choices"])
 
-        selected_choices_array = [
-            1 if ix in selected_choices else 0 for ix in range(available_choices)
-        ]
-        correct_choices_array = [
-            1 if ix in correct_choices else 0 for ix in range(available_choices)
-        ]
+        selected_choices_array = [1 if ix in selected_choices else 0 for ix in range(available_choices)]
+        correct_choices_array = [1 if ix in correct_choices else 0 for ix in range(available_choices)]
         hamming_distance = sum(
-            [
-                1
-                for i in range(available_choices)
-                if selected_choices_array[i] != correct_choices_array[i]
-            ]
+            [1 for i in range(available_choices) if selected_choices_array[i] != correct_choices_array[i]]
         )
 
         if element_instance["type"] == "MC":
@@ -198,45 +227,10 @@ def compute_correctness_columns(df_element_instances, row):
             else:
                 return "PARTIAL"
         elif element_instance["type"] == "KPRIM":
-            return (
-                "CORRECT"
-                if hamming_distance == 0
-                else "PARTIAL" if hamming_distance == 1 else "INCORRECT"
-            )
+            return "CORRECT" if hamming_distance == 0 else "PARTIAL" if hamming_distance == 1 else "INCORRECT"
 
     elif element_instance["type"] == "NUMERICAL":
-        response_value = float(response["value"])
-
-        if "solutionRanges" in options:
-            within_range = list(
-                map(
-                    lambda range: float(range["min"])
-                    <= response_value
-                    <= float(range["max"]),
-                    options["solutionRanges"],
-                )
-            )
-            if any(within_range):
-                return "CORRECT"
-            else:
-                return "INCORRECT"
-
-        elif "exactSolutions" in options:
-            response_correct = list(
-                map(
-                    lambda solution: float(solution) - 1e-10
-                    <= response_value
-                    <= float(solution) + 1e-10,
-                    options["exactSolutions"],
-                )
-            )
-
-            if any(response_correct):
-                return "CORRECT"
-            else:
-                return "INCORRECT"
-
-        return "INCORRECT"
+        return _numerical_correctness(response, options)
 
     elif element_instance["type"] == "FREE_TEXT":
         # if no sample solution is specified, automatically grade as correct
@@ -246,9 +240,7 @@ def compute_correctness_columns(df_element_instances, row):
         # otherwise, check if the response (ignoring capitalization) is included
         # in the list of solutions
         response_value = response["value"]
-        solutions = list(
-            map(lambda solution: solution.strip().lower(), options["solutions"])
-        )
+        solutions = list(map(lambda solution: solution.strip().lower(), options["solutions"]))
         if response_value.strip().lower() in solutions:
             return "CORRECT"
 
@@ -300,27 +292,22 @@ def compute_correctness(session: Session, df_details, verbose: bool = False):
         print("Columns:", df_details.columns)
 
     element_instance_ids = df_details["elementInstanceId"].unique().tolist()
-    element_instances = session.execute(
-        select(ElementInstance).where(ElementInstance.id.in_(element_instance_ids))
-    ).scalars().all()
-
-    df_element_instances = pd.DataFrame(
-        list(map(map_element_instance_options, element_instances))
+    element_instances = (
+        session.execute(select(ElementInstance).where(ElementInstance.id.in_(element_instance_ids))).scalars().all()
     )
+
+    df_element_instances = pd.DataFrame(list(map(map_element_instance_options, element_instances)))
 
     if len(df_element_instances) == 0:
         print("No element instances found for the given element instance ids.")
         return None, None
 
-    df_details["correctness"] = df_details.apply(
-        lambda x: compute_correctness_columns(df_element_instances, x), axis=1
-    )
+    df_details["correctness"] = df_details.apply(lambda x: compute_correctness_columns(df_element_instances, x), axis=1)
     df_details = df_details.dropna(subset=["correctness"])
 
     if verbose:
         print(
-            "Number of question response details with correctness computed "
-            "(no flashcards / content elements):",
+            "Number of question response details with correctness computed (no flashcards / content elements):",
             len(df_details),
         )
 

--- a/apps/analytics/src/modules/participant_analytics/get_participant_responses.py
+++ b/apps/analytics/src/modules/participant_analytics/get_participant_responses.py
@@ -7,9 +7,6 @@ from sqlalchemy.orm import Session, selectinload
 from src.db_helpers import coerce_timestamp, row_to_dict
 from src.models import (
     Course,
-    MicroLearning,
-    Participant,
-    PracticeQuiz,
     QuestionResponseDetail,
 )
 
@@ -21,18 +18,12 @@ def _coerce_window_bounds(start_date: object, end_date: object) -> tuple[datetim
     return coerce_timestamp(start_date), coerce_timestamp(end_date)
 
 
-def _load_course_windows(
-    session: Session, course_ids: set[str]
-) -> dict[str, dict[str, datetime]]:
+def _load_course_windows(session: Session, course_ids: set[str]) -> dict[str, dict[str, datetime]]:
     if not course_ids:
         return {}
 
     rows = (
-        session.execute(
-            select(Course.id, Course.startDate, Course.endDate).where(
-                Course.id.in_(course_ids)
-            )
-        )
+        session.execute(select(Course.id, Course.startDate, Course.endDate).where(Course.id.in_(course_ids)))
         .mappings()
         .all()
     )
@@ -59,29 +50,17 @@ def _detail_to_dict(
         course_window = course_windows.get(course_id)
         base["courseId"] = course_id
         base["course_start_date"] = (
-            coerce_timestamp(course_window["startDate"])
-            if course_window
-            else _MISSING_COURSE_START
+            coerce_timestamp(course_window["startDate"]) if course_window else _MISSING_COURSE_START
         )
-        base["course_end_date"] = (
-            coerce_timestamp(course_window["endDate"])
-            if course_window
-            else _MISSING_COURSE_END
-        )
+        base["course_end_date"] = coerce_timestamp(course_window["endDate"]) if course_window else _MISSING_COURSE_END
     elif detail.microLearning is not None:
         course_id = str(detail.microLearning.courseId)
         course_window = course_windows.get(course_id)
         base["courseId"] = course_id
         base["course_start_date"] = (
-            coerce_timestamp(course_window["startDate"])
-            if course_window
-            else _MISSING_COURSE_START
+            coerce_timestamp(course_window["startDate"]) if course_window else _MISSING_COURSE_START
         )
-        base["course_end_date"] = (
-            coerce_timestamp(course_window["endDate"])
-            if course_window
-            else _MISSING_COURSE_END
-        )
+        base["course_end_date"] = coerce_timestamp(course_window["endDate"]) if course_window else _MISSING_COURSE_END
     else:
         base["courseId"] = None
         base["course_start_date"] = _MISSING_COURSE_START
@@ -90,55 +69,48 @@ def _detail_to_dict(
     return base
 
 
-def get_participant_responses(
-    session: Session, start_date: str, end_date: str, verbose: bool = False
-):
+def get_participant_responses(session: Session, start_date: str, end_date: str, verbose: bool = False):
     """Return a dataframe of per-response detail rows for the window.
 
-    ``selectinload`` chains replace the Prisma ``include`` tree with one
-    ``IN (...)`` query per relation level — same round-trip count as before.
+    The time predicate stays in Postgres so the ``createdAt`` BRIN index can
+    prune the append-mostly detail table before relationships are loaded.
     """
-    participants = session.execute(
-        select(Participant).options(
-            selectinload(Participant.detailQuestionResponses).options(
+    start_ts, end_ts = _coerce_window_bounds(start_date, end_date)
+    details = (
+        session.execute(
+            select(QuestionResponseDetail)
+            .where(
+                QuestionResponseDetail.createdAt >= start_ts,
+                QuestionResponseDetail.createdAt <= end_ts,
+            )
+            .options(
                 selectinload(QuestionResponseDetail.practiceQuiz),
                 selectinload(QuestionResponseDetail.microLearning),
             )
         )
-    ).scalars().all()
-
-    start_ts, end_ts = _coerce_window_bounds(start_date, end_date)
+        .scalars()
+        .all()
+    )
 
     course_ids = {
         str(detail.practiceQuiz.courseId)
-        for participant in participants
-        for detail in participant.detailQuestionResponses
+        for detail in details
         if detail.practiceQuiz is not None and detail.practiceQuiz.courseId is not None
     } | {
         str(detail.microLearning.courseId)
-        for participant in participants
-        for detail in participant.detailQuestionResponses
+        for detail in details
         if detail.microLearning is not None and detail.microLearning.courseId is not None
     }
     course_windows = _load_course_windows(session, course_ids)
 
     rows = []
-    for participant in participants:
-        pid = participant.id
-        for detail in participant.detailQuestionResponses:
-            if detail.createdAt is None:
-                continue
-            detail_created_at = coerce_timestamp(detail.createdAt)
-            if not (start_ts <= detail_created_at <= end_ts):
-                continue
-            rows.append(_detail_to_dict(detail, pid, course_windows))
+    for detail in details:
+        if detail.createdAt is None:
+            continue
+        rows.append(_detail_to_dict(detail, str(detail.participantId), course_windows))
 
     if verbose:
-        print(
-            "Found {} detail responses for timespan {}..{}".format(
-                len(rows), start_date, end_date
-            )
-        )
+        print("Found {} detail responses for timespan {}..{}".format(len(rows), start_date, end_date))
 
     df_details = pd.DataFrame(rows)
     if df_details.empty:

--- a/apps/analytics/src/modules/participant_analytics/get_participant_responses.py
+++ b/apps/analytics/src/modules/participant_analytics/get_participant_responses.py
@@ -105,8 +105,6 @@ def get_participant_responses(session: Session, start_date: str, end_date: str, 
 
     rows = []
     for detail in details:
-        if detail.createdAt is None:
-            continue
         rows.append(_detail_to_dict(detail, str(detail.participantId), course_windows))
 
     if verbose:

--- a/apps/analytics/src/modules/participant_analytics/save_participant_analytics.py
+++ b/apps/analytics/src/modules/participant_analytics/save_participant_analytics.py
@@ -1,8 +1,6 @@
-from datetime import date, datetime
-
 from sqlalchemy.orm import Session
 
-from src.db_helpers import bulk_upsert, coerce_date
+from src.db_helpers import bulk_upsert, coerce_date, utcnow
 from src.models import ParticipantAnalytics
 
 
@@ -12,7 +10,8 @@ def save_participant_analytics(
     if df_analytics is None or df_analytics.empty:
         return
 
-    computedAt = date.today()
+    now = utcnow()
+    computedAt = now.date()
 
     if analytics_type in ("DAILY", "WEEKLY", "MONTHLY"):
         ts = coerce_date(timestamp)
@@ -31,8 +30,8 @@ def save_participant_analytics(
                 "meanWrongCount": float(row["meanWrongCount"]),
                 "participantId": row["participantId"],
                 "courseId": row["courseId"],
-                "createdAt": datetime.now(),
-                "updatedAt": datetime.now(),
+                "createdAt": now,
+                "updatedAt": now,
             }
             for _, row in df_analytics.iterrows()
         ]
@@ -57,8 +56,8 @@ def save_participant_analytics(
                 "lastWrongCount": float(row["lastWrongCount"]),
                 "participantId": row["participantId"],
                 "courseId": row["courseId"],
-                "createdAt": datetime.now(),
-                "updatedAt": datetime.now(),
+                "createdAt": now,
+                "updatedAt": now,
             }
             for _, row in df_analytics.iterrows()
         ]

--- a/apps/analytics/src/scripts/10_chat_topic_clustering.py
+++ b/apps/analytics/src/scripts/10_chat_topic_clustering.py
@@ -52,6 +52,7 @@ def main() -> None:
         win_end = datetime.now().strftime("%Y-%m-%d") + "T23:59:59.999Z"
 
         total_rows = 0
+        failures = []
         for cb in chatbots:
             try:
                 written = cluster_chatbot(
@@ -65,9 +66,15 @@ def main() -> None:
                 )
                 total_rows += written
             except Exception as exc:
+                session.rollback()
+                failures.append(str(cb.id))
                 print(f"[chat_topic_clustering] chatbot={cb.id} FAILED: {exc}")
 
         print(f"[chat_topic_clustering] total rows written: {total_rows}")
+
+        if failures:
+            failed_ids = ", ".join(failures)
+            raise RuntimeError(f"{len(failures)} of {len(chatbots)} chatbot clustering jobs failed: {failed_ids}")
 
         script_exit(script=__name__, started=started, rows_written=total_rows)
 

--- a/apps/analytics/tests/test_analytics_save_timestamps.py
+++ b/apps/analytics/tests/test_analytics_save_timestamps.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib
+from datetime import datetime
+
+import pandas as pd
+
+
+class _FakeSession:
+    def commit(self):
+        return None
+
+
+def _capture_rows(monkeypatch, module):
+    captured = {}
+    monkeypatch.setattr(
+        module,
+        "bulk_upsert",
+        lambda _session, _model, rows, **_kwargs: captured.setdefault("rows", rows),
+    )
+    return captured
+
+
+def test_participant_analytics_uses_one_utc_timestamp(monkeypatch):
+    module = importlib.import_module("src.modules.participant_analytics.save_participant_analytics")
+    fixed_now = datetime(2026, 7, 23, 12, 30)
+    captured = _capture_rows(monkeypatch, module)
+    monkeypatch.setattr(module, "utcnow", lambda: fixed_now)
+    df = pd.DataFrame(
+        [
+            {
+                "participantId": "participant-1",
+                "courseId": "course-1",
+                "trialsCount": 1,
+                "responseCount": 2,
+                "totalScore": 3,
+                "totalPoints": 4,
+                "totalXp": 5,
+                "meanCorrectCount": 0.5,
+                "meanPartialCount": 0.25,
+                "meanWrongCount": 0.25,
+            }
+        ]
+    )
+
+    module.save_participant_analytics(_FakeSession(), df, "2026-07-23T00:00:00Z", "DAILY")
+
+    row = captured["rows"][0]
+    assert row["computedAt"] == fixed_now.date()
+    assert row["createdAt"] == fixed_now
+    assert row["updatedAt"] == fixed_now
+    assert row["createdAt"].tzinfo is None
+
+
+def test_aggregated_analytics_uses_one_utc_timestamp(monkeypatch):
+    module = importlib.import_module("src.modules.aggregated_analytics.save_aggregated_analytics")
+    fixed_now = datetime(2026, 7, 23, 12, 30)
+    captured = _capture_rows(monkeypatch, module)
+    monkeypatch.setattr(module, "utcnow", lambda: fixed_now)
+    df = pd.DataFrame(
+        [
+            {
+                "courseId": "course-1",
+                "participantCount": 1,
+                "responseCount": 2,
+                "totalScore": 3,
+                "totalPoints": 4,
+                "totalXp": 5,
+            }
+        ]
+    )
+
+    module.save_aggregated_analytics(_FakeSession(), df, "2026-07-23T00:00:00Z", "DAILY")
+
+    row = captured["rows"][0]
+    assert row["computedAt"] == fixed_now.date()
+    assert row["createdAt"] == fixed_now
+    assert row["updatedAt"] == fixed_now
+    assert row["createdAt"].tzinfo is None

--- a/apps/analytics/tests/test_chat_topic_clustering_script.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_script.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+class _Scalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _Scalars(self._rows)
+
+
+class _Session:
+    def __init__(self, rows):
+        self._rows = rows
+        self.rollback_count = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def execute(self, _stmt):
+        return _Result(self._rows)
+
+    def rollback(self):
+        self.rollback_count += 1
+
+
+def test_chat_topic_clustering_reports_partial_failures(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+psycopg://localhost:5432/analytics",
+    )
+    module = importlib.import_module("src.scripts.10_chat_topic_clustering")
+    session = _Session([type("Chatbot", (), {"id": "ok"})(), type("Chatbot", (), {"id": "broken"})()])
+    clustered: list[str] = []
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: session)
+    monkeypatch.setattr(module, "scoped_course_ids", lambda _session: None)
+    monkeypatch.setattr(module, "script_entry", lambda **_kwargs: 0.0)
+    monkeypatch.setattr(module, "script_exit", lambda **_kwargs: None)
+
+    def cluster(_session, chatbot_id, *_args, **_kwargs):
+        clustered.append(chatbot_id)
+        if chatbot_id == "broken":
+            raise RuntimeError("cluster failed")
+        return 2
+
+    monkeypatch.setattr(module, "cluster_chatbot", cluster)
+
+    with pytest.raises(RuntimeError, match=r"1 of 2 chatbot clustering jobs failed.*broken"):
+        module.main()
+
+    assert clustered == ["ok", "broken"]
+    assert session.rollback_count == 1

--- a/apps/analytics/tests/test_chat_topic_clustering_script.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_script.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib
+import sys
+import types
 
 import pytest
 
@@ -40,6 +42,14 @@ class _Session:
 
 
 def test_chat_topic_clustering_reports_partial_failures(monkeypatch):
+    cluster_module = types.ModuleType("src.modules.chat_topic_clustering.cluster_chatbot")
+    cluster_module.cluster_chatbot = lambda *_args, **_kwargs: 0
+    monkeypatch.setitem(
+        sys.modules,
+        "src.modules.chat_topic_clustering.cluster_chatbot",
+        cluster_module,
+    )
+    sys.modules.pop("src.scripts.10_chat_topic_clustering", None)
     monkeypatch.setenv(
         "DATABASE_URL",
         "postgresql+psycopg://localhost:5432/analytics",

--- a/apps/analytics/tests/test_course_scope_sql.py
+++ b/apps/analytics/tests/test_course_scope_sql.py
@@ -4,6 +4,8 @@ import os
 import sys
 import uuid
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -112,6 +114,50 @@ def test_aggregated_chatbot_analytics_renders_course_filter_for_weekly():
     )
 
     assert f"""AND cb."courseId" IN ('{course_id}')""" in session.statements[0]
+
+
+@pytest.mark.parametrize("analytics_type", ["DAILY", "WEEKLY", "MONTHLY", "COURSE"])
+def test_participant_chat_analytics_refreshes_existing_rollups(analytics_type):
+    from src.modules.chat_analytics.compute_participant_chat_analytics import (
+        compute_participant_chat_analytics,
+    )
+
+    session = _CaptureSession(scalars=[0])
+
+    compute_participant_chat_analytics(
+        session,
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-31T23:59:59.999Z",
+        "2026-01-31",
+        analytics_type,
+    )
+
+    statement = session.statements[-1]
+    assert "ON CONFLICT" in statement
+    assert "DO UPDATE SET" in statement
+    assert """WHERE "ParticipantChatAnalytics"."type" = 'COURSE'""" not in statement
+
+
+@pytest.mark.parametrize("analytics_type", ["DAILY", "WEEKLY", "MONTHLY", "COURSE"])
+def test_aggregated_chatbot_analytics_refreshes_existing_rollups(analytics_type):
+    from src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics import (
+        compute_aggregated_chatbot_analytics,
+    )
+
+    session = _CaptureSession()
+
+    compute_aggregated_chatbot_analytics(
+        session,
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-31T23:59:59.999Z",
+        "2026-01-31",
+        analytics_type,
+    )
+
+    statement = session.statements[-1]
+    assert "ON CONFLICT" in statement
+    assert "DO UPDATE SET" in statement
+    assert """WHERE "AggregatedChatbotAnalytics"."type" = 'COURSE'""" not in statement
 
 
 def test_chat_quiz_correlation_renders_course_filters():

--- a/apps/analytics/tests/test_db_helpers.py
+++ b/apps/analytics/tests/test_db_helpers.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
+import pytest
 from sqlalchemy import Integer, String, create_engine, select
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, load_only, mapped_column
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from src.db_helpers import coerce_date, coerce_timestamp, row_to_dict
+from src.db_helpers import bulk_upsert, coerce_date, coerce_timestamp, row_to_dict, utcnow
 
 
 class _Base(DeclarativeBase):
@@ -67,3 +68,27 @@ def test_coerce_date_rejects_non_date_strings():
         pass
     else:
         raise AssertionError("expected invalid date string to raise ValueError")
+
+
+def test_bulk_upsert_rejects_rows_with_different_columns():
+    rows = [
+        {"id": 1, "name": "complete", "legacy": "present"},
+        {"id": 2, "name": "missing-legacy"},
+    ]
+
+    with pytest.raises(ValueError, match=r"row 1.*same columns"):
+        bulk_upsert(
+            session=None,  # type: ignore[arg-type]
+            Model=_Thing,
+            rows=rows,
+            conflict_cols=["id"],
+        )
+
+
+def test_utcnow_is_naive_utc():
+    before = datetime.now(timezone.utc).replace(tzinfo=None)
+    result = utcnow()
+    after = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    assert result.tzinfo is None
+    assert before - timedelta(seconds=1) <= result <= after + timedelta(seconds=1)

--- a/apps/analytics/tests/test_live_quiz_analytics_sql.py
+++ b/apps/analytics/tests/test_live_quiz_analytics_sql.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+
+def test_aggregated_query_ranks_attempts_per_participant_and_instance():
+    from src.modules.live_quiz_analytics.compute_live_quiz_analytics import _AGGREGATED_SQL
+
+    assert 'PARTITION BY lqr."participantId", lqr."instanceId"' in _AGGREGATED_SQL
+    assert "attempt_asc = 1" in _AGGREGATED_SQL
+    assert "attempt_desc = 1" in _AGGREGATED_SQL
+    assert "JOIN LATERAL" not in _AGGREGATED_SQL
+
+
+@pytest.mark.integration
+def test_aggregated_query_computes_first_and_last_per_participant(session):
+    from src.modules.live_quiz_analytics.compute_live_quiz_analytics import (
+        compute_aggregated_live_quiz_analytics,
+    )
+
+    session.execute(
+        text(
+            """
+            CREATE TEMP TABLE "LiveQuiz" (
+              id text PRIMARY KEY,
+              "courseId" text,
+              "finishedAt" timestamptz,
+              "isAssessmentEnabled" boolean NOT NULL
+            );
+            CREATE TEMP TABLE "ElementBlock" (
+              id integer PRIMARY KEY,
+              "liveQuizId" text NOT NULL
+            );
+            CREATE TEMP TABLE "ElementInstance" (
+              id integer PRIMARY KEY,
+              "elementBlockId" integer NOT NULL
+            );
+            CREATE TEMP TABLE "LiveQuizResponse" (
+              id integer PRIMARY KEY,
+              "participantId" text NOT NULL,
+              "instanceId" integer NOT NULL,
+              "submittedAt" timestamptz NOT NULL,
+              correctness text NOT NULL,
+              "correctionOnly" boolean NOT NULL
+            );
+            CREATE TEMP TABLE "AggregatedLiveQuizAnalytics" (
+              "liveQuizId" text PRIMARY KEY,
+              "courseId" text NOT NULL,
+              "participantCount" integer NOT NULL,
+              "responseCount" integer NOT NULL,
+              "meanFirstCorrectness" real,
+              "meanLastCorrectness" real,
+              "lateSubmitterRate" real,
+              "createdAt" timestamptz NOT NULL,
+              "updatedAt" timestamptz NOT NULL
+            );
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "LiveQuiz"
+              (id, "courseId", "finishedAt", "isAssessmentEnabled")
+            VALUES
+              ('quiz-1', 'course-1', :finished_at, true)
+            """
+        ),
+        {"finished_at": datetime(2026, 7, 23, 10, 5, tzinfo=UTC)},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ElementBlock" (id, "liveQuizId")
+            VALUES (1, 'quiz-1')
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ElementInstance" (id, "elementBlockId")
+            VALUES (10, 1)
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "LiveQuizResponse"
+              (id, "participantId", "instanceId", "submittedAt", correctness, "correctionOnly")
+            VALUES
+              (1, 'participant-1', 10, :p1_first, 'WRONG', false),
+              (2, 'participant-1', 10, :p1_last, 'CORRECT', false),
+              (3, 'participant-2', 10, :p2_only, 'CORRECT', false),
+              (4, 'participant-2', 10, :ignored_correction, 'WRONG', true)
+            """
+        ),
+        {
+            "p1_first": datetime(2026, 7, 23, 10, 1, tzinfo=UTC),
+            "p1_last": datetime(2026, 7, 23, 10, 3, tzinfo=UTC),
+            "p2_only": datetime(2026, 7, 23, 10, 6, tzinfo=UTC),
+            "ignored_correction": datetime(2026, 7, 23, 10, 0, tzinfo=UTC),
+        },
+    )
+
+    assert compute_aggregated_live_quiz_analytics(session) == 1
+
+    result = (
+        session.execute(
+            text(
+                """
+                SELECT
+                  "participantCount",
+                  "responseCount",
+                  "meanFirstCorrectness",
+                  "meanLastCorrectness",
+                  "lateSubmitterRate"
+                FROM "AggregatedLiveQuizAnalytics"
+                WHERE "liveQuizId" = 'quiz-1'
+                """
+            )
+        )
+        .mappings()
+        .one()
+    )
+    assert result["participantCount"] == 2
+    assert result["responseCount"] == 3
+    assert result["meanFirstCorrectness"] == pytest.approx(0.5)
+    assert result["meanLastCorrectness"] == pytest.approx(1.0)
+    assert result["lateSubmitterRate"] == pytest.approx(0.5)

--- a/apps/analytics/tests/test_participant_analytics_helpers.py
+++ b/apps/analytics/tests/test_participant_analytics_helpers.py
@@ -184,16 +184,24 @@ def test_numerical_ranges_match_product_grading(response_value, expected):
     [
         ({"solutionRanges": []}, 0, None),
         ({"solutionRanges": [{}]}, 0, None),
+        ({"solutionRanges": [{"min": "bad"}]}, 0, None),
         ({"solutionRanges": [{"max": 0}]}, 0, "CORRECT"),
         ({"solutionRanges": [{"max": 0}]}, 1, "INCORRECT"),
         ({"solutionRanges": [{"min": 0}]}, -1, "INCORRECT"),
         ({"exactSolutions": []}, 0.1, None),
         ({"solutionRanges": [], "exactSolutions": [0]}, 0, "CORRECT"),
+        (
+            {"solutionRanges": [{"min": 10, "max": 20}], "exactSolutions": [5]},
+            5,
+            "INCORRECT",
+        ),
         ({"exactSolutions": [0]}, 1e-30, "CORRECT"),
         ({"exactSolutions": [0]}, 1e-12, "INCORRECT"),
         ({"exactSolutions": [0, 100]}, 100, "CORRECT"),
         ({"exactSolutions": [0, 100]}, 50, "INCORRECT"),
         ({"exactSolutions": [0.1]}, 0.1, "CORRECT"),
+        ({"solutionRanges": [{"min": 0}]}, float("nan"), None),
+        ({"solutionRanges": [{"min": 0}]}, float("inf"), None),
     ],
 )
 def test_numerical_exact_and_empty_solutions_match_product_grading(options, response_value, expected):

--- a/apps/analytics/tests/test_participant_analytics_helpers.py
+++ b/apps/analytics/tests/test_participant_analytics_helpers.py
@@ -108,6 +108,37 @@ def test_window_bounds_accept_aware_strings_and_compare_with_naive_datetimes():
     assert start_ts <= detail_ts <= end_ts
 
 
+def test_participant_response_query_filters_the_window_in_postgres():
+    module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
+
+    captured = {}
+
+    class _FakeScalars:
+        def all(self):
+            return []
+
+    class _FakeResult:
+        def scalars(self):
+            return _FakeScalars()
+
+    class _FakeSession:
+        def execute(self, stmt):
+            captured["stmt"] = stmt
+            return _FakeResult()
+
+    result = module.get_participant_responses(
+        _FakeSession(),
+        "2026-02-15T00:00:00.000Z",
+        "2026-02-15T23:59:59.999Z",
+    )
+
+    statement = str(captured["stmt"])
+    assert 'FROM "QuestionResponseDetail"' in statement
+    assert '"QuestionResponseDetail"."createdAt" >= ' in statement
+    assert '"QuestionResponseDetail"."createdAt" <= ' in statement
+    assert result.empty
+
+
 def _selection_instance_df(options):
     return pd.DataFrame(
         [

--- a/apps/analytics/tests/test_participant_analytics_helpers.py
+++ b/apps/analytics/tests/test_participant_analytics_helpers.py
@@ -132,6 +132,84 @@ def _case_study_instance_df(options):
     )
 
 
+def _numerical_instance_df(options):
+    return pd.DataFrame(
+        [
+            {
+                "elementInstanceId": "instance-1",
+                "type": "NUMERICAL",
+                "options": options,
+            }
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("response_value", "expected"),
+    [
+        (5, "CORRECT"),
+        (10, "CORRECT"),
+        (16, "CORRECT"),
+        (50, "INCORRECT"),
+        (70, "CORRECT"),
+        (70.11, "INCORRECT"),
+        (95, "CORRECT"),
+    ],
+)
+def test_numerical_ranges_match_product_grading(response_value, expected):
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
+
+    result = module.compute_correctness_columns(
+        _numerical_instance_df(
+            {
+                "solutionRanges": [
+                    {"max": 10},
+                    {"min": 13, "max": 30},
+                    {"min": 70, "max": 70},
+                    {"min": 90},
+                ]
+            }
+        ),
+        {
+            "elementInstanceId": "instance-1",
+            "response": {"value": response_value},
+        },
+    )
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("options", "response_value", "expected"),
+    [
+        ({"solutionRanges": []}, 0, None),
+        ({"solutionRanges": [{}]}, 0, None),
+        ({"solutionRanges": [{"max": 0}]}, 0, "CORRECT"),
+        ({"solutionRanges": [{"max": 0}]}, 1, "INCORRECT"),
+        ({"solutionRanges": [{"min": 0}]}, -1, "INCORRECT"),
+        ({"exactSolutions": []}, 0.1, None),
+        ({"solutionRanges": [], "exactSolutions": [0]}, 0, "CORRECT"),
+        ({"exactSolutions": [0]}, 1e-30, "CORRECT"),
+        ({"exactSolutions": [0]}, 1e-12, "INCORRECT"),
+        ({"exactSolutions": [0, 100]}, 100, "CORRECT"),
+        ({"exactSolutions": [0, 100]}, 50, "INCORRECT"),
+        ({"exactSolutions": [0.1]}, 0.1, "CORRECT"),
+    ],
+)
+def test_numerical_exact_and_empty_solutions_match_product_grading(options, response_value, expected):
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
+
+    result = module.compute_correctness_columns(
+        _numerical_instance_df(options),
+        {
+            "elementInstanceId": "instance-1",
+            "response": {"value": response_value},
+        },
+    )
+
+    assert result == expected
+
+
 def test_selection_correctness_without_sample_solution_is_treated_as_correct():
     module = importlib.import_module(
         "src.modules.participant_analytics.compute_correctness"

--- a/apps/hatchet-worker-response-processor/package.json
+++ b/apps/hatchet-worker-response-processor/package.json
@@ -35,7 +35,8 @@
     "dev:offline": "pnpm run dev",
     "dev:test": "cross-env NODE_ENV=test ASSESSMENT_MODE=false tsx --env-file .env src/index.ts",
     "dev:ts": "cross-env NODE_ENV=development tsx --watch --env-file .env src/index.ts",
-    "start:test": "node --env-file .env dist/index.js"
+    "start:test": "node --env-file .env dist/index.js",
+    "test": "node --import tsx --test test/*.test.mjs"
   },
   "engines": {
     "node": "=24"

--- a/apps/hatchet-worker-response-processor/src/processors/helpers.ts
+++ b/apps/hatchet-worker-response-processor/src/processors/helpers.ts
@@ -166,11 +166,14 @@ export function validateStudentResponse({
     // if all cases are passed, choices response is considered to be valid
     return { valid: true }
   } else if (type === 'NUMERICAL') {
-    // response should be a string and be parseable as a number
+    // response should contain only a finite number
+    const trimmedResponse =
+      typeof response.value === 'string' ? response.value.trim() : ''
+    const parsedResponse = Number(trimmedResponse)
     if (
       typeof response.value !== 'string' ||
-      !response.value ||
-      isNaN(parseFloat(response.value))
+      !trimmedResponse ||
+      !Number.isFinite(parsedResponse)
     ) {
       return {
         valid: false,
@@ -179,7 +182,6 @@ export function validateStudentResponse({
     }
 
     // if restrictions are defined, check that the parsed number is within the defined bounds
-    const parsedResponse = parseFloat(response.value)
     if (
       restrictions &&
       (('min' in restrictions &&

--- a/apps/hatchet-worker-response-processor/test/numerical-response.test.mjs
+++ b/apps/hatchet-worker-response-processor/test/numerical-response.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { validateStudentResponse } from '../src/processors/helpers.ts'
+
+describe('numerical response validation', () => {
+  it('rejects partially parsed and non-finite values', () => {
+    for (const value of ['1junk', 'NaN', 'Infinity', '-Infinity', '   ']) {
+      assert.equal(
+        validateStudentResponse({
+          type: 'NUMERICAL',
+          response: { value },
+        }).valid,
+        false,
+        `expected ${JSON.stringify(value)} to be invalid`
+      )
+    }
+  })
+
+  it('accepts finite numbers represented as strings', () => {
+    for (const value of ['0', '-2.5', '.5', '1e3', ' 42 ']) {
+      assert.deepEqual(
+        validateStudentResponse({
+          type: 'NUMERICAL',
+          response: { value },
+        }),
+        { valid: true }
+      )
+    }
+  })
+})

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -99,6 +99,7 @@ export function gradeQuestionNumerical({
   solutionRanges,
   exactSolutions,
 }: GradeQuestionNumericalArgs): number | null {
+  if (!Number.isFinite(response)) return null
   if (!solutionRanges?.length && !exactSolutions?.length) return null
 
   if (solutionRanges && solutionRanges.length > 0) {

--- a/packages/grading/src/index.ts
+++ b/packages/grading/src/index.ts
@@ -110,8 +110,10 @@ export function gradeQuestionNumerical({
     if (definedSolutionRanges.length === 0) return null
 
     const withinRanges = definedSolutionRanges.map(({ min, max }) => {
-      if (min && response < min - Number.EPSILON) return false
-      if (max && response > max + Number.EPSILON) return false
+      if (typeof min === 'number' && response < min - Number.EPSILON)
+        return false
+      if (typeof max === 'number' && response > max + Number.EPSILON)
+        return false
       return true
     })
 

--- a/packages/grading/test/index.test.ts
+++ b/packages/grading/test/index.test.ts
@@ -323,6 +323,25 @@ describe('@klicker-uzh/grading', () => {
       response: -1,
     })
     expect(zeroLowerBound).toEqual(0)
+
+    const nonFiniteResponse = gradeQuestionNumerical({
+      solutionRanges: [{ min: 0, max: 10 }],
+      response: Number.NaN,
+    })
+    expect(nonFiniteResponse).toEqual(null)
+
+    const positiveInfinityResponse = gradeQuestionNumerical({
+      solutionRanges: [{ min: 0 }],
+      response: Number.POSITIVE_INFINITY,
+    })
+    expect(positiveInfinityResponse).toEqual(null)
+
+    const solutionRangePrecedence = gradeQuestionNumerical({
+      solutionRanges: [{ min: 10, max: 20 }],
+      exactSolutions: [5],
+      response: 5,
+    })
+    expect(solutionRangePrecedence).toEqual(0)
   })
 
   it('should grade FREE_TEXT questions correctly', () => {

--- a/packages/grading/test/index.test.ts
+++ b/packages/grading/test/index.test.ts
@@ -311,6 +311,18 @@ describe('@klicker-uzh/grading', () => {
       response: 0.1,
     })
     expect(points17).toEqual(null)
+
+    const zeroUpperBound = gradeQuestionNumerical({
+      solutionRanges: [{ max: 0 }],
+      response: 1,
+    })
+    expect(zeroUpperBound).toEqual(0)
+
+    const zeroLowerBound = gradeQuestionNumerical({
+      solutionRanges: [{ min: 0 }],
+      response: -1,
+    })
+    expect(zeroLowerBound).toEqual(0)
   })
 
   it('should grade FREE_TEXT questions correctly', () => {

--- a/packages/hatchet/package.json
+++ b/packages/hatchet/package.json
@@ -37,7 +37,8 @@
     "dev": "run-p --npm-path pnpm dev:ts",
     "dev:infisical": "../../util/_run_with_infisical.sh --env dev pnpm run dev",
     "dev:offline": "pnpm run dev",
-    "dev:ts": "cross-env NODE_ENV=development rollup -c --watch"
+    "dev:ts": "cross-env NODE_ENV=development rollup -c --watch",
+    "test": "node --test test/*.test.mjs"
   },
   "engines": {
     "node": "=24"

--- a/packages/hatchet/rollup.config.js
+++ b/packages/hatchet/rollup.config.js
@@ -5,7 +5,7 @@ import { defineConfig } from 'rollup'
 const config = defineConfig([
   {
     // Main build configuration
-    input: ['src/index.ts'],
+    input: ['src/index.ts', 'src/tasks.ts'],
     output: {
       dir: 'dist',
       format: 'esm',

--- a/packages/hatchet/rollup.config.js
+++ b/packages/hatchet/rollup.config.js
@@ -5,7 +5,7 @@ import { defineConfig } from 'rollup'
 const config = defineConfig([
   {
     // Main build configuration
-    input: ['src/index.ts', 'src/tasks.ts'],
+    input: ['src/index.ts'],
     output: {
       dir: 'dist',
       format: 'esm',

--- a/packages/hatchet/src/tasks.ts
+++ b/packages/hatchet/src/tasks.ts
@@ -394,10 +394,6 @@ export function prepareHatchetTasks({
     executionTimeout: '60m',
     fn: makeScriptTaskFn(ANALYTICS_SCRIPTS.s10_clustering),
   })
-  const taskS13 = recomputeLearningAnalytics.task({
-    name: 's13-platform-semester-analytics',
-    fn: makeScriptTaskFn(ANALYTICS_SCRIPTS.s13_platform),
-  })
   const taskS14 = recomputeLearningAnalytics.task({
     name: 's14-live-quiz-assessment-analytics',
     fn: makeScriptTaskFn(ANALYTICS_SCRIPTS.s14_live_quiz),
@@ -409,6 +405,11 @@ export function prepareHatchetTasks({
     executionTimeout: '60m', // window-iterating
     parents: [taskS0],
     fn: makeScriptTaskFn(ANALYTICS_SCRIPTS.s1_aggregated),
+  })
+  const taskS13 = recomputeLearningAnalytics.task({
+    name: 's13-platform-semester-analytics',
+    parents: [taskS2],
+    fn: makeScriptTaskFn(ANALYTICS_SCRIPTS.s13_platform),
   })
   const taskS11 = recomputeLearningAnalytics.task({
     name: 's11-chat-quiz-correlation',

--- a/packages/hatchet/src/tasks.ts
+++ b/packages/hatchet/src/tasks.ts
@@ -471,11 +471,9 @@ export function prepareHatchetTasks({
         `[scanEndedCourses] graceDays=${effectiveGrace} cutoff=${cutoff.toISOString()} candidates=${candidates.length}`
       )
 
-      // Day-bucketed idempotency key — a scanner retry inside the same UTC
-      // day reuses the key and Hatchet de-duplicates the emission. Workflow
-      // concurrency still cancels an in-progress older run on a new key, but
-      // the common case (CI retry, manual re-trigger) no longer costs a
-      // scheduling round trip per duplicate.
+      // Day-bucketed dashboard metadata makes scanner emissions identifiable.
+      // It does not deduplicate events; workflow concurrency cancels an
+      // in-progress older run when another event targets the same course.
       const today = new Date().toISOString().slice(0, 10)
       await Promise.all(
         candidates.map(({ id }) =>

--- a/packages/hatchet/test/analytics-dag.test.mjs
+++ b/packages/hatchet/test/analytics-dag.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { prepareHatchetTasks } from '../dist/tasks.js'
+
+function makeHatchet() {
+  return {
+    events: {
+      push: async () => undefined,
+    },
+    task(definition) {
+      return definition
+    },
+    workflow(definition) {
+      const registeredTasks = []
+      return {
+        ...definition,
+        registeredTasks,
+        task(taskDefinition) {
+          registeredTasks.push(taskDefinition)
+          return taskDefinition
+        },
+      }
+    },
+  }
+}
+
+test('platform analytics waits for course analytics and validity waits for every task', () => {
+  const handlers = new Proxy(
+    {},
+    {
+      get: () => async () => true,
+    }
+  )
+  const prepared = prepareHatchetTasks({
+    hatchet: makeHatchet(),
+    pubSub: {},
+    emitter: {},
+    redisExec: {},
+    redisAssessmentExec: {},
+    handlers,
+  })
+  const definitions = new Map(
+    prepared.recomputeLearningAnalytics.registeredTasks.map(
+      (taskDefinition) => [taskDefinition.name, taskDefinition]
+    )
+  )
+  const parentNames = (name) =>
+    (definitions.get(name)?.parents ?? []).map((parent) => parent.name)
+
+  assert.deepEqual(parentNames('s13-platform-semester-analytics'), [
+    's2-course-heatmap',
+  ])
+  assert.deepEqual(
+    new Set(parentNames('s99-mark-analytics-valid')),
+    new Set([
+      's0-participant-analytics',
+      's1-aggregated-analytics',
+      's2-course-heatmap',
+      's3-instance-activity-perf',
+      's4-participant-perf',
+      's5-participant-course-analytics',
+      's6-activity-progress',
+      's7-participant-activity-perf',
+      's8-chat-analytics',
+      's9-aggregated-chatbot-analytics',
+      's10-chat-topic-clustering',
+      's11-chat-quiz-correlation',
+      's13-platform-semester-analytics',
+      's14-live-quiz-assessment-analytics',
+    ])
+  )
+})

--- a/packages/hatchet/test/analytics-dag.test.mjs
+++ b/packages/hatchet/test/analytics-dag.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { prepareHatchetTasks } from '../dist/tasks.js'
+import { prepareHatchetTasks } from '../src/tasks.ts'
 
 function makeHatchet() {
   return {

--- a/packages/prisma-data/src/data/interactions/responses.ts
+++ b/packages/prisma-data/src/data/interactions/responses.ts
@@ -85,10 +85,7 @@ async function loadCourseActivities(
   return activities
 }
 
-// Build the JSON payloads QuestionResponse stores in firstResponse /
-// lastResponse. Shape matches what live code produces; the exact content
-// doesn't matter for the analytics pipeline, but well-formed JSON avoids
-// downstream surprises if we later expand what the pipeline reads.
+// Build valid response payloads consumed by analytics correctness computation.
 function responsePayload(elementType: string, rng: Rng): object {
   switch (elementType) {
     case 'SC':

--- a/packages/prisma-data/src/data/interactions/responses.ts
+++ b/packages/prisma-data/src/data/interactions/responses.ts
@@ -17,10 +17,14 @@ type CourseActivity = {
 
 type Outcome = 'CORRECT' | 'PARTIAL' | 'WRONG'
 
-// Element types the analytics compute_correctness handles. NUMERICAL is
-// technically supported but the existing Testkurs seed uses one-sided
-// solutionRanges like {max: 5}, which the pipeline can't score.
-const SCORABLE_ELEMENT_TYPES = new Set(['SC', 'MC', 'KPRIM', 'FREE_TEXT'])
+// Element types for which this seeder emits payloads analytics can score.
+const SCORABLE_ELEMENT_TYPES = new Set([
+  'SC',
+  'MC',
+  'KPRIM',
+  'NUMERICAL',
+  'FREE_TEXT',
+])
 
 const OUTCOME_VALUES: Record<
   Outcome,

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -32,13 +32,13 @@
     "build": "run-s --npm-path pnpm generate build:ts",
     "build:test": "pnpm run build",
     "build:ts": "cross-env NODE_ENV=production rollup -c",
-    "check": "run-s --npm-path pnpm generate check:ts",
+    "check": "run-s --npm-path pnpm generate check:ts test:analytics-index-deploy",
     "check:ts": "tsc --noEmit -p tsconfig.check.json",
     "generate": "prisma generate",
     "prisma:deploy": "../../util/_run_with_infisical.sh --env dev pnpm run prisma:deploy:raw",
     "prisma:deploy:prod": "../../util/_run_with_infisical.sh --env prd pnpm run prisma:deploy:raw",
     "prisma:deploy:qa": "../../util/_run_with_infisical.sh --env stg pnpm run prisma:deploy:raw",
-    "prisma:deploy:raw": "prisma migrate deploy",
+    "prisma:deploy:raw": "node scripts/prepareAnalyticsIndexes.mjs && prisma migrate deploy",
     "prisma:diff": "../../util/_run_with_infisical.sh --env prd env SHADOW_DATABASE_URL=postgres://klicker-prod:klicker@localhost:5432/shadow pnpm run prisma:diff:raw",
     "prisma:diff:raw": "prisma migrate diff --from-config-datasource --to-migrations src/prisma/schema/migrations",
     "prisma:migrate": "../../util/_run_with_infisical.sh --env dev pnpm run prisma:migrate:raw",
@@ -68,7 +68,8 @@
     "prisma:studio": "../../util/_run_with_infisical.sh --env dev pnpm run prisma:studio:raw",
     "prisma:studio:prod": "../../util/_run_with_infisical.sh --env prd pnpm run prisma:studio:raw",
     "prisma:studio:qa": "../../util/_run_with_infisical.sh --env stg pnpm run prisma:studio:raw",
-    "prisma:studio:raw": "prisma studio"
+    "prisma:studio:raw": "prisma studio",
+    "test:analytics-index-deploy": "node --test scripts/prepareAnalyticsIndexes.test.mjs"
   },
   "engines": {
     "node": "=24"

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -38,7 +38,7 @@
     "prisma:deploy": "../../util/_run_with_infisical.sh --env dev pnpm run prisma:deploy:raw",
     "prisma:deploy:prod": "../../util/_run_with_infisical.sh --env prd pnpm run prisma:deploy:raw",
     "prisma:deploy:qa": "../../util/_run_with_infisical.sh --env stg pnpm run prisma:deploy:raw",
-    "prisma:deploy:raw": "node scripts/prepareAnalyticsIndexes.mjs && prisma migrate deploy",
+    "prisma:deploy:raw": "node scripts/prepareAnalyticsIndexes.mjs",
     "prisma:diff": "../../util/_run_with_infisical.sh --env prd env SHADOW_DATABASE_URL=postgres://klicker-prod:klicker@localhost:5432/shadow pnpm run prisma:diff:raw",
     "prisma:diff:raw": "prisma migrate diff --from-config-datasource --to-migrations src/prisma/schema/migrations",
     "prisma:migrate": "../../util/_run_with_infisical.sh --env dev pnpm run prisma:migrate:raw",

--- a/packages/prisma/scripts/create-analytics-indexes-concurrently.sql
+++ b/packages/prisma/scripts/create-analytics-indexes-concurrently.sql
@@ -1,49 +1,14 @@
-\set ON_ERROR_STOP on
-
--- Run this file with psql before Prisma deploys the analytics index migrations
--- to a shared environment. Do not wrap it in BEGIN / COMMIT.
---
--- IF NOT EXISTS also sees invalid indexes and would skip them, so abort until
--- the operator drops the exact invalid index concurrently.
-SELECT EXISTS (
-  SELECT 1
-  FROM pg_index
-  WHERE NOT indisvalid
-    AND indexrelid::regclass::text IN (
-      '"QuestionResponse_courseId_createdAt_idx"',
-      '"ChatMessage_threadId_createdAt_idx"',
-      '"ParticipantAnalytics_courseId_type_timestamp_idx"',
-      '"AggregatedAnalytics_courseId_type_timestamp_idx"',
-      '"QuestionResponseDetail_createdAt_brin_idx"',
-      '"LiveQuizResponse_createdAt_brin_idx"',
-      '"LiveQuizResponse_instanceId_submittedAt_idx"'
-    )
-) AS analytics_invalid_indexes \gset
-
-\if :analytics_invalid_indexes
-SELECT indexrelid::regclass AS invalid_index
-FROM pg_index
-WHERE NOT indisvalid
-  AND indexrelid::regclass::text IN (
-    '"QuestionResponse_courseId_createdAt_idx"',
-    '"ChatMessage_threadId_createdAt_idx"',
-    '"ParticipantAnalytics_courseId_type_timestamp_idx"',
-    '"AggregatedAnalytics_courseId_type_timestamp_idx"',
-    '"QuestionResponseDetail_createdAt_brin_idx"',
-    '"LiveQuizResponse_createdAt_brin_idx"',
-    '"LiveQuizResponse_instanceId_submittedAt_idx"'
-  );
-\echo 'Drop the listed invalid index concurrently, then rerun this file.'
-\quit 3
-\endif
-
-DROP INDEX CONCURRENTLY IF EXISTS "public"."ChatMessage_threadId_idx";
+-- Executed statement-by-statement, outside a transaction, by
+-- prepareAnalyticsIndexes.mjs. Do not run this file directly: the wrapper
+-- detects invalid concurrent indexes and validates every result.
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "QuestionResponse_courseId_createdAt_idx"
 ON "public"."QuestionResponse"("courseId", "createdAt");
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "ChatMessage_threadId_createdAt_idx"
 ON "public"."ChatMessage"("threadId", "createdAt");
+
+DROP INDEX CONCURRENTLY IF EXISTS "public"."ChatMessage_threadId_idx";
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "ParticipantAnalytics_courseId_type_timestamp_idx"
 ON "public"."ParticipantAnalytics"("courseId", "type", "timestamp");
@@ -57,5 +22,5 @@ ON "public"."QuestionResponseDetail" USING BRIN ("createdAt");
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiveQuizResponse_createdAt_brin_idx"
 ON "public"."LiveQuizResponse" USING BRIN ("createdAt");
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiveQuizResponse_instanceId_submittedAt_idx"
-ON "public"."LiveQuizResponse"("instanceId", "submittedAt");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiveQuizResponse_instanceId_participantId_submittedAt_idx"
+ON "public"."LiveQuizResponse"("instanceId", "participantId", "submittedAt");

--- a/packages/prisma/scripts/create-analytics-indexes-concurrently.sql
+++ b/packages/prisma/scripts/create-analytics-indexes-concurrently.sql
@@ -1,0 +1,61 @@
+\set ON_ERROR_STOP on
+
+-- Run this file with psql before Prisma deploys the analytics index migrations
+-- to a shared environment. Do not wrap it in BEGIN / COMMIT.
+--
+-- IF NOT EXISTS also sees invalid indexes and would skip them, so abort until
+-- the operator drops the exact invalid index concurrently.
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_index
+  WHERE NOT indisvalid
+    AND indexrelid::regclass::text IN (
+      '"QuestionResponse_courseId_createdAt_idx"',
+      '"ChatMessage_threadId_createdAt_idx"',
+      '"ParticipantAnalytics_courseId_type_timestamp_idx"',
+      '"AggregatedAnalytics_courseId_type_timestamp_idx"',
+      '"QuestionResponseDetail_createdAt_brin_idx"',
+      '"LiveQuizResponse_createdAt_brin_idx"',
+      '"LiveQuizResponse_instanceId_submittedAt_idx"'
+    )
+) AS analytics_invalid_indexes \gset
+
+\if :analytics_invalid_indexes
+SELECT indexrelid::regclass AS invalid_index
+FROM pg_index
+WHERE NOT indisvalid
+  AND indexrelid::regclass::text IN (
+    '"QuestionResponse_courseId_createdAt_idx"',
+    '"ChatMessage_threadId_createdAt_idx"',
+    '"ParticipantAnalytics_courseId_type_timestamp_idx"',
+    '"AggregatedAnalytics_courseId_type_timestamp_idx"',
+    '"QuestionResponseDetail_createdAt_brin_idx"',
+    '"LiveQuizResponse_createdAt_brin_idx"',
+    '"LiveQuizResponse_instanceId_submittedAt_idx"'
+  );
+\echo 'Drop the listed invalid index concurrently, then rerun this file.'
+\quit 3
+\endif
+
+DROP INDEX CONCURRENTLY IF EXISTS "public"."ChatMessage_threadId_idx";
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "QuestionResponse_courseId_createdAt_idx"
+ON "public"."QuestionResponse"("courseId", "createdAt");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ChatMessage_threadId_createdAt_idx"
+ON "public"."ChatMessage"("threadId", "createdAt");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ParticipantAnalytics_courseId_type_timestamp_idx"
+ON "public"."ParticipantAnalytics"("courseId", "type", "timestamp");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "AggregatedAnalytics_courseId_type_timestamp_idx"
+ON "public"."AggregatedAnalytics"("courseId", "type", "timestamp");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "QuestionResponseDetail_createdAt_brin_idx"
+ON "public"."QuestionResponseDetail" USING BRIN ("createdAt");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiveQuizResponse_createdAt_brin_idx"
+ON "public"."LiveQuizResponse" USING BRIN ("createdAt");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiveQuizResponse_instanceId_submittedAt_idx"
+ON "public"."LiveQuizResponse"("instanceId", "submittedAt");

--- a/packages/prisma/scripts/prepareAnalyticsIndexes.mjs
+++ b/packages/prisma/scripts/prepareAnalyticsIndexes.mjs
@@ -1,0 +1,238 @@
+import { spawnSync } from 'node:child_process'
+import { readFile, readdir } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { Client } from 'pg'
+
+export const LEGACY_ANALYTICS_MIGRATION = '20260420_analytics_covering_indexes'
+
+export const ANALYTICS_INDEX_NAMES = [
+  'QuestionResponse_courseId_createdAt_idx',
+  'ChatMessage_threadId_createdAt_idx',
+  'ParticipantAnalytics_courseId_type_timestamp_idx',
+  'AggregatedAnalytics_courseId_type_timestamp_idx',
+  'QuestionResponseDetail_createdAt_brin_idx',
+  'LiveQuizResponse_createdAt_brin_idx',
+  'LiveQuizResponse_instanceId_participantId_submittedAt_idx',
+]
+
+const REQUIRED_TABLES = [
+  'QuestionResponse',
+  'ChatMessage',
+  'ParticipantAnalytics',
+  'AggregatedAnalytics',
+  'QuestionResponseDetail',
+  'LiveQuizResponse',
+]
+
+export function parseSqlStatements(sql) {
+  return sql
+    .replace(/^--.*$/gm, '')
+    .split(';')
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+}
+
+async function loadStatements() {
+  const sql = await readFile(
+    new URL('./create-analytics-indexes-concurrently.sql', import.meta.url),
+    'utf8'
+  )
+  return parseSqlStatements(sql)
+}
+
+async function loadPriorMigrationNames() {
+  const migrations = await readdir(
+    new URL('../src/prisma/schema/migrations/', import.meta.url),
+    { withFileTypes: true }
+  )
+  return migrations
+    .filter(
+      (entry) => entry.isDirectory() && entry.name < LEGACY_ANALYTICS_MIGRATION
+    )
+    .map((entry) => entry.name)
+}
+
+async function tablesAreReady(client) {
+  const checks = REQUIRED_TABLES.map(
+    (_, index) => `to_regclass($${index + 1}) IS NOT NULL`
+  ).join(' AND ')
+  const names = REQUIRED_TABLES.map((name) => `public."${name}"`)
+  const result = await client.query(`SELECT ${checks} AS ready`, names)
+  return result.rows[0]?.ready === true
+}
+
+async function legacyMigrationState(client) {
+  const migrationTable = await client.query(
+    `SELECT to_regclass('public."_prisma_migrations"') IS NOT NULL AS present`
+  )
+  if (migrationTable.rows[0]?.present !== true) return 'unmanaged'
+
+  const result = await client.query(
+    `SELECT finished_at, rolled_back_at
+     FROM "_prisma_migrations"
+     WHERE migration_name = $1
+     ORDER BY started_at DESC
+     LIMIT 1`,
+    [LEGACY_ANALYTICS_MIGRATION]
+  )
+  if (result.rows.length === 0) return 'pending'
+
+  const migration = result.rows[0]
+  if (migration.finished_at && !migration.rolled_back_at) return 'applied'
+  throw new Error(
+    `${LEGACY_ANALYTICS_MIGRATION} has an unfinished or rolled-back record; resolve that migration state before deploying`
+  )
+}
+
+async function assertPriorMigrationsApplied(client, priorMigrationNames) {
+  const result = await client.query(
+    `SELECT migration_name
+     FROM "_prisma_migrations"
+     WHERE migration_name = ANY($1::text[])
+       AND finished_at IS NOT NULL
+       AND rolled_back_at IS NULL`,
+    [priorMigrationNames]
+  )
+  const applied = new Set(
+    result.rows.map(({ migration_name }) => migration_name)
+  )
+  const missing = priorMigrationNames.filter((name) => !applied.has(name))
+  if (missing.length > 0) {
+    throw new Error(
+      `Cannot baseline ${LEGACY_ANALYTICS_MIGRATION}: ${missing.length} earlier migrations are not recorded as applied`
+    )
+  }
+}
+
+async function assertNoInvalidIndexes(client) {
+  const result = await client.query(
+    `SELECT c.relname AS name
+     FROM pg_index i
+     JOIN pg_class c ON c.oid = i.indexrelid
+     WHERE NOT i.indisvalid
+       AND c.relname = ANY($1::text[])
+     ORDER BY c.relname`,
+    [ANALYTICS_INDEX_NAMES]
+  )
+  if (result.rows.length === 0) return
+
+  const names = result.rows.map(({ name }) => name).join(', ')
+  throw new Error(
+    `Invalid analytics indexes found: ${names}. Drop only those exact indexes concurrently, then retry.`
+  )
+}
+
+async function assertValidIndexes(client) {
+  const result = await client.query(
+    `SELECT c.relname AS name, i.indisvalid, i.indisready
+     FROM pg_index i
+     JOIN pg_class c ON c.oid = i.indexrelid
+     WHERE c.relname = ANY($1::text[])`,
+    [ANALYTICS_INDEX_NAMES]
+  )
+  const valid = new Set(
+    result.rows
+      .filter(({ indisvalid, indisready }) => indisvalid && indisready)
+      .map(({ name }) => name)
+  )
+  const missing = ANALYTICS_INDEX_NAMES.filter((name) => !valid.has(name))
+  if (missing.length > 0) {
+    throw new Error(
+      `Analytics index validation failed for: ${missing.join(', ')}`
+    )
+  }
+}
+
+export async function prepareAnalyticsIndexes(
+  client,
+  statements,
+  priorMigrationNames = []
+) {
+  if (!(await tablesAreReady(client))) {
+    return { prepared: false, resolveLegacyMigration: false }
+  }
+
+  const migrationState = await legacyMigrationState(client)
+  if (migrationState === 'unmanaged') {
+    throw new Error(
+      `Cannot baseline ${LEGACY_ANALYTICS_MIGRATION}: initialized database has no Prisma migration table`
+    )
+  }
+  if (migrationState === 'pending') {
+    await assertPriorMigrationsApplied(client, priorMigrationNames)
+  }
+  await assertNoInvalidIndexes(client)
+  for (const statement of statements) {
+    await client.query(statement)
+  }
+  await assertValidIndexes(client)
+
+  return {
+    prepared: true,
+    resolveLegacyMigration: migrationState === 'pending',
+  }
+}
+
+function resolveLegacyMigration() {
+  const result = spawnSync(
+    'pnpm',
+    [
+      'exec',
+      'prisma',
+      'migrate',
+      'resolve',
+      '--applied',
+      LEGACY_ANALYTICS_MIGRATION,
+    ],
+    {
+      env: process.env,
+      stdio: 'inherit',
+    }
+  )
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `prisma migrate resolve exited with status ${result.status ?? 'unknown'}`
+    )
+  }
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required for Prisma migration deployment')
+  }
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL })
+  await client.connect()
+  let result
+  try {
+    result = await prepareAnalyticsIndexes(
+      client,
+      await loadStatements(),
+      await loadPriorMigrationNames()
+    )
+  } finally {
+    await client.end()
+  }
+
+  if (!result.prepared) {
+    console.log(
+      'Analytics tables are absent; the normal migration chain will create indexes on the fresh database.'
+    )
+    return
+  }
+
+  console.log('Analytics indexes are present, valid, and ready.')
+  if (result.resolveLegacyMigration) {
+    resolveLegacyMigration()
+  }
+}
+
+const entryPoint = process.argv[1]
+if (entryPoint && fileURLToPath(import.meta.url) === entryPoint) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/packages/prisma/scripts/prepareAnalyticsIndexes.mjs
+++ b/packages/prisma/scripts/prepareAnalyticsIndexes.mjs
@@ -11,43 +11,43 @@ export const ANALYTICS_INDEXES = [
     name: 'QuestionResponse_courseId_createdAt_idx',
     table: 'QuestionResponse',
     method: 'btree',
-    columns: ['"courseId"', '"createdAt"'],
+    columns: ['courseId', 'createdAt'],
   },
   {
     name: 'ChatMessage_threadId_createdAt_idx',
     table: 'ChatMessage',
     method: 'btree',
-    columns: ['"threadId"', '"createdAt"'],
+    columns: ['threadId', 'createdAt'],
   },
   {
     name: 'ParticipantAnalytics_courseId_type_timestamp_idx',
     table: 'ParticipantAnalytics',
     method: 'btree',
-    columns: ['"courseId"', 'type', '"timestamp"'],
+    columns: ['courseId', 'type', 'timestamp'],
   },
   {
     name: 'AggregatedAnalytics_courseId_type_timestamp_idx',
     table: 'AggregatedAnalytics',
     method: 'btree',
-    columns: ['"courseId"', 'type', '"timestamp"'],
+    columns: ['courseId', 'type', 'timestamp'],
   },
   {
     name: 'QuestionResponseDetail_createdAt_brin_idx',
     table: 'QuestionResponseDetail',
     method: 'brin',
-    columns: ['"createdAt"'],
+    columns: ['createdAt'],
   },
   {
     name: 'LiveQuizResponse_createdAt_brin_idx',
     table: 'LiveQuizResponse',
     method: 'brin',
-    columns: ['"createdAt"'],
+    columns: ['createdAt'],
   },
   {
     name: 'LiveQuizResponse_instanceId_participantId_submittedAt_idx',
     table: 'LiveQuizResponse',
     method: 'btree',
-    columns: ['"instanceId"', '"participantId"', '"submittedAt"'],
+    columns: ['instanceId', 'participantId', 'submittedAt'],
   },
 ]
 
@@ -119,7 +119,6 @@ async function inspectDatabase(client) {
 
   return {
     migrationCount,
-    migrationTablePresent,
     missingTables,
     presentTableCount,
   }
@@ -193,7 +192,6 @@ async function validateIndexes(client, { requireAll }) {
   const result = await client.query(
     `SELECT
        c.relname AS name,
-       n.nspname AS schema_name,
        t.relname AS table_name,
        am.amname AS access_method,
        i.indisvalid,
@@ -217,12 +215,17 @@ async function validateIndexes(client, { requireAll }) {
     const actual = actualByName.get(expected.name)
     if (!actual) return false
     return (
-      actual.schema_name !== 'public' ||
       actual.table_name !== expected.table ||
       actual.access_method !== expected.method ||
       !actual.indisvalid ||
       !actual.indisready ||
-      JSON.stringify(actual.key_columns) !== JSON.stringify(expected.columns)
+      JSON.stringify(
+        actual.key_columns.map((column) =>
+          column.startsWith('"') && column.endsWith('"')
+            ? column.slice(1, -1)
+            : column
+        )
+      ) !== JSON.stringify(expected.columns)
     )
   }).map(({ name }) => name)
   if (mismatched.length > 0) {

--- a/packages/prisma/scripts/prepareAnalyticsIndexes.mjs
+++ b/packages/prisma/scripts/prepareAnalyticsIndexes.mjs
@@ -6,15 +6,54 @@ import { Client } from 'pg'
 
 export const LEGACY_ANALYTICS_MIGRATION = '20260420_analytics_covering_indexes'
 
-export const ANALYTICS_INDEX_NAMES = [
-  'QuestionResponse_courseId_createdAt_idx',
-  'ChatMessage_threadId_createdAt_idx',
-  'ParticipantAnalytics_courseId_type_timestamp_idx',
-  'AggregatedAnalytics_courseId_type_timestamp_idx',
-  'QuestionResponseDetail_createdAt_brin_idx',
-  'LiveQuizResponse_createdAt_brin_idx',
-  'LiveQuizResponse_instanceId_participantId_submittedAt_idx',
+export const ANALYTICS_INDEXES = [
+  {
+    name: 'QuestionResponse_courseId_createdAt_idx',
+    table: 'QuestionResponse',
+    method: 'btree',
+    columns: ['"courseId"', '"createdAt"'],
+  },
+  {
+    name: 'ChatMessage_threadId_createdAt_idx',
+    table: 'ChatMessage',
+    method: 'btree',
+    columns: ['"threadId"', '"createdAt"'],
+  },
+  {
+    name: 'ParticipantAnalytics_courseId_type_timestamp_idx',
+    table: 'ParticipantAnalytics',
+    method: 'btree',
+    columns: ['"courseId"', 'type', '"timestamp"'],
+  },
+  {
+    name: 'AggregatedAnalytics_courseId_type_timestamp_idx',
+    table: 'AggregatedAnalytics',
+    method: 'btree',
+    columns: ['"courseId"', 'type', '"timestamp"'],
+  },
+  {
+    name: 'QuestionResponseDetail_createdAt_brin_idx',
+    table: 'QuestionResponseDetail',
+    method: 'brin',
+    columns: ['"createdAt"'],
+  },
+  {
+    name: 'LiveQuizResponse_createdAt_brin_idx',
+    table: 'LiveQuizResponse',
+    method: 'brin',
+    columns: ['"createdAt"'],
+  },
+  {
+    name: 'LiveQuizResponse_instanceId_participantId_submittedAt_idx',
+    table: 'LiveQuizResponse',
+    method: 'btree',
+    columns: ['"instanceId"', '"participantId"', '"submittedAt"'],
+  },
 ]
+
+export const ANALYTICS_INDEX_NAMES = ANALYTICS_INDEXES.map(({ name }) => name)
+
+const MIGRATION_LOCK_NAME = 'klicker-uzh-prisma-deploy'
 
 const REQUIRED_TABLES = [
   'QuestionResponse',
@@ -53,13 +92,37 @@ async function loadPriorMigrationNames() {
     .map((entry) => entry.name)
 }
 
-async function tablesAreReady(client) {
-  const checks = REQUIRED_TABLES.map(
-    (_, index) => `to_regclass($${index + 1}) IS NOT NULL`
-  ).join(' AND ')
-  const names = REQUIRED_TABLES.map((name) => `public."${name}"`)
-  const result = await client.query(`SELECT ${checks} AS ready`, names)
-  return result.rows[0]?.ready === true
+async function inspectDatabase(client) {
+  const tables = await client.query(
+    `SELECT name, to_regclass(format('public.%I', name)) IS NOT NULL AS present
+     FROM unnest($1::text[]) AS name`,
+    [REQUIRED_TABLES]
+  )
+  const missingTables = tables.rows
+    .filter(({ present }) => !present)
+    .map(({ name }) => name)
+  const presentTableCount = REQUIRED_TABLES.length - missingTables.length
+
+  const migrationTable = await client.query(
+    `SELECT to_regclass('public."_prisma_migrations"') IS NOT NULL AS present`
+  )
+  const migrationTablePresent = migrationTable.rows[0]?.present === true
+  const migrationCount = migrationTablePresent
+    ? Number(
+        (
+          await client.query(
+            `SELECT COUNT(*)::int AS count FROM "_prisma_migrations"`
+          )
+        ).rows[0]?.count ?? 0
+      )
+    : 0
+
+  return {
+    migrationCount,
+    migrationTablePresent,
+    missingTables,
+    presentTableCount,
+  }
 }
 
 async function legacyMigrationState(client) {
@@ -110,7 +173,10 @@ async function assertNoInvalidIndexes(client) {
     `SELECT c.relname AS name
      FROM pg_index i
      JOIN pg_class c ON c.oid = i.indexrelid
+     JOIN pg_class t ON t.oid = i.indrelid
+     JOIN pg_namespace n ON n.oid = t.relnamespace
      WHERE NOT i.indisvalid
+       AND n.nspname = 'public'
        AND c.relname = ANY($1::text[])
      ORDER BY c.relname`,
     [ANALYTICS_INDEX_NAMES]
@@ -123,20 +189,52 @@ async function assertNoInvalidIndexes(client) {
   )
 }
 
-async function assertValidIndexes(client) {
+async function validateIndexes(client, { requireAll }) {
   const result = await client.query(
-    `SELECT c.relname AS name, i.indisvalid, i.indisready
+    `SELECT
+       c.relname AS name,
+       n.nspname AS schema_name,
+       t.relname AS table_name,
+       am.amname AS access_method,
+       i.indisvalid,
+       i.indisready,
+       ARRAY(
+         SELECT pg_get_indexdef(i.indexrelid, key_position, true)
+         FROM generate_series(1, i.indnkeyatts) AS key_position
+       ) AS key_columns
      FROM pg_index i
      JOIN pg_class c ON c.oid = i.indexrelid
-     WHERE c.relname = ANY($1::text[])`,
+     JOIN pg_class t ON t.oid = i.indrelid
+     JOIN pg_namespace n ON n.oid = t.relnamespace
+     JOIN pg_am am ON am.oid = c.relam
+     WHERE n.nspname = 'public'
+       AND c.relname = ANY($1::text[])`,
     [ANALYTICS_INDEX_NAMES]
   )
-  const valid = new Set(
-    result.rows
-      .filter(({ indisvalid, indisready }) => indisvalid && indisready)
-      .map(({ name }) => name)
+
+  const actualByName = new Map(result.rows.map((index) => [index.name, index]))
+  const mismatched = ANALYTICS_INDEXES.filter((expected) => {
+    const actual = actualByName.get(expected.name)
+    if (!actual) return false
+    return (
+      actual.schema_name !== 'public' ||
+      actual.table_name !== expected.table ||
+      actual.access_method !== expected.method ||
+      !actual.indisvalid ||
+      !actual.indisready ||
+      JSON.stringify(actual.key_columns) !== JSON.stringify(expected.columns)
+    )
+  }).map(({ name }) => name)
+  if (mismatched.length > 0) {
+    throw new Error(
+      `Analytics index definition validation failed for: ${mismatched.join(', ')}`
+    )
+  }
+
+  if (!requireAll) return
+  const missing = ANALYTICS_INDEX_NAMES.filter(
+    (name) => !actualByName.has(name)
   )
-  const missing = ANALYTICS_INDEX_NAMES.filter((name) => !valid.has(name))
   if (missing.length > 0) {
     throw new Error(
       `Analytics index validation failed for: ${missing.join(', ')}`
@@ -149,8 +247,14 @@ export async function prepareAnalyticsIndexes(
   statements,
   priorMigrationNames = []
 ) {
-  if (!(await tablesAreReady(client))) {
+  const database = await inspectDatabase(client)
+  if (database.presentTableCount === 0 && database.migrationCount === 0) {
     return { prepared: false, resolveLegacyMigration: false }
+  }
+  if (database.missingTables.length > 0) {
+    throw new Error(
+      `Initialized database is missing required analytics tables: ${database.missingTables.join(', ')}`
+    )
   }
 
   const migrationState = await legacyMigrationState(client)
@@ -163,10 +267,11 @@ export async function prepareAnalyticsIndexes(
     await assertPriorMigrationsApplied(client, priorMigrationNames)
   }
   await assertNoInvalidIndexes(client)
+  await validateIndexes(client, { requireAll: false })
   for (const statement of statements) {
     await client.query(statement)
   }
-  await assertValidIndexes(client)
+  await validateIndexes(client, { requireAll: true })
 
   return {
     prepared: true,
@@ -174,26 +279,33 @@ export async function prepareAnalyticsIndexes(
   }
 }
 
-function resolveLegacyMigration() {
-  const result = spawnSync(
-    'pnpm',
-    [
-      'exec',
-      'prisma',
-      'migrate',
-      'resolve',
-      '--applied',
-      LEGACY_ANALYTICS_MIGRATION,
-    ],
-    {
-      env: process.env,
-      stdio: 'inherit',
-    }
+export async function acquireMigrationLock(client) {
+  const result = await client.query(
+    `SELECT pg_try_advisory_lock(hashtext($1)) AS acquired`,
+    [MIGRATION_LOCK_NAME]
   )
+  if (result.rows[0]?.acquired !== true) {
+    throw new Error(
+      'Another repository Prisma deployment holds the analytics prebuild lock'
+    )
+  }
+}
+
+async function releaseMigrationLock(client) {
+  await client.query(`SELECT pg_advisory_unlock(hashtext($1))`, [
+    MIGRATION_LOCK_NAME,
+  ])
+}
+
+function runPrisma(args) {
+  const result = spawnSync('pnpm', ['exec', 'prisma', ...args], {
+    env: process.env,
+    stdio: 'inherit',
+  })
   if (result.error) throw result.error
   if (result.status !== 0) {
     throw new Error(
-      `prisma migrate resolve exited with status ${result.status ?? 'unknown'}`
+      `prisma ${args.join(' ')} exited with status ${result.status ?? 'unknown'}`
     )
   }
 }
@@ -205,27 +317,31 @@ async function main() {
 
   const client = new Client({ connectionString: process.env.DATABASE_URL })
   await client.connect()
-  let result
+  let locked = false
   try {
-    result = await prepareAnalyticsIndexes(
+    await acquireMigrationLock(client)
+    locked = true
+    const result = await prepareAnalyticsIndexes(
       client,
       await loadStatements(),
       await loadPriorMigrationNames()
     )
+
+    if (!result.prepared) {
+      console.log(
+        'Analytics tables are absent; the normal migration chain will create indexes on the fresh database.'
+      )
+    } else {
+      console.log('Analytics indexes are present, valid, and ready.')
+    }
+
+    if (result.resolveLegacyMigration) {
+      runPrisma(['migrate', 'resolve', '--applied', LEGACY_ANALYTICS_MIGRATION])
+    }
+    runPrisma(['migrate', 'deploy'])
   } finally {
+    if (locked) await releaseMigrationLock(client)
     await client.end()
-  }
-
-  if (!result.prepared) {
-    console.log(
-      'Analytics tables are absent; the normal migration chain will create indexes on the fresh database.'
-    )
-    return
-  }
-
-  console.log('Analytics indexes are present, valid, and ready.')
-  if (result.resolveLegacyMigration) {
-    resolveLegacyMigration()
   }
 }
 

--- a/packages/prisma/scripts/prepareAnalyticsIndexes.test.mjs
+++ b/packages/prisma/scripts/prepareAnalyticsIndexes.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  ANALYTICS_INDEX_NAMES,
+  parseSqlStatements,
+  prepareAnalyticsIndexes,
+} from './prepareAnalyticsIndexes.mjs'
+
+class FakeClient {
+  constructor({
+    tablesReady = true,
+    migrationState = 'pending',
+    invalidIndexes = [],
+    appliedMigrations = ['20260419_before_analytics'],
+  } = {}) {
+    this.tablesReady = tablesReady
+    this.migrationState = migrationState
+    this.invalidIndexes = invalidIndexes
+    this.appliedMigrations = appliedMigrations
+    this.executed = []
+  }
+
+  async query(sql) {
+    if (sql.includes('AS ready')) {
+      return { rows: [{ ready: this.tablesReady }] }
+    }
+    if (sql.includes('AS present')) {
+      return { rows: [{ present: this.migrationState !== 'missing-table' }] }
+    }
+    if (sql.includes('finished_at, rolled_back_at')) {
+      if (this.migrationState === 'pending') return { rows: [] }
+      if (this.migrationState === 'applied') {
+        return {
+          rows: [{ finished_at: new Date(), rolled_back_at: null }],
+        }
+      }
+      return {
+        rows: [{ finished_at: null, rolled_back_at: null }],
+      }
+    }
+    if (sql.includes('migration_name = ANY')) {
+      return {
+        rows: this.appliedMigrations.map((migration_name) => ({
+          migration_name,
+        })),
+      }
+    }
+    if (sql.includes('NOT i.indisvalid')) {
+      return { rows: this.invalidIndexes.map((name) => ({ name })) }
+    }
+    if (sql.includes('i.indisvalid, i.indisready')) {
+      return {
+        rows: ANALYTICS_INDEX_NAMES.map((name) => ({
+          name,
+          indisvalid: true,
+          indisready: true,
+        })),
+      }
+    }
+
+    this.executed.push(sql)
+    return { rows: [] }
+  }
+}
+
+async function statements() {
+  const sql = await readFile(
+    new URL('./create-analytics-indexes-concurrently.sql', import.meta.url),
+    'utf8'
+  )
+  return parseSqlStatements(sql)
+}
+
+test('parses every concurrent index statement and drops the old index after its replacement', async () => {
+  const parsed = await statements()
+
+  assert.equal(parsed.length, 8)
+  const replacement = parsed.findIndex((sql) =>
+    sql.includes('ChatMessage_threadId_createdAt_idx')
+  )
+  const oldIndexDrop = parsed.findIndex((sql) =>
+    sql.includes('DROP INDEX CONCURRENTLY')
+  )
+  assert.ok(replacement >= 0)
+  assert.ok(oldIndexDrop > replacement)
+})
+
+test('skips the prebuild on a fresh database', async () => {
+  const client = new FakeClient({ tablesReady: false })
+
+  assert.deepEqual(await prepareAnalyticsIndexes(client, await statements()), {
+    prepared: false,
+    resolveLegacyMigration: false,
+  })
+  assert.deepEqual(client.executed, [])
+})
+
+test('prebuilds initialized databases and baselines a pending legacy migration', async () => {
+  const client = new FakeClient()
+  const parsed = await statements()
+
+  assert.deepEqual(
+    await prepareAnalyticsIndexes(client, parsed, [
+      '20260419_before_analytics',
+    ]),
+    {
+      prepared: true,
+      resolveLegacyMigration: true,
+    }
+  )
+  assert.deepEqual(client.executed, parsed)
+})
+
+test('does not baseline an already applied legacy migration', async () => {
+  const client = new FakeClient({ migrationState: 'applied' })
+
+  assert.deepEqual(await prepareAnalyticsIndexes(client, await statements()), {
+    prepared: true,
+    resolveLegacyMigration: false,
+  })
+})
+
+test('fails before building when a named invalid index exists', async () => {
+  const client = new FakeClient({
+    invalidIndexes: ['QuestionResponse_courseId_createdAt_idx'],
+  })
+
+  await assert.rejects(
+    prepareAnalyticsIndexes(client, await statements()),
+    /Invalid analytics indexes found/
+  )
+  assert.deepEqual(client.executed, [])
+})
+
+test('fails on an unfinished legacy migration record', async () => {
+  const client = new FakeClient({ migrationState: 'failed' })
+
+  await assert.rejects(
+    prepareAnalyticsIndexes(client, await statements()),
+    /unfinished or rolled-back/
+  )
+})
+
+test('does not baseline an initialized database without complete migration history', async () => {
+  const client = new FakeClient({ appliedMigrations: [] })
+
+  await assert.rejects(
+    prepareAnalyticsIndexes(client, await statements(), [
+      '20260419_before_analytics',
+    ]),
+    /earlier migrations are not recorded as applied/
+  )
+  assert.deepEqual(client.executed, [])
+})
+
+test('does not baseline an initialized database without a migration table', async () => {
+  const client = new FakeClient({ migrationState: 'missing-table' })
+
+  await assert.rejects(
+    prepareAnalyticsIndexes(client, await statements()),
+    /has no Prisma migration table/
+  )
+  assert.deepEqual(client.executed, [])
+})

--- a/packages/prisma/scripts/prepareAnalyticsIndexes.test.mjs
+++ b/packages/prisma/scripts/prepareAnalyticsIndexes.test.mjs
@@ -77,13 +77,12 @@ class FakeClient {
       return {
         rows: ANALYTICS_INDEXES.map((index) => ({
           name: index.name,
-          schema_name: 'public',
           table_name:
             index.name === this.wrongIndexName ? 'WrongTable' : index.table,
           access_method: index.method,
           indisvalid: true,
           indisready: true,
-          key_columns: index.columns,
+          key_columns: index.columns.map((column) => `"${column}"`),
         })),
       }
     }
@@ -117,13 +116,30 @@ test('parses every concurrent index statement and drops the old index after its 
   assert.ok(replacement >= 0)
   assert.ok(oldIndexDrop > replacement)
 
-  const createNames = parsed
-    .map((sql) =>
-      sql.match(/CREATE INDEX CONCURRENTLY IF NOT EXISTS "([^"]+)"/)
-    )
-    .filter(Boolean)
-    .map((match) => match[1])
-  assert.deepEqual(createNames, ANALYTICS_INDEX_NAMES)
+  const createIndexes = parsed
+    .filter((sql) => sql.startsWith('CREATE INDEX'))
+    .map((sql) => {
+      const normalized = sql.replace(/\s+/g, ' ').trim()
+      const match = normalized.match(
+        /^CREATE INDEX CONCURRENTLY IF NOT EXISTS "([^"]+)" ON "public"\."([^"]+)"(?: USING (BRIN|BTREE))? ?\(([^)]+)\)$/i
+      )
+      assert.ok(match, `unexpected analytics index statement: ${normalized}`)
+      return {
+        name: match[1],
+        table: match[2],
+        method: (match[3] ?? 'btree').toLowerCase(),
+        columns: match[4].split(',').map((column) => {
+          const identifier = column.trim().match(/^"([^"]+)"$/)
+          assert.ok(identifier, `unexpected index column: ${column}`)
+          return identifier[1]
+        }),
+      }
+    })
+  assert.deepEqual(createIndexes, ANALYTICS_INDEXES)
+  assert.deepEqual(
+    createIndexes.map(({ name }) => name),
+    ANALYTICS_INDEX_NAMES
+  )
 })
 
 test('skips the prebuild on a fresh database', async () => {

--- a/packages/prisma/scripts/prepareAnalyticsIndexes.test.mjs
+++ b/packages/prisma/scripts/prepareAnalyticsIndexes.test.mjs
@@ -3,31 +3,54 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 import {
+  ANALYTICS_INDEXES,
   ANALYTICS_INDEX_NAMES,
+  acquireMigrationLock,
   parseSqlStatements,
   prepareAnalyticsIndexes,
 } from './prepareAnalyticsIndexes.mjs'
 
 class FakeClient {
   constructor({
-    tablesReady = true,
+    missingTables = [],
     migrationState = 'pending',
     invalidIndexes = [],
     appliedMigrations = ['20260419_before_analytics'],
+    migrationCount = 1,
+    wrongIndexName,
+    lockAcquired = true,
   } = {}) {
-    this.tablesReady = tablesReady
+    this.missingTables = missingTables
     this.migrationState = migrationState
     this.invalidIndexes = invalidIndexes
     this.appliedMigrations = appliedMigrations
+    this.migrationCount = migrationCount
+    this.wrongIndexName = wrongIndexName
+    this.lockAcquired = lockAcquired
     this.executed = []
   }
 
   async query(sql) {
-    if (sql.includes('AS ready')) {
-      return { rows: [{ ready: this.tablesReady }] }
+    if (sql.includes('FROM unnest')) {
+      return {
+        rows: [
+          'QuestionResponse',
+          'ChatMessage',
+          'ParticipantAnalytics',
+          'AggregatedAnalytics',
+          'QuestionResponseDetail',
+          'LiveQuizResponse',
+        ].map((name) => ({
+          name,
+          present: !this.missingTables.includes(name),
+        })),
+      }
     }
     if (sql.includes('AS present')) {
       return { rows: [{ present: this.migrationState !== 'missing-table' }] }
+    }
+    if (sql.includes('COUNT(*)::int')) {
+      return { rows: [{ count: this.migrationCount }] }
     }
     if (sql.includes('finished_at, rolled_back_at')) {
       if (this.migrationState === 'pending') return { rows: [] }
@@ -50,14 +73,22 @@ class FakeClient {
     if (sql.includes('NOT i.indisvalid')) {
       return { rows: this.invalidIndexes.map((name) => ({ name })) }
     }
-    if (sql.includes('i.indisvalid, i.indisready')) {
+    if (sql.includes('pg_get_indexdef')) {
       return {
-        rows: ANALYTICS_INDEX_NAMES.map((name) => ({
-          name,
+        rows: ANALYTICS_INDEXES.map((index) => ({
+          name: index.name,
+          schema_name: 'public',
+          table_name:
+            index.name === this.wrongIndexName ? 'WrongTable' : index.table,
+          access_method: index.method,
           indisvalid: true,
           indisready: true,
+          key_columns: index.columns,
         })),
       }
+    }
+    if (sql.includes('pg_try_advisory_lock')) {
+      return { rows: [{ acquired: this.lockAcquired }] }
     }
 
     this.executed.push(sql)
@@ -85,15 +116,46 @@ test('parses every concurrent index statement and drops the old index after its 
   )
   assert.ok(replacement >= 0)
   assert.ok(oldIndexDrop > replacement)
+
+  const createNames = parsed
+    .map((sql) =>
+      sql.match(/CREATE INDEX CONCURRENTLY IF NOT EXISTS "([^"]+)"/)
+    )
+    .filter(Boolean)
+    .map((match) => match[1])
+  assert.deepEqual(createNames, ANALYTICS_INDEX_NAMES)
 })
 
 test('skips the prebuild on a fresh database', async () => {
-  const client = new FakeClient({ tablesReady: false })
+  const client = new FakeClient({
+    missingTables: [
+      'QuestionResponse',
+      'ChatMessage',
+      'ParticipantAnalytics',
+      'AggregatedAnalytics',
+      'QuestionResponseDetail',
+      'LiveQuizResponse',
+    ],
+    migrationState: 'missing-table',
+    migrationCount: 0,
+  })
 
   assert.deepEqual(await prepareAnalyticsIndexes(client, await statements()), {
     prepared: false,
     resolveLegacyMigration: false,
   })
+  assert.deepEqual(client.executed, [])
+})
+
+test('fails closed on an initialized database with a partial analytics schema', async () => {
+  const client = new FakeClient({
+    missingTables: ['ParticipantAnalytics'],
+  })
+
+  await assert.rejects(
+    prepareAnalyticsIndexes(client, await statements()),
+    /missing required analytics tables: ParticipantAnalytics/
+  )
   assert.deepEqual(client.executed, [])
 })
 
@@ -134,6 +196,18 @@ test('fails before building when a named invalid index exists', async () => {
   assert.deepEqual(client.executed, [])
 })
 
+test('fails before building when a named index has the wrong definition', async () => {
+  const client = new FakeClient({
+    wrongIndexName: 'QuestionResponse_courseId_createdAt_idx',
+  })
+
+  await assert.rejects(
+    prepareAnalyticsIndexes(client, await statements()),
+    /index definition validation failed/
+  )
+  assert.deepEqual(client.executed, [])
+})
+
 test('fails on an unfinished legacy migration record', async () => {
   const client = new FakeClient({ migrationState: 'failed' })
 
@@ -163,4 +237,13 @@ test('does not baseline an initialized database without a migration table', asyn
     /has no Prisma migration table/
   )
   assert.deepEqual(client.executed, [])
+})
+
+test('fails when another repository migration command holds the advisory lock', async () => {
+  const client = new FakeClient({ lockAcquired: false })
+
+  await assert.rejects(
+    acquireMigrationLock(client),
+    /Another repository Prisma deployment/
+  )
 })

--- a/packages/prisma/src/prisma/schema/migrations/20260420_analytics_covering_indexes/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260420_analytics_covering_indexes/migration.sql
@@ -1,19 +1,16 @@
 -- Analytics pipeline covering + BRIN indexes (Phase A).
 -- See project/ANALYTICS_IMPROVEMENTS.md §R4 for rationale.
--- Shared environments must first run
--- packages/prisma/scripts/create-analytics-indexes-concurrently.sql. These
--- retry-safe statements then become no-ops inside Prisma's transaction.
 
 -- Replace standalone threadId index with composite (threadId, createdAt); composite covers threadId-only queries.
 DROP INDEX IF EXISTS "public"."ChatMessage_threadId_idx";
 
 -- B-tree composite indexes (Prisma @@index sourced).
-CREATE INDEX IF NOT EXISTS "QuestionResponse_courseId_createdAt_idx" ON "public"."QuestionResponse"("courseId", "createdAt");
-CREATE INDEX IF NOT EXISTS "ChatMessage_threadId_createdAt_idx" ON "public"."ChatMessage"("threadId", "createdAt");
-CREATE INDEX IF NOT EXISTS "ParticipantAnalytics_courseId_type_timestamp_idx" ON "public"."ParticipantAnalytics"("courseId", "type", "timestamp");
-CREATE INDEX IF NOT EXISTS "AggregatedAnalytics_courseId_type_timestamp_idx" ON "public"."AggregatedAnalytics"("courseId", "type", "timestamp");
+CREATE INDEX "QuestionResponse_courseId_createdAt_idx" ON "public"."QuestionResponse"("courseId", "createdAt");
+CREATE INDEX "ChatMessage_threadId_createdAt_idx" ON "public"."ChatMessage"("threadId", "createdAt");
+CREATE INDEX "ParticipantAnalytics_courseId_type_timestamp_idx" ON "public"."ParticipantAnalytics"("courseId", "type", "timestamp");
+CREATE INDEX "AggregatedAnalytics_courseId_type_timestamp_idx" ON "public"."AggregatedAnalytics"("courseId", "type", "timestamp");
 
 -- BRIN indexes for append-mostly event tables — near-free storage, prunes by date range.
 -- Prisma doesn't model BRIN natively, so these are raw-SQL only.
-CREATE INDEX IF NOT EXISTS "QuestionResponseDetail_createdAt_brin_idx" ON "public"."QuestionResponseDetail" USING BRIN ("createdAt");
-CREATE INDEX IF NOT EXISTS "LiveQuizResponse_createdAt_brin_idx" ON "public"."LiveQuizResponse" USING BRIN ("createdAt");
+CREATE INDEX "QuestionResponseDetail_createdAt_brin_idx" ON "public"."QuestionResponseDetail" USING BRIN ("createdAt");
+CREATE INDEX "LiveQuizResponse_createdAt_brin_idx" ON "public"."LiveQuizResponse" USING BRIN ("createdAt");

--- a/packages/prisma/src/prisma/schema/migrations/20260420_analytics_covering_indexes/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260420_analytics_covering_indexes/migration.sql
@@ -1,16 +1,19 @@
 -- Analytics pipeline covering + BRIN indexes (Phase A).
 -- See project/ANALYTICS_IMPROVEMENTS.md §R4 for rationale.
+-- Shared environments must first run
+-- packages/prisma/scripts/create-analytics-indexes-concurrently.sql. These
+-- retry-safe statements then become no-ops inside Prisma's transaction.
 
 -- Replace standalone threadId index with composite (threadId, createdAt); composite covers threadId-only queries.
 DROP INDEX IF EXISTS "public"."ChatMessage_threadId_idx";
 
 -- B-tree composite indexes (Prisma @@index sourced).
-CREATE INDEX "QuestionResponse_courseId_createdAt_idx" ON "public"."QuestionResponse"("courseId", "createdAt");
-CREATE INDEX "ChatMessage_threadId_createdAt_idx" ON "public"."ChatMessage"("threadId", "createdAt");
-CREATE INDEX "ParticipantAnalytics_courseId_type_timestamp_idx" ON "public"."ParticipantAnalytics"("courseId", "type", "timestamp");
-CREATE INDEX "AggregatedAnalytics_courseId_type_timestamp_idx" ON "public"."AggregatedAnalytics"("courseId", "type", "timestamp");
+CREATE INDEX IF NOT EXISTS "QuestionResponse_courseId_createdAt_idx" ON "public"."QuestionResponse"("courseId", "createdAt");
+CREATE INDEX IF NOT EXISTS "ChatMessage_threadId_createdAt_idx" ON "public"."ChatMessage"("threadId", "createdAt");
+CREATE INDEX IF NOT EXISTS "ParticipantAnalytics_courseId_type_timestamp_idx" ON "public"."ParticipantAnalytics"("courseId", "type", "timestamp");
+CREATE INDEX IF NOT EXISTS "AggregatedAnalytics_courseId_type_timestamp_idx" ON "public"."AggregatedAnalytics"("courseId", "type", "timestamp");
 
 -- BRIN indexes for append-mostly event tables — near-free storage, prunes by date range.
 -- Prisma doesn't model BRIN natively, so these are raw-SQL only.
-CREATE INDEX "QuestionResponseDetail_createdAt_brin_idx" ON "public"."QuestionResponseDetail" USING BRIN ("createdAt");
-CREATE INDEX "LiveQuizResponse_createdAt_brin_idx" ON "public"."LiveQuizResponse" USING BRIN ("createdAt");
+CREATE INDEX IF NOT EXISTS "QuestionResponseDetail_createdAt_brin_idx" ON "public"."QuestionResponseDetail" USING BRIN ("createdAt");
+CREATE INDEX IF NOT EXISTS "LiveQuizResponse_createdAt_brin_idx" ON "public"."LiveQuizResponse" USING BRIN ("createdAt");

--- a/packages/prisma/src/prisma/schema/migrations/20260723180000_analytics_live_quiz_submitted_at_index/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260723180000_analytics_live_quiz_submitted_at_index/migration.sql
@@ -1,5 +1,5 @@
--- Script 14 resolves LiveQuiz through ElementInstance and orders responses by
+-- Script 14 ranks each participant's first and last response per instance by
 -- submittedAt. Shared environments prebuild this through the checked-in
 -- concurrent-index script, making this retry-safe statement a no-op.
-CREATE INDEX IF NOT EXISTS "LiveQuizResponse_instanceId_submittedAt_idx"
-ON "public"."LiveQuizResponse"("instanceId", "submittedAt");
+CREATE INDEX IF NOT EXISTS "LiveQuizResponse_instanceId_participantId_submittedAt_idx"
+ON "public"."LiveQuizResponse"("instanceId", "participantId", "submittedAt");

--- a/packages/prisma/src/prisma/schema/migrations/20260723180000_analytics_live_quiz_submitted_at_index/migration.sql
+++ b/packages/prisma/src/prisma/schema/migrations/20260723180000_analytics_live_quiz_submitted_at_index/migration.sql
@@ -1,0 +1,5 @@
+-- Script 14 resolves LiveQuiz through ElementInstance and orders responses by
+-- submittedAt. Shared environments prebuild this through the checked-in
+-- concurrent-index script, making this retry-safe statement a no-op.
+CREATE INDEX IF NOT EXISTS "LiveQuizResponse_instanceId_submittedAt_idx"
+ON "public"."LiveQuizResponse"("instanceId", "submittedAt");

--- a/packages/prisma/src/prisma/schema/response.prisma
+++ b/packages/prisma/src/prisma/schema/response.prisma
@@ -144,8 +144,8 @@ model LiveQuizResponse {
 
   @@unique([instanceId, elementBlockExecution, participantId])
   @@index([instanceId, elementBlockExecution])
-  // Supports script 14's first-submission lookup without sorting every response for an instance.
-  @@index([instanceId, submittedAt])
+  // Supports script 14's first/last attempt windows per participant and instance.
+  @@index([instanceId, participantId, submittedAt])
 }
 
 enum PointCorrectionType {

--- a/packages/prisma/src/prisma/schema/response.prisma
+++ b/packages/prisma/src/prisma/schema/response.prisma
@@ -144,6 +144,8 @@ model LiveQuizResponse {
 
   @@unique([instanceId, elementBlockExecution, participantId])
   @@index([instanceId, elementBlockExecution])
+  // Supports script 14's first-submission lookup without sorting every response for an instance.
+  @@index([instanceId, submittedAt])
 }
 
 enum PointCorrectionType {

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -485,8 +485,25 @@ the repository script that replaces it before continuing.
   reproduced Slice 3A fixes without downloading the multi-gigabyte ML/CUDA
   dependency set; the full 116-test suite remains a local/final gate until
   Slice 5A establishes the CPU-only worker dependency set.
-- Active: Slice 3A, commit the independently reviewed CI adjustment.
-- Next: Prove grading parity in Slice 3B.
+- 2026-07-23: Slice 3A's independently reviewed CI adjustment committed as
+  `80c9ae5cf`.
+- 2026-07-23: Slice 3B reproduces and fixes numerical analytics differences
+  from `packages/grading`: bounded and one-sided ranges, empty or undefined
+  solutions, exact-solution precedence, and `Number.EPSILON` tolerance.
+  Parity work also exposed and fixed the product grader's zero-bound truthiness
+  defect, so a bound of exactly zero is no longer treated as absent.
+- 2026-07-23: The deterministic interaction seeder now includes numerical
+  element instances. The full analytics suite passes with 135 tests and 3
+  integration skips; the isolated analytics CI subset passes 56 tests; all 10
+  grading tests and the focused strict TypeScript check of the interaction
+  response seeder pass.
+- 2026-07-23: A seeded script-0 row diff could not run without borrowing
+  another active worktree's database. Container labels confirmed that none of
+  the running seeded environments belongs to this worktree, so no other
+  agent's database was reused or reset. This remains a final runtime evidence
+  item rather than being represented by unit parity tests.
+- Active: Slice 3B, commit and independently review grading parity.
+- Next: Prove index needs and refresh operational documentation in Slice 3C.
 
 ## Finish evidence
 

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -489,7 +489,8 @@ the repository script that replaces it before continuing.
   `80c9ae5cf`.
 - 2026-07-23: Slice 3B reproduces and fixes numerical analytics differences
   from `packages/grading`: bounded and one-sided ranges, empty or undefined
-  solutions, exact-solution precedence, and `Number.EPSILON` tolerance.
+  solutions, solution-range precedence with exact-solution fallback, and
+  `Number.EPSILON` tolerance.
   Parity work also exposed and fixed the product grader's zero-bound truthiness
   defect, so a bound of exactly zero is no longer treated as absent.
 - 2026-07-23: The deterministic interaction seeder now includes numerical
@@ -502,8 +503,23 @@ the repository script that replaces it before continuing.
   the running seeded environments belongs to this worktree, so no other
   agent's database was reused or reset. This remains a final runtime evidence
   item rather than being represented by unit parity tests.
-- Active: Slice 3B, commit and independently review grading parity.
-- Next: Prove index needs and refresh operational documentation in Slice 3C.
+- 2026-07-23: Slice 3B's independent review reproduced an ingestion and
+  defense-in-depth defect where a partially parsed numerical response could
+  become `NaN` and receive full range credit. The accepted adjustment requires
+  a complete finite numeric string at ingestion, rejects non-finite values in
+  the shared grader and Python analytics, and makes grading changes trigger the
+  analytics parity workflow. A production-data audit for historical zero-bound
+  responses remains a deployment gate because this worktree has no authorized
+  production-data access.
+- 2026-07-23: The accepted Slice 3B adjustments pass 139 analytics tests with
+  3 integration skips, the exact isolated 60-test analytics CI command, all 10
+  grading tests, 2 response-validation tests, both changed TypeScript package
+  checks, Ruff lint/format, Prettier, and diff hygiene. The analytics process
+  exits successfully despite the known sandbox-only `mirakuru` cleanup warning.
+- Completed: Slice 3B numerical grading parity and review adjustments.
+- Active: Prove index needs and refresh operational documentation in Slice 3C.
+- Next: Close the dormant-surface review findings, then build the native Python
+  Hatchet runtime in Slice 4.
 
 ## Finish evidence
 
@@ -517,6 +533,6 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit and independently review Slice 3A.
-2. Prove numerical grading parity in Slice 3B.
+1. Prove index needs and refresh operational documentation in Slice 3C.
+2. Close the dormant-surface review findings and prepare the native worker.
 3. Continue one verified slice at a time until both draft PRs are current.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -476,9 +476,17 @@ the repository script that replaces it before continuing.
   build/typecheck/DAG test, Syncpack, Prisma schema sync, Prettier, and diff
   hygiene. A seeded database run and live Hatchet failed-task smoke still need
   a stable local runtime and are not represented by these unit-level gates.
-- Active: Slice 3A, commit and independently review the correctness changes.
-- Next: Integrate accepted Slice 3A review findings, then prove grading parity
-  in Slice 3B.
+- 2026-07-23: Slice 3A correctness committed as `6a8a81609`.
+  Independent correctness and simplification reviews found no source-level
+  regression. The accepted review findings remove a test-only Rollup entry and
+  make the new Python correctness and Hatchet DAG tests run in CI.
+- 2026-07-23: The Python CI gate uses an isolated, pinned 15-package test
+  environment and passes all 23 focused correctness tests. This protects the
+  reproduced Slice 3A fixes without downloading the multi-gigabyte ML/CUDA
+  dependency set; the full 116-test suite remains a local/final gate until
+  Slice 5A establishes the CPU-only worker dependency set.
+- Active: Slice 3A, commit the independently reviewed CI adjustment.
+- Next: Prove grading parity in Slice 3B.
 
 ## Finish evidence
 

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -523,29 +523,47 @@ the repository script that replaces it before continuing.
   composite: the real script-0 path supplied every participant and still
   fetched every row. Pushing the daily window into SQL uses the existing BRIN
   index and reduces the warm plan from about 27 ms to 0.44 ms.
-- 2026-07-23: The designed live-quiz index named a column absent from
-  `LiveQuizResponse` and used the wrong timestamp. The real
-  `(instanceId, submittedAt)` path reduces script 14's first-response lookup
-  from a bitmap scan plus sort at about 1.98 ms (excluding one-time JIT setup)
-  to an ordered index lookup at about 0.05 ms.
+- 2026-07-23: Slice 3C review found that the designed live-quiz query selected
+  one first respondent per instance rather than one first attempt per
+  participant and instance; the existing "last" metric also averaged every
+  response instead of last attempts. The corrected window query now ranks both
+  directions per `(participantId, instanceId)`, has a multi-participant
+  database regression test, and uses
+  `(instanceId, participantId, submittedAt)`. On the 2.0M-row fixture, the
+  corrected full aggregation selects the 2,530 assessment responses for 30
+  participants through that index and completes a warm run in about 4.1 ms
+  with JIT disabled.
 - 2026-07-23: A fresh migration-chain test reproduced PostgreSQL error `25001`
   when `CREATE INDEX CONCURRENTLY` was placed directly in Prisma 6.16's
-  migration transaction. The corrected two-step rollout validates the
-  checked-in concurrent prebuild script against the scaled fixture and then
-  applies all 181 Prisma migrations successfully on an empty database. Retry-
-  safe migration statements no-op after the shared-environment prebuild.
+  migration transaction. Review then found that a manual runbook could still
+  be skipped and that editing a potentially applied migration was unsafe. The
+  historical migration is restored byte-for-byte. Every repository Prisma
+  deploy now runs an automated prebuild that checks migration history and
+  invalid indexes, creates indexes concurrently, validates them, baselines the
+  pending historical migration only when all earlier migrations are recorded,
+  and then invokes Prisma. The guarded command succeeds both on a fresh
+  181-migration database and on a disposable initialized-database simulation
+  with the historical migration pending; both analytics migrations and the
+  corrected index read back finished, valid, and ready.
+- 2026-07-23: A live read-only shared-environment migration audit was attempted,
+  but the Infisical endpoint `inf.prd.df-app.ch` timed out in DNS from this
+  environment. Restoring the historical migration removes the checksum risk;
+  the guarded deploy still verifies actual migration state before making any
+  production change.
 - 2026-07-23: Slice 3C also corrects scanner deduplication wording and records
   the dry-run buffer's downstream and incremental-union limitations. The
   window-query regression suite passes 38 tests.
-- 2026-07-23: Final Slice 3C verification passes 140 analytics tests with 3
-  integration skips, the exact isolated 61-test CI command, Prisma
-  generation/typecheck/patch tests, schema-mirror validation, Hatchet DAG
-  test/typecheck, Ruff, Prettier, and diff hygiene. A real scoped incremental
-  script-0 run completed in 98.7 seconds against the enlarged fixture and
-  wrote 94 DAILY, 16 WEEKLY, 6 MONTHLY, and 34 COURSE rows. Both evidence-backed
-  indexes report `indisvalid=true` and `indisready=true`.
-- Active: Verify, commit, and independently review Slice 3C.
-- Next: Build the native Python Hatchet runtime in Slice 4.
+- 2026-07-23: Final Slice 3C verification passes 141 analytics tests with 4
+  integration skips, the exact isolated 62-test analytics CI command with 1
+  database skip, and the new multi-participant database regression with both
+  tests active. Prisma generation/typecheck, 4 namespace patch tests, 8 guarded
+  deploy tests, schema-mirror validation, Hatchet DAG test/typecheck, Ruff,
+  Prettier, and diff hygiene pass. A real scoped incremental script-0 run
+  completed in 98.7 seconds against the enlarged fixture and wrote 94 DAILY,
+  16 WEEKLY, 6 MONTHLY, and 34 COURSE rows. Both evidence-backed indexes report
+  `indisvalid=true` and `indisready=true`.
+- Active: Verify and commit the accepted Slice 3C review fixes.
+- Next: Register the native Python Hatchet worker and proof task in Slice 4A.
 
 ## Finish evidence
 
@@ -559,6 +577,6 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Verify, commit, and independently review Slice 3C.
+1. Close Slice 3C review findings.
 2. Register the native Python worker and proof task in Slice 4A.
 3. Continue one verified slice at a time until both draft PRs are current.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -600,6 +600,5 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Close Slice 3C review findings.
-2. Register the native Python worker and proof task in Slice 4A.
-3. Continue one verified slice at a time until both draft PRs are current.
+1. Register the native Python worker and proof task in Slice 4A.
+2. Continue one verified slice at a time until both draft PRs are current.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -12,8 +12,7 @@ the existing Hatchet control plane.
 - Plan: `project/2026-07-23-learning-analytics-production-plan.md`
 - Phase 1 branch: `chat-analytics`
 - Phase 1 target: `v3`
-- Phase 1 PR:
-  [#5199](https://github.com/uzh-bf/klicker-uzh/pull/5199)
+- Phase 1 PR: none yet
 - Phase 1 worktree:
   `trees/chat-analytics-integration`
 - Phase 2 branch: `analytics-phase-a`
@@ -362,7 +361,7 @@ Focused slices run the relevant subset. Slice 6 reruns the complete matrix:
 | Dependency policy | `volta run --node 24.16.0 pnpm run check:syncpack` | Exit 0 |
 | Analytics format | `cd apps/analytics && uv run ruff format --check . && uv run ruff check .` | Exit 0 |
 | Analytics types | `cd apps/analytics && uv run pyright` | Exit 0 |
-| Analytics tests | `cd apps/analytics && uv run python -m unittest discover -s tests` | All tests pass |
+| Analytics tests | `cd apps/analytics && uv run pytest` | All tests pass |
 | Hatchet packages | `volta run --node 24.16.0 pnpm exec turbo run check --filter=@klicker-uzh/hatchet --filter=@klicker-uzh/hatchet-worker-analytics --filter=@klicker-uzh/hatchet-worker-general` | Exit 0 |
 | GraphQL package | `volta run --node 24.16.0 pnpm exec turbo run check --filter=@klicker-uzh/graphql` | Exit 0 |
 | GraphQL tests | `volta run --node 24.16.0 pnpm --filter @klicker-uzh/graphql test` | All tests pass |
@@ -422,29 +421,46 @@ the repository script that replaces it before continuing.
   immediately. Dependency pruning and small SQL-loading/query-shape cleanups
   were rejected for Slice 1 because they are unrelated to the merge and lack
   runtime value or build evidence.
-- 2026-07-24: Final base review found that aggregate chat metrics did not
-  apply the current-consent gate to message rows, participant and aggregate
-  chat windows retained stale rows after consent changes, below-threshold
-  clustering retained old topics, script 0 did not apply course scope to
-  daily/weekly/monthly reads, and incremental completion timestamps were
-  global. These are accepted privacy/correctness blockers.
-- 2026-07-24: The base fix joins current eligible participant/chatbot pairs
-  into both aggregate message CTEs; atomically replaces participant and
-  aggregate chat windows; clears old clusters when eligible messages fall
-  below the threshold; pushes course scope into both the parent and nested
-  response queries; and scopes completion watermarks for every scoped run.
-- 2026-07-24: Current base verification passes Ruff formatting/lint across 92
-  files and 35 focused unit/contract tests. The pre-push repository build
-  completed all 22 runnable build tasks.
-- 2026-07-24: Exact-commit review found that a valid empty COURSE chat result
-  still aborted correlation and retained old outcome/activity state. The
-  correction now treats dependency-complete empty sources as valid and
-  atomically rebuilds outcomes plus activity flags from current source rows.
-- 2026-07-24: Opened draft PR
-  [#5199](https://github.com/uzh-bf/klicker-uzh/pull/5199) from
-  `chat-analytics` to `v3`.
-- Active: Commit and independently review the accepted final base corrections,
-  then merge them through the Phase A stack.
+- 2026-07-23: Slice 1 review adjustments committed as `35a9f97`.
+- 2026-07-23: Created the Phase A integration worktree at
+  `trees/analytics-phase-a-integration`, fast-forwarded `analytics-phase-a` to
+  remote tip `18d0bb8c03`, and merged the refreshed `chat-analytics` history.
+  All 33 conflicts are resolved without discarding Phase A behavior. The
+  resolution keeps Phase A SQLAlchemy models, dry-run support, tests, and
+  scripts while adopting the refreshed Node 24, uv/Ruff, generated GraphQL,
+  and canonical Prisma-schema tooling.
+- 2026-07-23: Slice 2 analytics verification passes Ruff format/lint and
+  `pytest` with 103 passed and 3 skipped. The Phase A Pyright baseline reports
+  2,078 errors across generated SQLAlchemy models, missing third-party stubs,
+  and broadly untyped existing code; making this gate actionable remains
+  production-readiness work rather than a merge-only rewrite.
+- 2026-07-23: Slice 2 TypeScript and schema verification passes GraphQL
+  generation/build/typecheck, Prisma generation/typecheck/namespace tests,
+  Syncpack, all three Hatchet package checks, and the canonical-to-analytics
+  schema-mirror check.
+- 2026-07-23: The GraphQL test suite cannot currently complete against the
+  local test database. A sandboxed run was denied with `EPERM`; an allowed run
+  reached PostgreSQL but the connection terminated and successive tests timed
+  out. No assertion failure was observed before the run was stopped.
+- 2026-07-23: Independent Slice 2 review found no source-level feature loss.
+  It identified one merge-created image regression: the resolved analytics
+  image still invoked the removed Prisma-Python generator. The review
+  adjustment removes that obsolete build step. Verified cleanup also removes
+  nested Infisical execution and a double-import in the dry-run runner. Dormant
+  Phase A helpers were preserved because they are not a production blocker and
+  this integration must not discard intended follow-up surfaces.
+- 2026-07-23: A local analytics-image build passed the removed Prisma-generation
+  stage but was stopped when Linux dependency resolution began downloading
+  several gigabytes of CUDA/Torch artifacts. CPU-only/minimal ML dependency
+  resolution and the 918 MB root build context remain explicit Slice 5A image
+  work; the interrupted build is not recorded as a passing image gate.
+- 2026-07-23: Confirmed correctness findings remain assigned to Slice 3A:
+  partial script-10 clustering failures can still resolve successfully, and
+  script 13 races the script-2 rows it updates. Cooperative cancellation of
+  the transitional subprocess remains assigned to the native-worker cutover
+  slices.
+- Active: Slice 2, verify and commit the independent-review adjustment.
+- Next: Reproduce the focused correctness and CI gaps in Slice 3A.
 
 ## Finish evidence
 
@@ -458,7 +474,6 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit and review the final base privacy/scope correction.
-2. Merge the corrected base into `analytics-phase-a`.
-3. Port database-backed regressions through the SQLAlchemy/native-worker path
-   and continue to the final draft-PR CI readback.
+1. Commit and independently review the refreshed Phase A merge.
+2. Reproduce and close the focused correctness and CI gaps in Slice 3A.
+3. Continue one verified slice at a time until both draft PRs are current.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -580,9 +580,13 @@ the repository script that replaces it before continuing.
 - 2026-07-23: The hardened deploy passes 11 focused wrapper tests, a real run
   against an initialized disposable database, and a fresh locked 181-migration
   chain in `deploy_fresh_lock_review_20260723`.
-- Active: Commit and independently re-review the final Slice 3C deploy
-  hardening.
-- Next: Register the native Python Hatchet worker and proof task in Slice 4A.
+- 2026-07-23: Final independent correctness review found no blocker. The
+  simplification review's accepted follow-up makes the SQL inventory test
+  compare table, access method, and ordered columns as well as names, and
+  removes redundant validator state.
+- Completed: Slice 3C query/index evidence, operational documentation, and
+  guarded repository deploy path.
+- Active: Register the native Python Hatchet worker and proof task in Slice 4A.
 
 ## Finish evidence
 

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -459,8 +459,26 @@ the repository script that replaces it before continuing.
   script 13 races the script-2 rows it updates. Cooperative cancellation of
   the transitional subprocess remains assigned to the native-worker cutover
   slices.
-- Active: Slice 2, verify and commit the independent-review adjustment.
-- Next: Reproduce the focused correctness and CI gaps in Slice 3A.
+- 2026-07-23: Slice 2 integration committed as `cc69458b7`; its independently
+  reviewed runtime corrections committed as `97986835d`.
+- 2026-07-23: Slice 3A now refreshes late-arriving participant and aggregate
+  chat rows for daily, weekly, monthly, and course grains; validates
+  homogeneous bulk-upsert row shapes; and writes participant and aggregate
+  timestamps from one UTC clock value per save.
+- 2026-07-23: Script 10 now rolls back failed chatbot work and fails the
+  overall task after processing the remaining chatbots. The transitional
+  subprocess handler's non-zero exit propagation remains covered by six
+  focused GraphQL tests. Script 13 now waits for script 2, and an isolated
+  Hatchet task-registration test verifies that dependency plus the complete
+  script-99 fan-in.
+- 2026-07-23: Slice 3A verification passes Ruff format/lint, 116 Python tests
+  with 3 integration skips, 6 focused GraphQL handler tests, the Hatchet
+  build/typecheck/DAG test, Syncpack, Prisma schema sync, Prettier, and diff
+  hygiene. A seeded database run and live Hatchet failed-task smoke still need
+  a stable local runtime and are not represented by these unit-level gates.
+- Active: Slice 3A, commit and independently review the correctness changes.
+- Next: Integrate accepted Slice 3A review findings, then prove grading parity
+  in Slice 3B.
 
 ## Finish evidence
 
@@ -474,6 +492,6 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit and independently review the refreshed Phase A merge.
-2. Reproduce and close the focused correctness and CI gaps in Slice 3A.
+1. Commit and independently review Slice 3A.
+2. Prove numerical grading parity in Slice 3B.
 3. Continue one verified slice at a time until both draft PRs are current.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -517,9 +517,35 @@ the repository script that replaces it before continuing.
   checks, Ruff lint/format, Prettier, and diff hygiene. The analytics process
   exits successfully despite the known sandbox-only `mirakuru` cleanup warning.
 - Completed: Slice 3B numerical grading parity and review adjustments.
-- Active: Prove index needs and refresh operational documentation in Slice 3C.
-- Next: Close the dormant-surface review findings, then build the native Python
-  Hatchet runtime in Slice 4.
+- 2026-07-23: Slice 3C uses a fresh isolated Postgres 15 database with repository
+  seeds expanded to 252,170 `QuestionResponseDetail` and 2,047,528
+  `LiveQuizResponse` rows. `EXPLAIN ANALYZE` disproves the designed detail
+  composite: the real script-0 path supplied every participant and still
+  fetched every row. Pushing the daily window into SQL uses the existing BRIN
+  index and reduces the warm plan from about 27 ms to 0.44 ms.
+- 2026-07-23: The designed live-quiz index named a column absent from
+  `LiveQuizResponse` and used the wrong timestamp. The real
+  `(instanceId, submittedAt)` path reduces script 14's first-response lookup
+  from a bitmap scan plus sort at about 1.98 ms (excluding one-time JIT setup)
+  to an ordered index lookup at about 0.05 ms.
+- 2026-07-23: A fresh migration-chain test reproduced PostgreSQL error `25001`
+  when `CREATE INDEX CONCURRENTLY` was placed directly in Prisma 6.16's
+  migration transaction. The corrected two-step rollout validates the
+  checked-in concurrent prebuild script against the scaled fixture and then
+  applies all 181 Prisma migrations successfully on an empty database. Retry-
+  safe migration statements no-op after the shared-environment prebuild.
+- 2026-07-23: Slice 3C also corrects scanner deduplication wording and records
+  the dry-run buffer's downstream and incremental-union limitations. The
+  window-query regression suite passes 38 tests.
+- 2026-07-23: Final Slice 3C verification passes 140 analytics tests with 3
+  integration skips, the exact isolated 61-test CI command, Prisma
+  generation/typecheck/patch tests, schema-mirror validation, Hatchet DAG
+  test/typecheck, Ruff, Prettier, and diff hygiene. A real scoped incremental
+  script-0 run completed in 98.7 seconds against the enlarged fixture and
+  wrote 94 DAILY, 16 WEEKLY, 6 MONTHLY, and 34 COURSE rows. Both evidence-backed
+  indexes report `indisvalid=true` and `indisready=true`.
+- Active: Verify, commit, and independently review Slice 3C.
+- Next: Build the native Python Hatchet runtime in Slice 4.
 
 ## Finish evidence
 
@@ -533,6 +559,6 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Prove index needs and refresh operational documentation in Slice 3C.
-2. Close the dormant-surface review findings and prepare the native worker.
+1. Verify, commit, and independently review Slice 3C.
+2. Register the native Python worker and proof task in Slice 4A.
 3. Continue one verified slice at a time until both draft PRs are current.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -532,7 +532,14 @@ the repository script that replaces it before continuing.
   `(instanceId, participantId, submittedAt)`. On the 2.0M-row fixture, the
   corrected full aggregation selects the 2,530 assessment responses for 30
   participants through that index and completes a warm run in about 4.1 ms
-  with JIT disabled.
+  with JIT disabled. The exact query-plan command prepended
+  `EXPLAIN (ANALYZE, BUFFERS)` to
+  `aggregated_live_quiz_analytics.sql` and executed it twice after
+  `SET jit=off`; the warm run used
+  `LiveQuizResponse_instanceId_participantId_submittedAt_idx` and completed in
+  4.112 ms. The additional fixture expansion was local and ad hoc rather than
+  committed, so this timing is directional; a staging-like representative
+  rerun remains a production gate.
 - 2026-07-23: A fresh migration-chain test reproduced PostgreSQL error `25001`
   when `CREATE INDEX CONCURRENTLY` was placed directly in Prisma 6.16's
   migration transaction. Review then found that a manual runbook could still
@@ -562,7 +569,19 @@ the repository script that replaces it before continuing.
   completed in 98.7 seconds against the enlarged fixture and wrote 94 DAILY,
   16 WEEKLY, 6 MONTHLY, and 34 COURSE rows. Both evidence-backed indexes report
   `indisvalid=true` and `indisready=true`.
-- Active: Verify and commit the accepted Slice 3C review fixes.
+- 2026-07-23: Follow-up Slice 3C review found that the guarded deploy could
+  misclassify a partial schema as fresh and validated only index readiness.
+  The accepted hardening now treats only zero required tables plus zero
+  migration records as fresh; otherwise it fails closed with the missing table
+  names. It also verifies the public-schema table, access method, ordered key
+  columns, validity, and readiness of every same-name index; checks the SQL
+  create-index inventory against the definitions; and holds one advisory lock
+  across prebuild, optional historical baseline, and Prisma deploy.
+- 2026-07-23: The hardened deploy passes 11 focused wrapper tests, a real run
+  against an initialized disposable database, and a fresh locked 181-migration
+  chain in `deploy_fresh_lock_review_20260723`.
+- Active: Commit and independently re-review the final Slice 3C deploy
+  hardening.
 - Next: Register the native Python Hatchet worker and proof task in Slice 4A.
 
 ## Finish evidence

--- a/project/ANALYTICS_IMPROVEMENTS.md
+++ b/project/ANALYTICS_IMPROVEMENTS.md
@@ -1,8 +1,9 @@
 # Analytics Pipeline Improvements — Design Report
 
-**Status:** Design proposal
+**Status:** Historical design proposal; superseded for active execution by
+[`2026-07-23-learning-analytics-production-plan.md`](2026-07-23-learning-analytics-production-plan.md)
 **Scope:** `apps/analytics/`, `packages/hatchet/`, `packages/graphql/src/services/analyticsRecompute.ts`, analytics tables in `packages/prisma/src/prisma/schema/analytics.prisma`
-**Last reviewed:** 2026-04-19
+**Last reviewed:** 2026-07-23
 
 ---
 
@@ -165,16 +166,16 @@ The following indexes should be added to `packages/prisma/src/prisma/schema/` an
 | QuestionResponseDetail | BRIN on `createdAt` | Script 0 pushes each window into SQL; append order makes BRIN effective at low storage cost |
 | ChatMessage | `(threadId, createdAt)` | Scripts 8, 9, 10 |
 | ChatMessage | existing B-tree on `createdAt` | The base branch already supplies the time index; a second BRIN index is intentionally omitted |
-| LiveQuizResponse | `(instanceId, submittedAt)` | Script 14 reaches responses through `ElementInstance` and reads the first submission in time order |
+| LiveQuizResponse | `(instanceId, participantId, submittedAt)` | Script 14 ranks first and last attempts per participant and element instance |
 | LiveQuizResponse | BRIN on `createdAt` | Append-mostly date scans in platform analytics |
 | ParticipantAnalytics | `(courseId, type, timestamp)` | Script 1, 99 read participant rows per course-window |
 | AggregatedAnalytics | `(courseId, type, timestamp)` | API reads by these three keys |
 
 `EXPLAIN ANALYZE` on a 252k-row synthetic detail table showed that the originally proposed `(participantId, elementInstanceId, createdAt)` index still fetched every row because script 0 supplied every participant ID. Pushing the one-day predicate into SQL let the existing BRIN path complete in 0.44 ms, versus about 27 ms for the warm full-table path, so the unused composite is intentionally omitted.
 
-The original live-quiz proposal named a `liveQuizId` column that does not exist on `LiveQuizResponse` and used `createdAt` despite the query ordering by `submittedAt`. On a 2.0M-row synthetic fixture, `(instanceId, submittedAt)` replaced a bitmap scan plus sort with an ordered index lookup (about 2 ms to 0.05 ms, excluding one-time JIT setup).
+The original live-quiz proposal named a `liveQuizId` column that does not exist on `LiveQuizResponse` and used `createdAt` despite the query ordering by `submittedAt`. Slice 3C also found that the first-correctness query selected only the first respondent per instance and the last-correctness query averaged all responses. The corrected query ranks attempts per `(participantId, instanceId)` and uses `(instanceId, participantId, submittedAt)`. A warm full aggregation over the 2.0M-row synthetic fixture selects 2,530 assessment responses for 30 participants through that index and completes in about 4.1 ms with JIT disabled.
 
-BRIN indexes are near-free in size and rebuild cost; they pay off as soon as the table grows past a few hundred thousand rows. Prisma does not model BRIN natively, so these are declared via migration SQL. Shared environments prebuild all hot-table indexes with the checked-in concurrent SQL script, outside Prisma's migration transaction; the retry-safe Prisma migrations then no-op.
+BRIN indexes are near-free in size and rebuild cost; they pay off as soon as the table grows past a few hundred thousand rows. Prisma does not model BRIN natively, so these are declared via migration SQL. The Prisma package's deploy command prebuilds all hot-table indexes concurrently, validates them, baselines the unchanged historical migration when necessary, and only then runs the remaining migration chain.
 
 ### R5 — Fix the DAILY/WEEKLY/MONTHLY upsert-no-op bug
 

--- a/project/ANALYTICS_IMPROVEMENTS.md
+++ b/project/ANALYTICS_IMPROVEMENTS.md
@@ -34,8 +34,8 @@ The recommendations below are ordered by risk/reward. The first three (unify on 
 | 9 | Chatbot adoption rollup | DAILY/WEEKLY/MONTHLY/COURSE | Raw SQL (weekly has its own file) | ChatMessage | AggregatedChatbotAnalytics |
 | 10 | Topic clustering per chatbot | Single pass × all chatbots (COURSE only) | sentence-transformers + UMAP + HDBSCAN | ChatMessage | ChatTopicCluster |
 | 11 | Chat × quiz correlation | Single pass (no windowing) | Raw SQL | ParticipantChatAnalytics, ParticipantPerformance | ParticipantChatOutcome, ParticipantCourseAnalytics |
-| 13 | Platform semester totals | Single pass | Raw SQL | ChatMessage, QuestionResponse, LiveQuizParticipantResponse | PlatformSemesterAnalytics, AggregatedCourseAnalytics |
-| 14 | Live quiz assessment stats | Single pass × all courses | Raw SQL | LiveQuizParticipantResponse, LiveQuiz | ParticipantLiveQuizAnalytics, AggregatedLiveQuizAnalytics |
+| 13 | Platform semester totals | Single pass | Raw SQL | ChatMessage, QuestionResponse, LiveQuizResponse | PlatformSemesterAnalytics, AggregatedCourseAnalytics |
+| 14 | Live quiz assessment stats | Single pass × all courses | Raw SQL | LiveQuizResponse, LiveQuiz | ParticipantLiveQuizAnalytics, AggregatedLiveQuizAnalytics |
 | 99 | Flip validity flags | Single pass | Raw SQL | ParticipantAnalytics, ParticipantChatAnalytics | Course |
 
 ### 2.2 Dependency Graph
@@ -79,7 +79,7 @@ Today's timeout is "each of the 15 scripts gets 1 hour." That means a pathologic
 
 ### P5 — Missing indexes on hot event tables
 
-The analytics pipeline queries `QuestionResponseDetail`, `QuestionResponse`, `ChatMessage`, and `LiveQuizParticipantResponse` with predicates like `WHERE courseId = $1 AND createdAt BETWEEN $2 AND $3`. Without a composite `(courseId, createdAt)` index, Postgres sequentially scans the table or falls back to a single-column `createdAt` index and then filters by course. A BRIN index on `createdAt` gives most of the pruning benefit for append-only event data at a fraction of the size of a B-tree.
+The analytics pipeline queries `QuestionResponse`, `QuestionResponseDetail`, `ChatMessage`, and `LiveQuizResponse` through different access paths. Course-window tables benefit from composite keys; append-mostly date scans benefit from BRIN; script 14 reaches responses through `ElementInstance` and orders by `submittedAt`. Indexes must match those concrete predicates and joins rather than applying one `(courseId, createdAt)` shape everywhere.
 
 ### P6 — No incremental path for topic clustering (script 10)
 
@@ -99,7 +99,7 @@ All orchestration lives in Node; Python scripts are blind subprocesses. If Pytho
 
 ### P10 — Partition readiness
 
-Event tables (`QuestionResponse`, `QuestionResponseDetail`, `ChatMessage`, `LiveQuizParticipantResponse`) will grow monotonically. At current scale (millions of rows) they do not need partitioning yet, but the migration is easier to do while still small. Deferring beyond 50M rows increases the migration cost to a full dual-write + backfill rollout.
+Event tables (`QuestionResponse`, `QuestionResponseDetail`, `ChatMessage`, `LiveQuizResponse`) will grow monotonically. At current scale (millions of rows) they do not need partitioning yet, but the migration is easier to do while still small. Deferring beyond 50M rows increases the migration cost to a full dual-write + backfill rollout.
 
 ---
 
@@ -162,15 +162,19 @@ The following indexes should be added to `packages/prisma/src/prisma/schema/` an
 | Table | Index | Rationale |
 |---|---|---|
 | QuestionResponse | `(courseId, createdAt)` | Scripts 0, 3, 4, 5, 6, 7 all filter by these two columns |
-| QuestionResponseDetail | `(participantId, elementInstanceId, createdAt)` | Script 0's per-attempt walk |
-| QuestionResponseDetail | BRIN on `createdAt` | Append-mostly log, saves 95% of B-tree size |
+| QuestionResponseDetail | BRIN on `createdAt` | Script 0 pushes each window into SQL; append order makes BRIN effective at low storage cost |
 | ChatMessage | `(threadId, createdAt)` | Scripts 8, 9, 10 |
-| ChatMessage | BRIN on `createdAt` | Append-only |
-| LiveQuizParticipantResponse | `(liveQuizId, createdAt)` | Script 14 |
+| ChatMessage | existing B-tree on `createdAt` | The base branch already supplies the time index; a second BRIN index is intentionally omitted |
+| LiveQuizResponse | `(instanceId, submittedAt)` | Script 14 reaches responses through `ElementInstance` and reads the first submission in time order |
+| LiveQuizResponse | BRIN on `createdAt` | Append-mostly date scans in platform analytics |
 | ParticipantAnalytics | `(courseId, type, timestamp)` | Script 1, 99 read participant rows per course-window |
 | AggregatedAnalytics | `(courseId, type, timestamp)` | API reads by these three keys |
 
-BRIN indexes are near-free in size and rebuild cost; they pay off as soon as the table grows past a few hundred thousand rows. Prisma does not model BRIN natively, so these need to be declared via `migrations/*/migration.sql` with a raw `CREATE INDEX USING BRIN`.
+`EXPLAIN ANALYZE` on a 252k-row synthetic detail table showed that the originally proposed `(participantId, elementInstanceId, createdAt)` index still fetched every row because script 0 supplied every participant ID. Pushing the one-day predicate into SQL let the existing BRIN path complete in 0.44 ms, versus about 27 ms for the warm full-table path, so the unused composite is intentionally omitted.
+
+The original live-quiz proposal named a `liveQuizId` column that does not exist on `LiveQuizResponse` and used `createdAt` despite the query ordering by `submittedAt`. On a 2.0M-row synthetic fixture, `(instanceId, submittedAt)` replaced a bitmap scan plus sort with an ordered index lookup (about 2 ms to 0.05 ms, excluding one-time JIT setup).
+
+BRIN indexes are near-free in size and rebuild cost; they pay off as soon as the table grows past a few hundred thousand rows. Prisma does not model BRIN natively, so these are declared via migration SQL. Shared environments prebuild all hot-table indexes with the checked-in concurrent SQL script, outside Prisma's migration transaction; the retry-safe Prisma migrations then no-op.
 
 ### R5 — Fix the DAILY/WEEKLY/MONTHLY upsert-no-op bug
 


### PR DESCRIPTION
## What

This is layer 9 of 14. It aligns Analytics scoring with the shared grading package and makes the query-index rollout fail closed.

- corrects incremental and aggregate scoring differences found against the shared grader
- adds cross-language parity fixtures and CI enforcement
- aligns response access paths with the production query shapes
- adds guarded, idempotent Analytics index deployment with contract tests
- records query-plan and index evidence in the production plan

## Branch coverage

- Base: `analytics-stack-08-dryrun-diagnostics` at `f9c6cb89a6`
- Head: `c0cad0fd48`
- Reviewed: 11 commits, 42 files, 1,767 insertions, 248 deletions
- Covered: Analytics computations, grading parity, response processing, query indexes, deploy guard, CI workflows, tests, image inputs, seeds, and production evidence

## Review focus

- Compare Python scoring with the shared TypeScript grader for every supported element type.
- Confirm incremental recompute does not retain stale or out-of-scope rows.
- Review index deployment failure behavior and the non-transactional production procedure.

## Verification

Current layer:

- GitHub CI is required after publication.

Current stack head:

- Analytics Ruff checks passed.
- Analytics tests passed 184 cases with 15 PostgreSQL-only skips.

Earlier verification of the identical implementation tree:

- Grading parity, index definition, query-plan, and 11 guarded index-deploy tests passed.
- All 199 database-enabled Analytics tests, repository `check:all`, and the Node 24 build passed.

## Security / privacy

The deploy wrapper validates migration state and fails closed. No production query output or database credentials are included.

## Blocking before merge

- [ ] Layer 8 is merged first.
- [ ] Required GitHub checks pass.
- [ ] Maintainer review is complete.

## Follow-up after merge

- Layer 10 performs the native Python Hatchet cutover.
