### PR TITLE
fix(analytics): reconcile consent and finalization

### DIFF
--- a/apps/analytics/ANALYTICS.md
+++ b/apps/analytics/ANALYTICS.md
@@ -8,12 +8,12 @@ The pipeline is raw-SQL first: each module pairs a `compute_*.py` wrapper with a
 
 Every per-window table carries a `type` column with one of:
 
-| Value | Meaning | Timestamp convention |
-| --- | --- | --- |
-| `DAILY` | Closed 24h window ending at midnight UTC | `timestamp` = that day's date |
-| `WEEKLY` | Closed 7-day window ending Sunday UTC | `timestamp` = window end date |
-| `MONTHLY` | Calendar month, end-of-month UTC | `timestamp` = last day of month |
-| `COURSE` | Full course lifetime, one row per scope | `timestamp` = sentinel `1970-01-01` |
+| Value     | Meaning                                  | Timestamp convention                |
+| --------- | ---------------------------------------- | ----------------------------------- |
+| `DAILY`   | Closed 24h window ending at midnight UTC | `timestamp` = that day's date       |
+| `WEEKLY`  | Closed 7-day window ending Sunday UTC    | `timestamp` = window end date       |
+| `MONTHLY` | Calendar month, end-of-month UTC         | `timestamp` = last day of month     |
+| `COURSE`  | Full course lifetime, one row per scope  | `timestamp` = sentinel `1970-01-01` |
 
 The `COURSE` sentinel (`1970-01-01`) is the convention used by every per-window rollup; it keeps the `(type, …, timestamp)` uniqueness stable regardless of when the COURSE row was computed. `ParticipantCourseAnalytics`, `AggregatedCourseAnalytics`, `ParticipantPerformance`, `InstancePerformance`, `ActivityPerformance`, `ParticipantActivityPerformance`, `ActivityProgress`, `ParticipantChatOutcome`, `ParticipantLiveQuizAnalytics`, `AggregatedLiveQuizAnalytics`, and `PlatformSemesterAnalytics` have no `type` column — their grain is inherently per-course (or per-semester) and a single row per key represents the full lifetime.
 
@@ -111,7 +111,7 @@ Defined in the schema, **not computed by the current pipeline.** Would require a
 
 ## Chat analytics
 
-Added on the chat-analytics branch. Sourced from `ChatMessage`, `ChatThread`, `Chatbot`, `ChatUsageCredits`, `ChatAttachment`. Only participants with an accepted disclaimer (`ChatUsageCredits.acceptedDisclaimerId IS NOT NULL`) appear in these tables — the disclaimer gate is enforced in the SQL, not at read time.
+Added on the chat-analytics branch. Sourced from `ChatMessage`, `ChatThread`, `Chatbot`, `ChatUsageCredits`, `ChatAttachment`. Message-derived rows require the chatbot's current disclaimer to be accepted and not declined (`ChatUsageCredits.acceptedDisclaimerId = Chatbot.disclaimerId` and `disclaimerDeclined = false`). Incremental runs purge participant rows that no longer meet that rule across all retained history and rebuild affected aggregate windows from the earliest changed message or retained aggregate.
 
 ### `ParticipantChatAnalytics` — script 8
 
@@ -199,24 +199,24 @@ Scripts that short-circuit due to missing upstream data do not prevent script 99
 
 ## Source data summary
 
-| Analytics table | Source tables |
-| --- | --- |
-| `ParticipantAnalytics` | `QuestionResponse`, `QuestionResponseDetail`, `Participation` |
-| `AggregatedAnalytics` | `ParticipantAnalytics` (same window) |
-| `ParticipantCourseAnalytics` | `QuestionResponse`, `Participation` |
-| `AggregatedCourseAnalytics` | `ParticipantCourseAnalytics`, plus modality counts from `Chatbot` / `PracticeQuiz` / `MicroLearning` / `LiveQuiz` / `ChatUsageCredits` (script 13) |
-| `ParticipantPerformance` | `QuestionResponse`, `QuestionResponseDetail` |
-| `InstancePerformance` | `QuestionResponse`, `QuestionResponseDetail`, `ElementInstance` |
-| `ActivityPerformance` | `InstancePerformance`, `PracticeQuiz` / `MicroLearning` |
-| `ParticipantActivityPerformance` | `QuestionResponse`, `ElementInstance`, `PracticeQuiz` / `MicroLearning` |
-| `ActivityProgress` | `Participation`, `QuestionResponse`, `ElementInstance` |
-| `ParticipantChatAnalytics` | `ChatMessage`, `ChatThread`, `Chatbot`, `ChatUsageCredits`, `ChatAttachment` |
-| `AggregatedChatbotAnalytics` | `ChatMessage`, `ChatThread`, `Chatbot`, `ChatUsageCredits` |
-| `ChatTopicCluster` | `ChatMessage`, `ChatThread` |
-| `ParticipantChatOutcome` | `ParticipantChatAnalytics`, `ParticipantPerformance`, `Participation` |
-| `ParticipantLiveQuizAnalytics` | `LiveQuiz`, `ElementBlock`, `ElementInstance`, `LiveQuizResponse` |
-| `AggregatedLiveQuizAnalytics` | `ParticipantLiveQuizAnalytics` |
-| `PlatformSemesterAnalytics` | `QuestionResponse`, `LiveQuizResponse`, `ChatMessage`, `ChatThread`, `Chatbot`, `LiveQuiz`, `Participation`, `Course` |
+| Analytics table                  | Source tables                                                                                                                                      |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ParticipantAnalytics`           | `QuestionResponse`, `QuestionResponseDetail`, `Participation`                                                                                      |
+| `AggregatedAnalytics`            | `ParticipantAnalytics` (same window)                                                                                                               |
+| `ParticipantCourseAnalytics`     | `QuestionResponse`, `Participation`                                                                                                                |
+| `AggregatedCourseAnalytics`      | `ParticipantCourseAnalytics`, plus modality counts from `Chatbot` / `PracticeQuiz` / `MicroLearning` / `LiveQuiz` / `ChatUsageCredits` (script 13) |
+| `ParticipantPerformance`         | `QuestionResponse`, `QuestionResponseDetail`                                                                                                       |
+| `InstancePerformance`            | `QuestionResponse`, `QuestionResponseDetail`, `ElementInstance`                                                                                    |
+| `ActivityPerformance`            | `InstancePerformance`, `PracticeQuiz` / `MicroLearning`                                                                                            |
+| `ParticipantActivityPerformance` | `QuestionResponse`, `ElementInstance`, `PracticeQuiz` / `MicroLearning`                                                                            |
+| `ActivityProgress`               | `Participation`, `QuestionResponse`, `ElementInstance`                                                                                             |
+| `ParticipantChatAnalytics`       | `ChatMessage`, `ChatThread`, `Chatbot`, `ChatUsageCredits`, `ChatAttachment`                                                                       |
+| `AggregatedChatbotAnalytics`     | `ChatMessage`, `ChatThread`, `Chatbot`, `ChatUsageCredits`                                                                                         |
+| `ChatTopicCluster`               | `ChatMessage`, `ChatThread`                                                                                                                        |
+| `ParticipantChatOutcome`         | `ParticipantChatAnalytics`, `ParticipantPerformance`, `Participation`                                                                              |
+| `ParticipantLiveQuizAnalytics`   | `LiveQuiz`, `ElementBlock`, `ElementInstance`, `LiveQuizResponse`                                                                                  |
+| `AggregatedLiveQuizAnalytics`    | `ParticipantLiveQuizAnalytics`                                                                                                                     |
+| `PlatformSemesterAnalytics`      | `QuestionResponse`, `LiveQuizResponse`, `ChatMessage`, `ChatThread`, `Chatbot`, `LiveQuiz`, `Participation`, `Course`                              |
 
 ## Related references
 

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -146,6 +146,13 @@ It registers the non-mutating `learning-analytics-native-proof` task plus two co
 
 Both DAGs call the existing Python script entry points in-process with immutable per-run configuration and cooperative cancellation. `ANALYTICS_ALLOW_FULL=1` is required for the full DAG and remains unset by default. TypeScript retains only the GraphQL/manual event producers and the `scan-ended-courses` task. It does not register an analytics DAG or spawn Python.
 
+Incremental chat stages keep the normal 14-day window for unaffected courses.
+If current disclaimer consent changed, they purge now-ineligible participant
+rows across retained history and rebuild only the affected courses from the
+earliest affected message or aggregate window. The course chat watermark
+coordinates participant and aggregate cleanup even when those Hatchet tasks
+run in parallel.
+
 Cutover and rollback are cold: stop the current owner before starting another worker image so exactly one analytics DAG consumes these events.
 
 See the [Learning Analytics Operations](../../docs/learning-analytics-operations.md)

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -150,8 +150,10 @@ Incremental chat stages keep the normal 14-day window for unaffected courses.
 If current disclaimer consent changed, they purge now-ineligible participant
 rows across retained history and rebuild only the affected courses from the
 earliest affected message or aggregate window. The course chat watermark
-coordinates participant and aggregate cleanup even when those Hatchet tasks
-run in parallel.
+is the durable handoff from the participant stage to its aggregate child,
+preventing a completed aggregate task from swallowing a later consent cleanup.
+The final marker uses Hatchet's immutable workflow-creation time, so consent
+changes during a run remain visible to the next reconciliation.
 
 Cutover and rollback are cold: stop the current owner before starting another worker image so exactly one analytics DAG consumes these events.
 

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -26,6 +26,8 @@ The following commands are available through PNPM:
 ## Pipeline scripts
 
 The `src/scripts/` directory contains numbered scripts that form the analytics pipeline. Run them in order via `./_initialize_analytics.sh <target>` (target = `dev` | `qa` | `prd`; defaults to `dev`).
+The launcher exports one immutable `ANALYTICS_CHAT_CUTOFF` for all scripts.
+Do not run script 99 by itself: it fails closed without that shared cutoff.
 
 For per-table column-level documentation (purpose, grain, source data, computed columns) see [`ANALYTICS.md`](./ANALYTICS.md).
 
@@ -154,6 +156,9 @@ is the durable handoff from the participant stage to its aggregate child,
 preventing a completed aggregate task from swallowing a later consent cleanup.
 The final marker uses Hatchet's immutable workflow-creation time, so consent
 changes during a run remain visible to the next reconciliation.
+Finalize runs leave `analyticsFinalizedAt` unset when such a change is pending;
+the ended-course scanner then schedules a follow-up run that can converge
+before the course becomes terminal.
 
 Cutover and rollback are cold: stop the current owner before starting another worker image so exactly one analytics DAG consumes these events.
 

--- a/apps/analytics/_initialize_analytics.sh
+++ b/apps/analytics/_initialize_analytics.sh
@@ -16,6 +16,11 @@ case "$TARGET" in
   *)    echo "Unknown target: $TARGET (expected: dev | qa | prd)" >&2; exit 64 ;;
 esac
 
+# All scripts in one launcher invocation share this immutable UTC cutoff. The
+# final validity marker uses it so consent changes committed while the pipeline
+# is running remain visible to the next reconciliation.
+export ANALYTICS_CHAT_CUTOFF="${ANALYTICS_CHAT_CUTOFF:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+
 SCRIPTS=(
   src.scripts.0_initial_participant_analytics
   src.scripts.1_initial_aggregated_analytics

--- a/apps/analytics/_initialize_analytics.sh
+++ b/apps/analytics/_initialize_analytics.sh
@@ -19,7 +19,10 @@ esac
 # All scripts in one launcher invocation share this immutable UTC cutoff. The
 # final validity marker uses it so consent changes committed while the pipeline
 # is running remain visible to the next reconciliation.
-export ANALYTICS_CHAT_CUTOFF="${ANALYTICS_CHAT_CUTOFF:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+if [[ -z "${ANALYTICS_CHAT_CUTOFF:-}" ]]; then
+  ANALYTICS_CHAT_CUTOFF="$(uv run python -m src.analytics_cutoff)"
+  export ANALYTICS_CHAT_CUTOFF
+fi
 
 SCRIPTS=(
   src.scripts.0_initial_participant_analytics

--- a/apps/analytics/src/analytics_cutoff.py
+++ b/apps/analytics/src/analytics_cutoff.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta, timezone
+
+DATABASE_TIMESTAMP_RESOLUTION = timedelta(milliseconds=1)
+
+
+def database_safe_cutoff(created_at: datetime) -> str:
+    """Return a conservative UTC cutoff for PostgreSQL TIMESTAMP(3) columns."""
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    utc_created_at = created_at.astimezone(timezone.utc)
+    millisecond_floor = utc_created_at.replace(microsecond=(utc_created_at.microsecond // 1000) * 1000)
+    conservative_cutoff = millisecond_floor - DATABASE_TIMESTAMP_RESOLUTION
+    return conservative_cutoff.isoformat(timespec="milliseconds")
+
+
+if __name__ == "__main__":
+    print(database_safe_cutoff(datetime.now(timezone.utc)))

--- a/apps/analytics/src/hatchet_worker.py
+++ b/apps/analytics/src/hatchet_worker.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -90,6 +91,16 @@ def resolve_run_config(
     )
 
 
+def workflow_run_cutoff(ctx: Context) -> str:
+    """Return the immutable creation time shared by every task in this run."""
+    created_at = ctx.runs_client.get(ctx.workflow_run_id).run.created_at
+    if created_at is None:
+        raise RuntimeError("Hatchet workflow run has no creation timestamp")
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    return created_at.astimezone(timezone.utc).isoformat()
+
+
 def register_native_workflows(
     hatchet: Hatchet,
     *,
@@ -162,6 +173,11 @@ def register_native_workflows(
                 )
                 if full_only and config.mode != "full":
                     raise ValueError(f"{FULL_ANALYTICS_WORKFLOW_NAME} requires mode=full")
+                if key == "s99":
+                    config = replace(
+                        config,
+                        chat_analytics_cutoff=workflow_run_cutoff(ctx),
+                    )
                 try:
                     script_runner(ANALYTICS_SCRIPTS[key], config, ctx.done)
                 except AnalyticsRunCancelled as exc:
@@ -177,7 +193,12 @@ def register_native_workflows(
         add_task("s6", "s6-activity-progress")
         add_task("s7", "s7-participant-activity-perf")
         add_task("s8", "s8-chat-analytics", execution_timeout="60m")
-        add_task("s9", "s9-aggregated-chatbot-analytics", execution_timeout="60m")
+        add_task(
+            "s9",
+            "s9-aggregated-chatbot-analytics",
+            parents=("s8",),
+            execution_timeout="60m",
+        )
         add_task(
             "s10",
             "s10-chat-topic-clustering",

--- a/apps/analytics/src/hatchet_worker.py
+++ b/apps/analytics/src/hatchet_worker.py
@@ -14,6 +14,7 @@ from hatchet_sdk import (
 )
 from pydantic import BaseModel, ConfigDict
 
+from src.analytics_cutoff import database_safe_cutoff
 from src.analytics_runtime import run_analytics_module
 from src.modules.utils import (
     AnalyticsMode,
@@ -92,13 +93,11 @@ def resolve_run_config(
 
 
 def workflow_run_cutoff(ctx: Context) -> str:
-    """Return the immutable creation time shared by every task in this run."""
+    """Return one conservative, immutable cutoff shared by every task."""
     created_at = ctx.runs_client.get(ctx.workflow_run_id).run.created_at
     if created_at is None:
         raise RuntimeError("Hatchet workflow run has no creation timestamp")
-    if created_at.tzinfo is None:
-        created_at = created_at.replace(tzinfo=timezone.utc)
-    return created_at.astimezone(timezone.utc).isoformat()
+    return database_safe_cutoff(created_at)
 
 
 def register_native_workflows(

--- a/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics.sql
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics.sql
@@ -11,6 +11,13 @@ WITH params AS (
   SELECT CAST(:win_start AS timestamptz) AS win_start,
          CAST(:win_end AS timestamptz) AS win_end
 ),
+eligible_pairs AS (
+  SELECT cuc."participantId", cuc."chatbotId"
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  WHERE cuc."acceptedDisclaimerId" = cb."disclaimerId"
+    AND cuc."disclaimerDeclined" = false
+),
 messages AS (
   SELECT
     m.id, m.role, m."chatMode", m."modelId", m."reasoningEffort",
@@ -19,6 +26,8 @@ messages AS (
   FROM "ChatMessage" m
   JOIN "ChatThread" ct ON ct.id = m."threadId"
   JOIN "Chatbot" cb   ON cb.id = ct."chatbotId"
+  JOIN eligible_pairs ep
+    ON ep."participantId" = ct."participantId" AND ep."chatbotId" = ct."chatbotId"
   CROSS JOIN params
   WHERE m."createdAt" >= params.win_start AND m."createdAt" < params.win_end
     /*COURSE_FILTER*/

--- a/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics_weekly.sql
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics_weekly.sql
@@ -13,6 +13,13 @@ WITH params AS (
   SELECT CAST(:win_start AS timestamptz) AS win_start,
          CAST(:win_end AS timestamptz) AS win_end
 ),
+eligible_pairs AS (
+  SELECT cuc."participantId", cuc."chatbotId"
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  WHERE cuc."acceptedDisclaimerId" = cb."disclaimerId"
+    AND cuc."disclaimerDeclined" = false
+),
 messages AS (
   SELECT
     m.id, m.role, m."chatMode", m."modelId", m."reasoningEffort",
@@ -21,6 +28,8 @@ messages AS (
   FROM "ChatMessage" m
   JOIN "ChatThread" ct ON ct.id = m."threadId"
   JOIN "Chatbot" cb   ON cb.id = ct."chatbotId"
+  JOIN eligible_pairs ep
+    ON ep."participantId" = ct."participantId" AND ep."chatbotId" = ct."chatbotId"
   CROSS JOIN params
   WHERE m."createdAt" >= params.win_start AND m."createdAt" < params.win_end
     /*COURSE_FILTER*/

--- a/apps/analytics/src/modules/aggregated_chat_analytics/compute_aggregated_chatbot_analytics.py
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/compute_aggregated_chatbot_analytics.py
@@ -9,6 +9,12 @@ _DIR = os.path.dirname(__file__)
 _SQL_DEFAULT = load_sql(os.path.join(_DIR, "aggregated_chatbot_analytics.sql"))
 _SQL_WEEKLY = load_sql(os.path.join(_DIR, "aggregated_chatbot_analytics_weekly.sql"))
 _PLACEHOLDER = "/*COURSE_FILTER*/"
+_DELETE_SQL = """
+DELETE FROM "AggregatedChatbotAnalytics"
+WHERE "type" = CAST(:analytics_type AS "AnalyticsType")
+  AND "timestamp" = CAST(:ts AS date)
+  /*COURSE_FILTER*/
+"""
 
 __all__ = ["compute_aggregated_chatbot_analytics", "COURSE_TIMESTAMP"]
 
@@ -20,6 +26,11 @@ def _prepare_sql(template: str, course_ids: list[str] | None) -> str:
         else render_uuid_in_clause('cb."courseId"', course_ids)
     )
     return template.replace(_PLACEHOLDER, clause)
+
+
+def _prepare_delete_sql(course_ids: list[str] | None) -> str:
+    clause = "" if course_ids is None else render_uuid_in_clause('"courseId"', course_ids)
+    return _DELETE_SQL.replace(_PLACEHOLDER, clause)
 
 
 def compute_aggregated_chatbot_analytics(
@@ -46,6 +57,8 @@ def compute_aggregated_chatbot_analytics(
             f"{win_start}..{win_end} -> {timestamp}"
         )
 
+    params = {"analytics_type": analytics_type, "ts": timestamp}
+    session.execute(text(_prepare_delete_sql(course_ids)), params)
     if analytics_type == "WEEKLY":
         result = session.execute(
             text(_prepare_sql(_SQL_WEEKLY, course_ids)),
@@ -54,11 +67,10 @@ def compute_aggregated_chatbot_analytics(
     else:
         result = session.execute(
             text(_prepare_sql(_SQL_DEFAULT, course_ids)),
-            {
+            params
+            | {
                 "win_start": win_start,
                 "win_end": win_end,
-                "analytics_type": analytics_type,
-                "ts": timestamp,
             },
         )
     session.commit()

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from src.modules.utils import (
     analytics_mode,
+    analytics_run_config_from_env,
     load_sql,
     render_uuid_in_clause,
     scoped_course_ids,
@@ -14,8 +15,7 @@ _SQL = load_sql(os.path.join(os.path.dirname(__file__), "mark_analytics_valid.sq
 
 _SET_PLACEHOLDER = "/*COURSE_FINALIZE_SET*/"
 _FILTER_PLACEHOLDER = "/*COURSE_FINALIZE_FILTER*/"
-_BYPASS_PLACEHOLDER = "/*COURSE_FINALIZE_BYPASS*/"
-_CHAT_BYPASS_PLACEHOLDER = "/*CHAT_SCOPE_BYPASS*/"
+_SCOPE_BYPASS_PLACEHOLDER = "/*COURSE_SCOPE_BYPASS*/"
 
 
 def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
@@ -32,8 +32,7 @@ def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
         filter_clause += ' AND c."analyticsFinalizedAt" IS NULL'
     return (
         _SQL.replace(_SET_PLACEHOLDER, set_clause)
-        .replace(_BYPASS_PLACEHOLDER, bypass_clause)
-        .replace(_CHAT_BYPASS_PLACEHOLDER, bypass_clause)
+        .replace(_SCOPE_BYPASS_PLACEHOLDER, bypass_clause)
         .replace(_FILTER_PLACEHOLDER, filter_clause)
     )
 
@@ -41,8 +40,9 @@ def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
 def mark_analytics_valid(session: Session, verbose: bool = False):
     """Flip Course.areAnalyticsValid for every course that received analytics rows.
 
-    Also sets Course.chatAnalyticsValidAt on courses with ParticipantChatAnalytics
-    rows. Only courses actually covered by the run are touched (per §3.8
+    Also sets Course.chatAnalyticsValidAt for scoped courses, including a valid
+    empty chat result. Unscoped runs set it only for courses with participant
+    chat rows. Only courses actually covered by the run are touched (per §3.8
     safeguard).
 
     When ``ANALYTICS_MODE=finalize`` and ``ANALYTICS_COURSE_IDS`` is set, the
@@ -54,11 +54,13 @@ def mark_analytics_valid(session: Session, verbose: bool = False):
     finalize = mode == "finalize" and bool(course_ids)
 
     if verbose:
-        print(
-            f"[analytics_validity] mode={mode} finalize={finalize} "
-            f"course_ids={len(course_ids) if course_ids else 0}"
-        )
-    result = session.execute(text(_render_sql(finalize, course_ids)))
+        print(f"[analytics_validity] mode={mode} finalize={finalize} course_ids={len(course_ids) if course_ids else 0}")
+    result = session.execute(
+        text(_render_sql(finalize, course_ids)),
+        {
+            "chat_analytics_cutoff": analytics_run_config_from_env().chat_analytics_cutoff,
+        },
+    )
     session.commit()
     rows = result.rowcount or 0
     if verbose:

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
@@ -15,25 +15,25 @@ _SQL = load_sql(os.path.join(os.path.dirname(__file__), "mark_analytics_valid.sq
 _SET_PLACEHOLDER = "/*COURSE_FINALIZE_SET*/"
 _FILTER_PLACEHOLDER = "/*COURSE_FINALIZE_FILTER*/"
 _BYPASS_PLACEHOLDER = "/*COURSE_FINALIZE_BYPASS*/"
+_CHAT_BYPASS_PLACEHOLDER = "/*CHAT_SCOPE_BYPASS*/"
 
 
 def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
     set_clause = ""
     filter_clause = ""
-    # ``false`` keeps ``quiz OR chat OR false`` == ``quiz OR chat`` for normal
-    # runs; ``true`` in finalize mode lets the UPDATE touch courses with zero
-    # analytics rows (otherwise the scanner would re-emit courseEnded daily
-    # forever).
-    bypass_clause = "false"
+    # A scoped run covers every selected course even if current consent yields
+    # zero chat rows. Marking that empty result prevents a privacy rebuild on
+    # every later incremental run.
+    bypass_clause = "true" if course_ids is not None else "false"
     if course_ids is not None:
         filter_clause = render_uuid_in_clause("c.id", course_ids)
     if finalize:
         set_clause = '"analyticsFinalizedAt" = NOW(),'
         filter_clause += ' AND c."analyticsFinalizedAt" IS NULL'
-        bypass_clause = "true"
     return (
         _SQL.replace(_SET_PLACEHOLDER, set_clause)
         .replace(_BYPASS_PLACEHOLDER, bypass_clause)
+        .replace(_CHAT_BYPASS_PLACEHOLDER, bypass_clause)
         .replace(_FILTER_PLACEHOLDER, filter_clause)
     )
 

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
@@ -39,7 +39,6 @@ def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
     ) THEN c."analyticsFinalizedAt"
     ELSE CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
   END,"""
-        filter_clause += ' AND c."analyticsFinalizedAt" IS NULL'
     return (
         _SQL.replace(_SET_PLACEHOLDER, set_clause)
         .replace(_SCOPE_BYPASS_PLACEHOLDER, bypass_clause)
@@ -57,9 +56,10 @@ def mark_analytics_valid(session: Session, verbose: bool = False):
     safeguard).
 
     When ``ANALYTICS_MODE=finalize`` and ``ANALYTICS_COURSE_IDS`` is set, the
-    per-course terminal marker ``analyticsFinalizedAt`` is stamped for scoped
-    courses only when no chat-consent change arrived after the immutable run
-    cutoff. Otherwise the scanner can schedule a follow-up.
+    per-course terminal marker ``analyticsFinalizedAt`` is stamped or refreshed
+    for scoped courses only when no chat-consent change arrived after the
+    immutable run cutoff. Already-finalized courses remain eligible so the
+    scanner can reconcile late privacy changes.
     """
     config = analytics_run_config_from_env()
     if config.chat_analytics_cutoff is None:

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
@@ -4,7 +4,6 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.modules.utils import (
-    analytics_mode,
     analytics_run_config_from_env,
     load_sql,
     render_uuid_in_clause,
@@ -16,23 +15,35 @@ _SQL = load_sql(os.path.join(os.path.dirname(__file__), "mark_analytics_valid.sq
 _SET_PLACEHOLDER = "/*COURSE_FINALIZE_SET*/"
 _FILTER_PLACEHOLDER = "/*COURSE_FINALIZE_FILTER*/"
 _SCOPE_BYPASS_PLACEHOLDER = "/*COURSE_SCOPE_BYPASS*/"
+_PENDING_SCOPE_PLACEHOLDER = "/*PENDING_CHAT_COURSE_FILTER*/"
 
 
 def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
     set_clause = ""
     filter_clause = ""
+    pending_scope = ""
     # A scoped run covers every selected course even if current consent yields
     # zero chat rows. Marking that empty result prevents a privacy rebuild on
     # every later incremental run.
     bypass_clause = "true" if course_ids is not None else "false"
     if course_ids is not None:
         filter_clause = render_uuid_in_clause("c.id", course_ids)
+        pending_scope = render_uuid_in_clause('cb."courseId"', course_ids)
     if finalize:
-        set_clause = '"analyticsFinalizedAt" = NOW(),'
+        set_clause = """
+  "analyticsFinalizedAt" = CASE
+    WHEN EXISTS (
+      SELECT 1
+      FROM pending_chat_changes pending
+      WHERE pending."courseId" = c.id
+    ) THEN c."analyticsFinalizedAt"
+    ELSE CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+  END,"""
         filter_clause += ' AND c."analyticsFinalizedAt" IS NULL'
     return (
         _SQL.replace(_SET_PLACEHOLDER, set_clause)
         .replace(_SCOPE_BYPASS_PLACEHOLDER, bypass_clause)
+        .replace(_PENDING_SCOPE_PLACEHOLDER, pending_scope)
         .replace(_FILTER_PLACEHOLDER, filter_clause)
     )
 
@@ -46,11 +57,15 @@ def mark_analytics_valid(session: Session, verbose: bool = False):
     safeguard).
 
     When ``ANALYTICS_MODE=finalize`` and ``ANALYTICS_COURSE_IDS`` is set, the
-    per-course terminal marker ``analyticsFinalizedAt`` is stamped NOW() for the
-    scoped courses — the scanner's one-shot finalisation path.
+    per-course terminal marker ``analyticsFinalizedAt`` is stamped for scoped
+    courses only when no chat-consent change arrived after the immutable run
+    cutoff. Otherwise the scanner can schedule a follow-up.
     """
-    mode = analytics_mode()
-    course_ids = scoped_course_ids(session)
+    config = analytics_run_config_from_env()
+    if config.chat_analytics_cutoff is None:
+        raise RuntimeError("chat analytics validity requires the immutable workflow cutoff")
+    mode = config.mode
+    course_ids = scoped_course_ids(session, config)
     finalize = mode == "finalize" and bool(course_ids)
 
     if verbose:
@@ -58,7 +73,7 @@ def mark_analytics_valid(session: Session, verbose: bool = False):
     result = session.execute(
         text(_render_sql(finalize, course_ids)),
         {
-            "chat_analytics_cutoff": analytics_run_config_from_env().chat_analytics_cutoff,
+            "chat_analytics_cutoff": config.chat_analytics_cutoff,
         },
     )
     session.commit()

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.py
@@ -25,10 +25,11 @@ def _render_sql(finalize: bool, course_ids: list[str] | None) -> str:
     # analytics rows (otherwise the scanner would re-emit courseEnded daily
     # forever).
     bypass_clause = "false"
+    if course_ids is not None:
+        filter_clause = render_uuid_in_clause("c.id", course_ids)
     if finalize:
         set_clause = '"analyticsFinalizedAt" = NOW(),'
-        scoped = render_uuid_in_clause("c.id", course_ids or [])
-        filter_clause = f'{scoped} AND c."analyticsFinalizedAt" IS NULL'
+        filter_clause += ' AND c."analyticsFinalizedAt" IS NULL'
         bypass_clause = "true"
     return (
         _SQL.replace(_SET_PLACEHOLDER, set_clause)
@@ -49,7 +50,7 @@ def mark_analytics_valid(session: Session, verbose: bool = False):
     scoped courses — the scanner's one-shot finalisation path.
     """
     mode = analytics_mode()
-    course_ids = scoped_course_ids(session) if mode == "finalize" else None
+    course_ids = scoped_course_ids(session)
     finalize = mode == "finalize" and bool(course_ids)
 
     if verbose:

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.sql
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.sql
@@ -1,6 +1,6 @@
--- Mark Course.areAnalyticsValid + analyticsLastComputedAt for courses that have any
--- freshly-populated quiz-analytics row, and Course.chatAnalyticsValidAt only for
--- courses that have at least one ParticipantChatAnalytics row.
+-- Mark Course.areAnalyticsValid + analyticsLastComputedAt for courses covered by
+-- fresh analytics. Scoped runs also stamp a valid empty chat result; unscoped
+-- runs stamp Course.chatAnalyticsValidAt only for courses with chat rows.
 --
 -- When the pipeline runs in finalize mode, the handler injects an
 -- ``AND c.id IN (<csv>)`` clause into /*COURSE_FINALIZE_FILTER*/ and turns
@@ -21,11 +21,12 @@ UPDATE "Course" c SET
   "analyticsLastComputedAt" = NOW(),
   /*COURSE_FINALIZE_SET*/
   "chatAnalyticsValidAt"    = CASE
-    WHEN /*CHAT_SCOPE_BYPASS*/
-      OR EXISTS (SELECT 1 FROM chat_courses cc WHERE cc."courseId" = c.id) THEN NOW()
+    WHEN /*COURSE_SCOPE_BYPASS*/
+      OR EXISTS (SELECT 1 FROM chat_courses cc WHERE cc."courseId" = c.id)
+      THEN COALESCE(CAST(:chat_analytics_cutoff AS timestamptz), NOW())
     ELSE c."chatAnalyticsValidAt"
   END
 WHERE (EXISTS (SELECT 1 FROM quiz_courses qc WHERE qc."courseId" = c.id)
    OR EXISTS (SELECT 1 FROM chat_courses cc WHERE cc."courseId" = c.id)
-   OR /*COURSE_FINALIZE_BYPASS*/)
+   OR /*COURSE_SCOPE_BYPASS*/)
   /*COURSE_FINALIZE_FILTER*/;

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.sql
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.sql
@@ -21,7 +21,8 @@ UPDATE "Course" c SET
   "analyticsLastComputedAt" = NOW(),
   /*COURSE_FINALIZE_SET*/
   "chatAnalyticsValidAt"    = CASE
-    WHEN EXISTS (SELECT 1 FROM chat_courses cc WHERE cc."courseId" = c.id) THEN NOW()
+    WHEN /*CHAT_SCOPE_BYPASS*/
+      OR EXISTS (SELECT 1 FROM chat_courses cc WHERE cc."courseId" = c.id) THEN NOW()
     ELSE c."chatAnalyticsValidAt"
   END
 WHERE (EXISTS (SELECT 1 FROM quiz_courses qc WHERE qc."courseId" = c.id)

--- a/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.sql
+++ b/apps/analytics/src/modules/analytics_validity/mark_analytics_valid.sql
@@ -3,10 +3,9 @@
 -- runs stamp Course.chatAnalyticsValidAt only for courses with chat rows.
 --
 -- When the pipeline runs in finalize mode, the handler injects an
--- ``AND c.id IN (<csv>)`` clause into /*COURSE_FINALIZE_FILTER*/ and turns
--- /*COURSE_FINALIZE_SET*/ into ``"analyticsFinalizedAt" = NOW(),``. In the
--- default (incremental / full) mode the placeholders are empty and only the
--- live watermarks are updated.
+-- ``AND c.id IN (<csv>)`` clause into /*COURSE_FINALIZE_FILTER*/. Finalization
+-- stays pending when consent changed after this workflow's immutable cutoff.
+-- In incremental / full mode the finalize placeholder is empty.
 --
 -- Run as the last step of the analytics pipeline (per §3.8). Idempotent.
 
@@ -15,6 +14,26 @@ WITH quiz_courses AS (
 ),
 chat_courses AS (
   SELECT DISTINCT "courseId" FROM "ParticipantChatAnalytics"
+),
+pending_chat_changes AS (
+  SELECT DISTINCT cb."courseId"
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  WHERE (
+    cuc."disclaimerAcceptedAt"
+          > CAST(:chat_analytics_cutoff AS timestamptz) AT TIME ZONE 'UTC'
+     OR (
+       cuc."disclaimerDeclined" = true
+       AND cuc."updatedAt"
+             > CAST(:chat_analytics_cutoff AS timestamptz) AT TIME ZONE 'UTC'
+     )
+     OR (
+       cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
+       AND cb."updatedAt"
+             > CAST(:chat_analytics_cutoff AS timestamptz) AT TIME ZONE 'UTC'
+     )
+  )
+  /*PENDING_CHAT_COURSE_FILTER*/
 )
 UPDATE "Course" c SET
   "areAnalyticsValid"       = true,
@@ -23,7 +42,7 @@ UPDATE "Course" c SET
   "chatAnalyticsValidAt"    = CASE
     WHEN /*COURSE_SCOPE_BYPASS*/
       OR EXISTS (SELECT 1 FROM chat_courses cc WHERE cc."courseId" = c.id)
-      THEN COALESCE(CAST(:chat_analytics_cutoff AS timestamptz), NOW())
+      THEN CAST(:chat_analytics_cutoff AS timestamptz) AT TIME ZONE 'UTC'
     ELSE c."chatAnalyticsValidAt"
   END
 WHERE (EXISTS (SELECT 1 FROM quiz_courses qc WHERE qc."courseId" = c.id)

--- a/apps/analytics/src/modules/chat_analytics/compute_participant_chat_analytics.py
+++ b/apps/analytics/src/modules/chat_analytics/compute_participant_chat_analytics.py
@@ -7,6 +7,12 @@ from src.modules.utils import COURSE_TIMESTAMP, load_sql, render_uuid_in_clause
 
 _SQL = load_sql(os.path.join(os.path.dirname(__file__), "participant_chat_analytics.sql"))
 _COURSE_FILTER_PLACEHOLDER = "/*COURSE_FILTER*/"
+_DELETE_SQL = """
+DELETE FROM "ParticipantChatAnalytics"
+WHERE "type" = CAST(:analytics_type AS "AnalyticsType")
+  AND "timestamp" = CAST(:ts AS date)
+  /*COURSE_FILTER*/
+"""
 _ATTACHMENT_ROLLUP_PLACEHOLDER = "/*ATTACHMENT_ROLLUP_CTE*/"
 _TABLE_EXISTS_SQL = text(
     """
@@ -76,6 +82,11 @@ def _prepare_sql(
     )
 
 
+def _prepare_delete_sql(course_ids: list[str] | None) -> str:
+    clause = "" if course_ids is None else render_uuid_in_clause('"courseId"', course_ids)
+    return _DELETE_SQL.replace(_COURSE_FILTER_PLACEHOLDER, clause)
+
+
 def compute_participant_chat_analytics(
     session: Session,
     win_start: str,
@@ -96,6 +107,11 @@ def compute_participant_chat_analytics(
     if verbose and not include_attachments:
         print("[chat_analytics] ChatAttachment missing; defaulting attachmentCount to 0")
 
+    params = {
+        "analytics_type": analytics_type,
+        "ts": timestamp,
+    }
+    session.execute(text(_prepare_delete_sql(course_ids)), params)
     result = session.execute(
         text(
             _prepare_sql(
@@ -104,11 +120,10 @@ def compute_participant_chat_analytics(
                 include_attachments=include_attachments,
             )
         ),
-        {
+        params
+        | {
             "win_start": win_start,
             "win_end": win_end,
-            "analytics_type": analytics_type,
-            "ts": timestamp,
         },
     )
     session.commit()

--- a/apps/analytics/src/modules/chat_analytics/consent_reconciliation.py
+++ b/apps/analytics/src/modules/chat_analytics/consent_reconciliation.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from src.dryrun import buffer_registry
 from src.modules.utils import render_uuid_in_clause
 
 _CURRENT_SCOPE_PLACEHOLDER = "/*CURRENT_COURSE_FILTER*/"
@@ -142,6 +143,8 @@ def plan_chat_analytics_runs(
         return []
     if window_since is None:
         return [ChatAnalyticsRun(course_ids=course_ids, window_since=None)]
+    if buffer_registry.is_active():
+        return [ChatAnalyticsRun(course_ids=course_ids, window_since=window_since)]
     if course_ids is None:
         return [ChatAnalyticsRun(course_ids=None, window_since=None)]
 
@@ -179,6 +182,8 @@ def purge_ineligible_participant_chat_analytics(
     course_ids: list[str] | None,
 ) -> int:
     """Remove all retained participant rows that current consent no longer permits."""
+    if buffer_registry.is_active():
+        return 0
     scope = "" if course_ids is None else render_uuid_in_clause('pca."courseId"', course_ids)
     result = session.execute(text(_PURGE_INELIGIBLE_SQL.replace(_PURGE_SCOPE_PLACEHOLDER, scope)))
     session.commit()

--- a/apps/analytics/src/modules/chat_analytics/consent_reconciliation.py
+++ b/apps/analytics/src/modules/chat_analytics/consent_reconciliation.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from src.modules.utils import render_uuid_in_clause
+
+_CURRENT_SCOPE_PLACEHOLDER = "/*CURRENT_COURSE_FILTER*/"
+_STALE_SCOPE_PLACEHOLDER = "/*STALE_COURSE_FILTER*/"
+_PURGE_SCOPE_PLACEHOLDER = "/*PURGE_COURSE_FILTER*/"
+
+_HISTORY_REBUILD_SQL = """
+WITH changed_pairs AS (
+  SELECT
+    cuc."participantId",
+    cuc."chatbotId",
+    cb."courseId"
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  JOIN "Course" c ON c.id = cb."courseId"
+  WHERE (
+    c."chatAnalyticsValidAt" IS NULL
+    OR cuc."disclaimerAcceptedAt" > c."chatAnalyticsValidAt"
+    OR (
+      cuc."disclaimerDeclined" = true
+      AND cuc."updatedAt" > c."chatAnalyticsValidAt"
+    )
+    OR (
+      cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
+      AND cb."updatedAt" > c."chatAnalyticsValidAt"
+    )
+  )
+  /*CURRENT_COURSE_FILTER*/
+
+  UNION
+
+  SELECT
+    pca."participantId",
+    pca."chatbotId",
+    pca."courseId"
+  FROM "ParticipantChatAnalytics" pca
+  JOIN "Chatbot" cb ON cb.id = pca."chatbotId"
+  LEFT JOIN "ChatUsageCredits" cuc
+    ON cuc."participantId" = pca."participantId"
+   AND cuc."chatbotId" = pca."chatbotId"
+  WHERE (
+    cuc."participantId" IS NULL
+    OR cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
+    OR cuc."disclaimerDeclined" = true
+  )
+  /*STALE_COURSE_FILTER*/
+),
+affected_dates AS (
+  SELECT
+    cp."courseId",
+    m."createdAt"::date AS "affectedDate"
+  FROM changed_pairs cp
+  JOIN "ChatThread" ct
+    ON ct."participantId" = cp."participantId"
+   AND ct."chatbotId" = cp."chatbotId"
+  JOIN "ChatMessage" m ON m."threadId" = ct.id
+  WHERE m."createdAt" < CAST(:incremental_since AS timestamptz)
+
+  UNION ALL
+
+  SELECT
+    cp."courseId",
+    aca."timestamp" AS "affectedDate"
+  FROM changed_pairs cp
+  JOIN "AggregatedChatbotAnalytics" aca
+    ON aca."chatbotId" = cp."chatbotId"
+   AND aca."courseId" = cp."courseId"
+  WHERE aca."timestamp" < CAST(:incremental_since AS date)
+),
+affected_history AS (
+  SELECT
+    "courseId",
+    MIN("affectedDate") AS "windowSince"
+  FROM affected_dates
+  GROUP BY "courseId"
+)
+SELECT "courseId", "windowSince"
+FROM affected_history
+ORDER BY "courseId"
+"""
+
+_PURGE_INELIGIBLE_SQL = """
+WITH ineligible_rows AS MATERIALIZED (
+  SELECT pca."participantId", pca."chatbotId", pca."timestamp", pca."type", pca."courseId"
+  FROM "ParticipantChatAnalytics" pca
+  JOIN "Chatbot" cb ON cb.id = pca."chatbotId"
+  LEFT JOIN "ChatUsageCredits" cuc
+    ON cuc."participantId" = pca."participantId"
+   AND cuc."chatbotId" = pca."chatbotId"
+  WHERE (
+    cuc."participantId" IS NULL
+    OR cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
+    OR cuc."disclaimerDeclined" = true
+  )
+  /*PURGE_COURSE_FILTER*/
+),
+marked_courses AS (
+  UPDATE "Course" c
+  SET "chatAnalyticsValidAt" = NULL
+  WHERE c.id IN (SELECT DISTINCT "courseId" FROM ineligible_rows)
+  RETURNING c.id
+)
+DELETE FROM "ParticipantChatAnalytics" pca
+USING ineligible_rows stale
+JOIN marked_courses marked ON marked.id = stale."courseId"
+WHERE pca."participantId" = stale."participantId"
+  AND pca."chatbotId" = stale."chatbotId"
+  AND pca."timestamp" = stale."timestamp"
+  AND pca."type" = stale."type"
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class ChatAnalyticsRun:
+    course_ids: list[str] | None
+    window_since: str | None
+
+
+def _history_rebuild_sql(course_ids: list[str] | None) -> str:
+    current_scope = "" if course_ids is None else render_uuid_in_clause('cb."courseId"', course_ids)
+    stale_scope = "" if course_ids is None else render_uuid_in_clause('pca."courseId"', course_ids)
+    return _HISTORY_REBUILD_SQL.replace(
+        _CURRENT_SCOPE_PLACEHOLDER,
+        current_scope,
+    ).replace(_STALE_SCOPE_PLACEHOLDER, stale_scope)
+
+
+def plan_chat_analytics_runs(
+    session: Session,
+    course_ids: list[str] | None,
+    window_since: str | None,
+) -> list[ChatAnalyticsRun]:
+    """Split incremental chat work into privacy rebuild and recent scopes."""
+    if course_ids == []:
+        return []
+    if window_since is None:
+        return [ChatAnalyticsRun(course_ids=course_ids, window_since=None)]
+    if course_ids is None:
+        return [ChatAnalyticsRun(course_ids=None, window_since=None)]
+
+    rows = session.execute(
+        text(_history_rebuild_sql(course_ids)),
+        {"incremental_since": window_since},
+    ).mappings()
+    rebuild_rows = list(rows)
+    if not rebuild_rows:
+        return [ChatAnalyticsRun(course_ids=course_ids, window_since=window_since)]
+
+    rebuild_ids = [str(row["courseId"]) for row in rebuild_rows]
+    earliest = min(str(row["windowSince"]) for row in rebuild_rows)
+    rebuild_set = set(rebuild_ids)
+    recent_ids = [course_id for course_id in course_ids if course_id not in rebuild_set]
+
+    runs = [
+        ChatAnalyticsRun(
+            course_ids=rebuild_ids,
+            window_since=earliest,
+        )
+    ]
+    if recent_ids:
+        runs.append(
+            ChatAnalyticsRun(
+                course_ids=recent_ids,
+                window_since=window_since,
+            )
+        )
+    return runs
+
+
+def purge_ineligible_participant_chat_analytics(
+    session: Session,
+    course_ids: list[str] | None,
+) -> int:
+    """Remove all retained participant rows that current consent no longer permits."""
+    scope = "" if course_ids is None else render_uuid_in_clause('pca."courseId"', course_ids)
+    result = session.execute(text(_PURGE_INELIGIBLE_SQL.replace(_PURGE_SCOPE_PLACEHOLDER, scope)))
+    session.commit()
+    return result.rowcount or 0

--- a/apps/analytics/src/modules/chat_quiz_correlation/compute_chat_quiz_correlation.py
+++ b/apps/analytics/src/modules/chat_quiz_correlation/compute_chat_quiz_correlation.py
@@ -53,6 +53,9 @@ def report_source_counts(
     verbose: bool = False,
 ) -> None:
     """Report current source counts without rejecting a valid empty result."""
+    if not verbose:
+        return
+
     buffer_active = buffer_registry.is_active()
 
     if buffer_active:
@@ -66,9 +69,8 @@ def report_source_counts(
         perf_rows = session.execute(
             text(f'SELECT COUNT(*) AS n FROM "ParticipantPerformance" WHERE true {scope_clause}')
         ).scalar_one()
-    if verbose:
-        source = "buffer" if buffer_active else "db"
-        print(f"[chat_quiz_correlation] preconditions ({source}): chat_course_rows={chat_rows} perf_rows={perf_rows}")
+    source = "buffer" if buffer_active else "db"
+    print(f"[chat_quiz_correlation] source counts ({source}): chat_course_rows={chat_rows} perf_rows={perf_rows}")
 
 
 def _execute_participant_chat_outcomes(

--- a/apps/analytics/src/modules/chat_quiz_correlation/compute_chat_quiz_correlation.py
+++ b/apps/analytics/src/modules/chat_quiz_correlation/compute_chat_quiz_correlation.py
@@ -14,6 +14,11 @@ ChatDoseBucketLiteral = Literal["NONE", "LOW", "MED", "HIGH"]
 _DIR = os.path.dirname(__file__)
 _OUTCOME_SQL = os.path.join(_DIR, "participant_chat_outcome.sql")
 _UPDATE_SQL = os.path.join(_DIR, "update_has_chat_activity.sql")
+_DELETE_OUTCOMES_SQL = """
+DELETE FROM "ParticipantChatOutcome"
+WHERE true
+  /*COURSE_FILTER*/
+"""
 
 _OUTCOME_PLACEHOLDERS = {
     "/*CHAT_COURSE_FILTER*/": '"courseId"',
@@ -21,6 +26,7 @@ _OUTCOME_PLACEHOLDERS = {
     "/*COURSE_PERFORMANCE_FILTER*/": '"courseId"',
 }
 _UPDATE_PLACEHOLDERS = {"/*COURSE_FILTER*/": 'pca."courseId"'}
+_DELETE_OUTCOME_PLACEHOLDERS = {"/*COURSE_FILTER*/": '"courseId"'}
 
 
 def _load(path: str) -> str:
@@ -41,53 +47,40 @@ def _render_sql(
     return rendered
 
 
-class AnalyticsNotReadyError(RuntimeError):
-    """Raised when required upstream analytics tables are empty.
-
-    Script 11 joins ParticipantChatAnalytics (script 8) with ParticipantPerformance
-    (script 4). If either table is empty we abort loudly rather than writing
-    degenerate rows — per §3.5 the outcome build has a hard precondition on
-    upstream runs.
-    """
-
-
-def assert_preconditions(
+def report_source_counts(
     session: Session,
     course_ids: list[str] | None = None,
     verbose: bool = False,
 ) -> None:
+    """Report current source counts without rejecting a valid empty result."""
     buffer_active = buffer_registry.is_active()
 
     if buffer_active:
         chat_rows = len(_buffered_chat_course_rows(course_ids) or [])
         perf_rows = len(_buffered_performance_rows(course_ids) or [])
     else:
-        scope_clause = (
-            "" if course_ids is None else render_uuid_in_clause('"courseId"', course_ids)
-        )
+        scope_clause = "" if course_ids is None else render_uuid_in_clause('"courseId"', course_ids)
         chat_rows = session.execute(
-            text(
-                'SELECT COUNT(*) AS n FROM "ParticipantChatAnalytics" '
-                f'WHERE "type" = \'COURSE\' {scope_clause}'
-            )
+            text(f'SELECT COUNT(*) AS n FROM "ParticipantChatAnalytics" WHERE "type" = \'COURSE\' {scope_clause}')
         ).scalar_one()
         perf_rows = session.execute(
             text(f'SELECT COUNT(*) AS n FROM "ParticipantPerformance" WHERE true {scope_clause}')
         ).scalar_one()
     if verbose:
         source = "buffer" if buffer_active else "db"
-        print(
-            f"[chat_quiz_correlation] preconditions ({source}): "
-            f"chat_course_rows={chat_rows} perf_rows={perf_rows}"
-        )
-    if chat_rows == 0:
-        raise AnalyticsNotReadyError(
-            "ParticipantChatAnalytics (type=COURSE) is empty — run script 8 first."
-        )
-    if perf_rows == 0:
-        raise AnalyticsNotReadyError(
-            "ParticipantPerformance is empty — run script 4 first."
-        )
+        print(f"[chat_quiz_correlation] preconditions ({source}): chat_course_rows={chat_rows} perf_rows={perf_rows}")
+
+
+def _execute_participant_chat_outcomes(
+    session: Session,
+    course_ids: list[str] | None,
+):
+    sql = _render_sql(
+        _load(_OUTCOME_SQL),
+        course_ids=course_ids,
+        placeholders=_OUTCOME_PLACEHOLDERS,
+    )
+    return session.execute(text(sql))
 
 
 def compute_participant_chat_outcomes(
@@ -98,14 +91,9 @@ def compute_participant_chat_outcomes(
     if buffer_registry.is_active():
         return _compute_outcomes_from_buffer(session, course_ids, verbose)
 
-    sql = _render_sql(
-        _load(_OUTCOME_SQL),
-        course_ids=course_ids,
-        placeholders=_OUTCOME_PLACEHOLDERS,
-    )
     if verbose:
         print("[chat_quiz_correlation] running participant_chat_outcome.sql")
-    result = session.execute(text(sql))
+    result = _execute_participant_chat_outcomes(session, course_ids)
     session.commit()
     rows = result.rowcount or 0
     if verbose:
@@ -113,24 +101,67 @@ def compute_participant_chat_outcomes(
     return rows
 
 
-def update_has_chat_activity(
+def _execute_has_chat_activity(
     session: Session,
-    course_ids: list[str] | None = None,
-    verbose: bool = False,
+    course_ids: list[str] | None,
 ):
     sql = _render_sql(
         _load(_UPDATE_SQL),
         course_ids=course_ids,
         placeholders=_UPDATE_PLACEHOLDERS,
     )
+    return session.execute(text(sql))
+
+
+def update_has_chat_activity(
+    session: Session,
+    course_ids: list[str] | None = None,
+    verbose: bool = False,
+):
     if verbose:
         print("[chat_quiz_correlation] running update_has_chat_activity.sql")
-    result = session.execute(text(sql))
+    result = _execute_has_chat_activity(session, course_ids)
     session.commit()
     rows = result.rowcount or 0
     if verbose:
         print(f"[chat_quiz_correlation] hasChatActivity rows updated: {rows}")
     return rows
+
+
+def reconcile_chat_quiz_correlation(
+    session: Session,
+    course_ids: list[str] | None = None,
+    verbose: bool = False,
+) -> tuple[int, int]:
+    """Atomically replace scoped outcomes and reset activity flags."""
+    if buffer_registry.is_active():
+        outcome_rows = compute_participant_chat_outcomes(
+            session,
+            course_ids=course_ids,
+            verbose=verbose,
+        )
+        activity_rows = update_has_chat_activity(
+            session,
+            course_ids=course_ids,
+            verbose=verbose,
+        )
+        return outcome_rows, activity_rows
+
+    delete_sql = _render_sql(
+        _DELETE_OUTCOMES_SQL,
+        course_ids=course_ids,
+        placeholders=_DELETE_OUTCOME_PLACEHOLDERS,
+    )
+    session.execute(text(delete_sql))
+    outcome_result = _execute_participant_chat_outcomes(session, course_ids)
+    activity_result = _execute_has_chat_activity(session, course_ids)
+    session.commit()
+
+    outcome_rows = outcome_result.rowcount or 0
+    activity_rows = activity_result.rowcount or 0
+    if verbose:
+        print(f"[chat_quiz_correlation] reconciled outcome_rows={outcome_rows} activity_rows={activity_rows}")
+    return outcome_rows, activity_rows
 
 
 # ---------------------------------------------------------------------------
@@ -239,11 +270,7 @@ def _compute_outcomes_from_buffer(
         perf = perf_lookup.get((course_id, participant_id))
         first_error = perf.get("firstErrorRate") if perf else None
         last_error = perf.get("lastErrorRate") if perf else None
-        delta = (
-            float(last_error) - float(first_error)
-            if first_error is not None and last_error is not None
-            else None
-        )
+        delta = float(last_error) - float(first_error) if first_error is not None and last_error is not None else None
         outcome_rows.append(
             {
                 "participantId": participant_id,
@@ -281,9 +308,7 @@ def _compute_outcomes_from_buffer(
     )
 
 
-def _bucket_for(
-    messages: int, cuts: tuple[float, float] | None
-) -> ChatDoseBucketLiteral:
+def _bucket_for(messages: int, cuts: tuple[float, float] | None) -> ChatDoseBucketLiteral:
     if messages <= 0 or cuts is None:
         return "NONE"
     cut_low, cut_med = cuts

--- a/apps/analytics/src/modules/chat_topic_clustering/cluster_chatbot.py
+++ b/apps/analytics/src/modules/chat_topic_clustering/cluster_chatbot.py
@@ -26,10 +26,7 @@ def cluster_chatbot(
     """
     rows = load_user_text(session, chatbot_id, win_start, win_end)
     if verbose:
-        print(
-            f"[chat_topic_clustering] chatbot={chatbot_id} "
-            f"messages_loaded={len(rows)}"
-        )
+        print(f"[chat_topic_clustering] chatbot={chatbot_id} messages_loaded={len(rows)}")
 
     if len(rows) < MIN_MESSAGES:
         if verbose:
@@ -38,7 +35,7 @@ def cluster_chatbot(
                 f"{MIN_MESSAGES} messages, got {len(rows)}"
             )
         return save_clusters(
-            db,
+            session,
             chatbot_id,
             analytics_type,
             timestamp,

--- a/apps/analytics/src/modules/participant_analytics/get_participant_responses.py
+++ b/apps/analytics/src/modules/participant_analytics/get_participant_responses.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 
 import pandas as pd
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from src.db_helpers import coerce_timestamp, row_to_dict
 from src.models import (
     Course,
+    MicroLearning,
+    PracticeQuiz,
     QuestionResponseDetail,
 )
 
@@ -69,21 +71,34 @@ def _detail_to_dict(
     return base
 
 
-def get_participant_responses(session: Session, start_date: str, end_date: str, verbose: bool = False):
+def get_participant_responses(
+    session: Session,
+    start_date: str,
+    end_date: str,
+    verbose: bool = False,
+    course_ids: list[str] | None = None,
+):
     """Return a dataframe of per-response detail rows for the window.
 
     The time predicate stays in Postgres so the ``createdAt`` BRIN index can
     prune the append-mostly detail table before relationships are loaded.
     """
     start_ts, end_ts = _coerce_window_bounds(start_date, end_date)
+    statement = select(QuestionResponseDetail).where(
+        QuestionResponseDetail.createdAt >= start_ts,
+        QuestionResponseDetail.createdAt <= end_ts,
+    )
+    if course_ids is not None:
+        statement = statement.where(
+            or_(
+                QuestionResponseDetail.practiceQuiz.has(PracticeQuiz.courseId.in_(course_ids)),
+                QuestionResponseDetail.microLearning.has(MicroLearning.courseId.in_(course_ids)),
+            )
+        )
+
     details = (
         session.execute(
-            select(QuestionResponseDetail)
-            .where(
-                QuestionResponseDetail.createdAt >= start_ts,
-                QuestionResponseDetail.createdAt <= end_ts,
-            )
-            .options(
+            statement.options(
                 selectinload(QuestionResponseDetail.practiceQuiz),
                 selectinload(QuestionResponseDetail.microLearning),
             )
@@ -92,7 +107,7 @@ def get_participant_responses(session: Session, start_date: str, end_date: str, 
         .all()
     )
 
-    course_ids = {
+    detail_course_ids = {
         str(detail.practiceQuiz.courseId)
         for detail in details
         if detail.practiceQuiz is not None and detail.practiceQuiz.courseId is not None
@@ -101,7 +116,7 @@ def get_participant_responses(session: Session, start_date: str, end_date: str, 
         for detail in details
         if detail.microLearning is not None and detail.microLearning.courseId is not None
     }
-    course_windows = _load_course_windows(session, course_ids)
+    course_windows = _load_course_windows(session, detail_course_ids)
 
     rows = []
     for detail in details:

--- a/apps/analytics/src/modules/utils.py
+++ b/apps/analytics/src/modules/utils.py
@@ -101,6 +101,7 @@ def analytics_run_config_from_env() -> AnalyticsRunConfig:
         mode=analytics_mode(),
         course_ids=tuple(course_ids) if course_ids is not None else None,
         window_since=analytics_window_since(),
+        chat_analytics_cutoff=(os.environ.get("ANALYTICS_CHAT_CUTOFF") or "").strip() or None,
     )
 
 

--- a/apps/analytics/src/modules/utils.py
+++ b/apps/analytics/src/modules/utils.py
@@ -49,6 +49,7 @@ class AnalyticsRunConfig:
     mode: AnalyticsMode
     course_ids: tuple[str, ...] | None = None
     window_since: str | None = None
+    chat_analytics_cutoff: str | None = None
 
 
 class AnalyticsRunCancelled(RuntimeError):

--- a/apps/analytics/src/scripts/0_initial_participant_analytics.py
+++ b/apps/analytics/src/scripts/0_initial_participant_analytics.py
@@ -64,7 +64,13 @@ def main() -> None:
                 win_start = specific_date + "T00:00:00.000Z"
                 win_end = specific_date + "T23:59:59.999Z"
                 compute_participant_analytics(
-                    session, win_start, win_end, win_start, "DAILY", verbose
+                    session,
+                    win_start,
+                    win_end,
+                    win_start,
+                    "DAILY",
+                    verbose,
+                    course_ids=scope,
                 )
 
         if compute_weekly:
@@ -74,14 +80,16 @@ def main() -> None:
                 if should_skip_window(week_end_date, windows_since):
                     continue
                 week_end = week_end_date + "T23:59:59.999Z"
-                week_start = (curr_date - pd.DateOffset(days=6)).strftime(
-                    "%Y-%m-%d"
-                ) + "T00:00:00.000Z"
-                print(
-                    f"Computing weekly participant analytics for {week_start} to {week_end}"
-                )
+                week_start = (curr_date - pd.DateOffset(days=6)).strftime("%Y-%m-%d") + "T00:00:00.000Z"
+                print(f"Computing weekly participant analytics for {week_start} to {week_end}")
                 compute_participant_analytics(
-                    session, week_start, week_end, week_end, "WEEKLY", verbose
+                    session,
+                    week_start,
+                    week_end,
+                    week_end,
+                    "WEEKLY",
+                    verbose,
+                    course_ids=scope,
                 )
 
         if compute_monthly:
@@ -91,46 +99,36 @@ def main() -> None:
                 if should_skip_window(month_end_date, windows_since):
                     continue
                 month_end = month_end_date + "T23:59:59.999Z"
-                month_start = (curr_date - pd.offsets.MonthBegin(1)).strftime(
-                    "%Y-%m-%d"
-                ) + "T00:00:00.000Z"
-                print(
-                    f"Computing monthly participant analytics for {month_start} to {month_end}"
-                )
+                month_start = (curr_date - pd.offsets.MonthBegin(1)).strftime("%Y-%m-%d") + "T00:00:00.000Z"
+                print(f"Computing monthly participant analytics for {month_start} to {month_end}")
                 compute_participant_analytics(
-                    session, month_start, month_end, month_end, "MONTHLY", verbose
+                    session,
+                    month_start,
+                    month_end,
+                    month_end,
+                    "MONTHLY",
+                    verbose,
+                    course_ids=scope,
                 )
 
         if compute_course:
             check_analytics_cancellation()
             curr_date = datetime.now()
 
-            stmt = select(Course.id, Course.startDate, Course.endDate).where(
-                Course.startDate <= curr_date
-            )
+            stmt = select(Course.id, Course.startDate, Course.endDate).where(Course.startDate <= curr_date)
             stmt = apply_course_scope(scope, stmt, Course.id)
             if stmt is None:
-                print(
-                    "[0_initial_participant_analytics] empty course scope — skipping COURSE pass"
-                )
+                print("[0_initial_participant_analytics] empty course scope — skipping COURSE pass")
                 df_courses = pd.DataFrame()
             else:
-                df_courses = pd.DataFrame(
-                    [dict(row) for row in session.execute(stmt).mappings().all()]
-                )
+                df_courses = pd.DataFrame([dict(row) for row in session.execute(stmt).mappings().all()])
 
             scope_note = f" (scoped to {len(scope)} ids)" if scope is not None else ""
-            print(
-                f"Found {len(df_courses)} courses with a start date before {curr_date}{scope_note}"
-            )
+            print(f"Found {len(df_courses)} courses with a start date before {curr_date}{scope_note}")
 
             if not df_courses.empty:
-                courses_without_responses = compute_participant_course_analytics(
-                    session, df_courses, verbose
-                )
-                print(
-                    f"Found {courses_without_responses} courses without any responses"
-                )
+                courses_without_responses = compute_participant_course_analytics(session, df_courses, verbose)
+                print(f"Found {courses_without_responses} courses without any responses")
 
         script_exit(script=__name__, started=started, rows_written=None)
 

--- a/apps/analytics/src/scripts/11_chat_quiz_correlation.py
+++ b/apps/analytics/src/scripts/11_chat_quiz_correlation.py
@@ -2,8 +2,8 @@
 # chat volume (ParticipantChatAnalytics type=COURSE) and quiz performance
 # (ParticipantPerformance). Also updates ParticipantCourseAnalytics.hasChatActivity.
 #
-# Preconditions: script 4 (ParticipantPerformance) AND script 8 (ParticipantChatAnalytics)
-# must have run for the target courses. Fails loud if either is empty.
+# Hatchet/process ordering guarantees that scripts 4 (ParticipantPerformance)
+# and 8 (ParticipantChatAnalytics) completed before this reconciliation runs.
 
 import sys
 
@@ -12,10 +12,8 @@ sys.path.append("../../")
 from src.db import SessionLocal
 from src.log import script_entry, script_exit
 from src.modules.chat_quiz_correlation.compute_chat_quiz_correlation import (
-    AnalyticsNotReadyError,
-    assert_preconditions,
-    compute_participant_chat_outcomes,
-    update_has_chat_activity,
+    reconcile_chat_quiz_correlation,
+    report_source_counts,
 )
 from src.modules.utils import (
     analytics_mode,
@@ -35,18 +33,9 @@ def main() -> None:
             window_since=analytics_window_since(),
         )
 
-        try:
-            assert_preconditions(session, course_ids=scope, verbose=True)
-        except AnalyticsNotReadyError as exc:
-            print(f"ERROR: {exc}")
-            raise
-
-        print("Building ParticipantChatOutcome rows")
-        compute_participant_chat_outcomes(session, course_ids=scope, verbose=True)
-
+        report_source_counts(session, course_ids=scope, verbose=True)
         check_analytics_cancellation()
-        print("Updating ParticipantCourseAnalytics.hasChatActivity")
-        update_has_chat_activity(session, course_ids=scope, verbose=True)
+        reconcile_chat_quiz_correlation(session, course_ids=scope, verbose=True)
 
         script_exit(script=__name__, started=started, rows_written=None)
 

--- a/apps/analytics/src/scripts/8_initial_chat_analytics.py
+++ b/apps/analytics/src/scripts/8_initial_chat_analytics.py
@@ -11,6 +11,10 @@ from src.log import script_entry, script_exit
 from src.modules.chat_analytics.compute_participant_chat_analytics import (
     compute_participant_chat_analytics,
 )
+from src.modules.chat_analytics.consent_reconciliation import (
+    plan_chat_analytics_runs,
+    purge_ineligible_participant_chat_analytics,
+)
 from src.modules.utils import (
     analytics_mode,
     analytics_window_since,
@@ -30,14 +34,17 @@ def main() -> None:
             window_since=window_since,
         )
 
-        iter_analytics_windows(
-            session,
-            compute_participant_chat_analytics,
-            course_ids=scope,
-            label="participant chat analytics",
-            windows_since=window_since,
-            verbose=False,
-        )
+        runs = plan_chat_analytics_runs(session, scope, window_since)
+        purge_ineligible_participant_chat_analytics(session, scope)
+        for run in runs:
+            iter_analytics_windows(
+                session,
+                compute_participant_chat_analytics,
+                course_ids=run.course_ids,
+                label="participant chat analytics",
+                windows_since=run.window_since,
+                verbose=False,
+            )
 
         script_exit(script=__name__, started=started, rows_written=None)
 

--- a/apps/analytics/src/scripts/9_initial_aggregated_chatbot_analytics.py
+++ b/apps/analytics/src/scripts/9_initial_aggregated_chatbot_analytics.py
@@ -11,6 +11,9 @@ from src.log import script_entry, script_exit
 from src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics import (
     compute_aggregated_chatbot_analytics,
 )
+from src.modules.chat_analytics.consent_reconciliation import (
+    plan_chat_analytics_runs,
+)
 from src.modules.utils import (
     analytics_mode,
     analytics_window_since,
@@ -30,14 +33,15 @@ def main() -> None:
             window_since=window_since,
         )
 
-        iter_analytics_windows(
-            session,
-            compute_aggregated_chatbot_analytics,
-            course_ids=scope,
-            label="aggregated chatbot analytics",
-            windows_since=window_since,
-            verbose=False,
-        )
+        for run in plan_chat_analytics_runs(session, scope, window_since):
+            iter_analytics_windows(
+                session,
+                compute_aggregated_chatbot_analytics,
+                course_ids=run.course_ids,
+                label="aggregated chatbot analytics",
+                windows_since=run.window_since,
+                verbose=False,
+            )
 
         script_exit(script=__name__, started=started, rows_written=None)
 

--- a/apps/analytics/tests/module_isolation.py
+++ b/apps/analytics/tests/module_isolation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+from typing import cast
+
+_MISSING = object()
+
+
+@contextmanager
+def preserve_imported_modules(module_names: tuple[str, ...]) -> Iterator[None]:
+    """Restore imported modules and their parent-package attributes after a test."""
+    previous = {name: sys.modules.get(name, _MISSING) for name in module_names}
+    previous_parent_attributes: dict[tuple[str, str], object] = {}
+    for name in module_names:
+        parent_name, attribute = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        previous_parent_attributes[(parent_name, attribute)] = (
+            getattr(parent, attribute, _MISSING) if parent is not None else _MISSING
+        )
+
+    try:
+        yield
+    finally:
+        for name, module in previous.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = cast(ModuleType, module)
+        for (parent_name, attribute), value in previous_parent_attributes.items():
+            parent = sys.modules.get(parent_name)
+            if parent is None:
+                continue
+            if value is _MISSING:
+                if hasattr(parent, attribute):
+                    delattr(parent, attribute)
+            else:
+                setattr(parent, attribute, value)

--- a/apps/analytics/tests/test_analytics_runtime.py
+++ b/apps/analytics/tests/test_analytics_runtime.py
@@ -17,41 +17,20 @@ from src.modules.utils import (
     analytics_run_config_from_env,
     analytics_window_since,
 )
+from tests.module_isolation import preserve_imported_modules
 
 _DATABASE_MODULES = (
     "src.db",
     "src.scripts.11_chat_quiz_correlation",
     "src.scripts.13_platform_semester_analytics",
 )
-_MISSING = object()
 
 
 @pytest.fixture(autouse=True)
 def isolate_database_modules() -> Iterator[None]:
     """Do not retain modules imported under a test-only DATABASE_URL."""
-    previous = {name: sys.modules.get(name, _MISSING) for name in _DATABASE_MODULES}
-    previous_parent_attributes = {}
-    for name in _DATABASE_MODULES:
-        parent_name, attribute = name.rsplit(".", 1)
-        parent = sys.modules.get(parent_name)
-        previous_parent_attributes[(parent_name, attribute)] = (
-            getattr(parent, attribute, _MISSING) if parent is not None else _MISSING
-        )
-    yield
-    for name, module in previous.items():
-        if module is _MISSING:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = cast(ModuleType, module)
-    for (parent_name, attribute), value in previous_parent_attributes.items():
-        parent = sys.modules.get(parent_name)
-        if parent is None:
-            continue
-        if value is _MISSING:
-            if hasattr(parent, attribute):
-                delattr(parent, attribute)
-        else:
-            setattr(parent, attribute, value)
+    with preserve_imported_modules(_DATABASE_MODULES):
+        yield
 
 
 def test_direct_runtime_uses_task_local_config_without_mutating_environment(monkeypatch) -> None:

--- a/apps/analytics/tests/test_analytics_runtime.py
+++ b/apps/analytics/tests/test_analytics_runtime.py
@@ -30,12 +30,28 @@ _MISSING = object()
 def isolate_database_modules() -> Iterator[None]:
     """Do not retain modules imported under a test-only DATABASE_URL."""
     previous = {name: sys.modules.get(name, _MISSING) for name in _DATABASE_MODULES}
+    previous_parent_attributes = {}
+    for name in _DATABASE_MODULES:
+        parent_name, attribute = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        previous_parent_attributes[(parent_name, attribute)] = (
+            getattr(parent, attribute, _MISSING) if parent is not None else _MISSING
+        )
     yield
     for name, module in previous.items():
         if module is _MISSING:
             sys.modules.pop(name, None)
         else:
             sys.modules[name] = cast(ModuleType, module)
+    for (parent_name, attribute), value in previous_parent_attributes.items():
+        parent = sys.modules.get(parent_name)
+        if parent is None:
+            continue
+        if value is _MISSING:
+            if hasattr(parent, attribute):
+                delattr(parent, attribute)
+        else:
+            setattr(parent, attribute, value)
 
 
 def test_direct_runtime_uses_task_local_config_without_mutating_environment(monkeypatch) -> None:

--- a/apps/analytics/tests/test_analytics_runtime.py
+++ b/apps/analytics/tests/test_analytics_runtime.py
@@ -123,7 +123,7 @@ def test_direct_runtime_normalizes_process_exit_to_task_failure(monkeypatch) -> 
     assert isinstance(exc_info.value.__cause__, SystemExit)
 
 
-def test_chat_quiz_precondition_raises_ordinary_task_error(monkeypatch) -> None:
+def test_chat_quiz_empty_sources_continue_to_reconciliation(monkeypatch) -> None:
     monkeypatch.setenv(
         "DATABASE_URL",
         "postgresql://postgres@127.0.0.1/analytics-entrypoint-test",
@@ -133,31 +133,32 @@ def test_chat_quiz_precondition_raises_ordinary_task_error(monkeypatch) -> None:
         importlib.import_module("src.scripts.11_chat_quiz_correlation"),
     )
     session = object()
-    expected = entrypoint.AnalyticsNotReadyError("analytics inputs missing")
-
-    def fail_precondition(*_args, **_kwargs) -> None:
-        raise expected
+    calls: list[str] = []
 
     monkeypatch.setattr(entrypoint, "SessionLocal", lambda: nullcontext(session))
     monkeypatch.setattr(entrypoint, "scoped_course_ids", lambda _session: None)
     monkeypatch.setattr(entrypoint, "script_entry", lambda **_kwargs: 0.0)
-    monkeypatch.setattr(entrypoint, "assert_preconditions", fail_precondition)
+    monkeypatch.setattr(entrypoint, "script_exit", lambda **_kwargs: None)
+    monkeypatch.setattr(entrypoint, "check_analytics_cancellation", lambda: None)
+    monkeypatch.setattr(
+        entrypoint,
+        "report_source_counts",
+        lambda *_args, **_kwargs: calls.append("report"),
+    )
+    monkeypatch.setattr(
+        entrypoint,
+        "reconcile_chat_quiz_correlation",
+        lambda *_args, **_kwargs: calls.append("reconcile"),
+    )
 
-    with pytest.raises(entrypoint.AnalyticsNotReadyError) as exc_info:
-        entrypoint.main()
+    entrypoint.main()
 
-    assert exc_info.value is expected
-    assert not isinstance(exc_info.value, SystemExit)
+    assert calls == ["report", "reconcile"]
 
 
 @pytest.mark.parametrize(
     ("module_name", "first_phase", "second_phase"),
     [
-        (
-            "src.scripts.11_chat_quiz_correlation",
-            "compute_participant_chat_outcomes",
-            "update_has_chat_activity",
-        ),
         (
             "src.scripts.13_platform_semester_analytics",
             "compute_platform_semester_analytics",
@@ -194,13 +195,6 @@ def test_script_stops_between_committed_phases(
         second_phase,
         lambda *_args, **_kwargs: calls.append("second"),
     )
-    if hasattr(entrypoint, "assert_preconditions"):
-        monkeypatch.setattr(
-            entrypoint,
-            "assert_preconditions",
-            lambda *_args, **_kwargs: None,
-        )
-
     with (
         analytics_run_context(config, lambda: calls == ["first"]),
         pytest.raises(AnalyticsRunCancelled),

--- a/apps/analytics/tests/test_analytics_runtime.py
+++ b/apps/analytics/tests/test_analytics_runtime.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from collections.abc import Iterator
 from contextlib import nullcontext
 from types import ModuleType
 from typing import Any, cast
@@ -16,6 +17,25 @@ from src.modules.utils import (
     analytics_run_config_from_env,
     analytics_window_since,
 )
+
+_DATABASE_MODULES = (
+    "src.db",
+    "src.scripts.11_chat_quiz_correlation",
+    "src.scripts.13_platform_semester_analytics",
+)
+_MISSING = object()
+
+
+@pytest.fixture(autouse=True)
+def isolate_database_modules() -> Iterator[None]:
+    """Do not retain modules imported under a test-only DATABASE_URL."""
+    previous = {name: sys.modules.get(name, _MISSING) for name in _DATABASE_MODULES}
+    yield
+    for name, module in previous.items():
+        if module is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = cast(ModuleType, module)
 
 
 def test_direct_runtime_uses_task_local_config_without_mutating_environment(monkeypatch) -> None:

--- a/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
+++ b/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 import pytest
@@ -1141,6 +1141,103 @@ def test_chat_cutoff_is_stored_as_utc_naive_in_non_utc_session(session):
         {"course": COURSE_A},
     ).scalar_one()
     assert stored_cutoff == datetime(2026, 7, 9, 9, 30)
+
+
+@pytest.mark.integration
+def test_same_millisecond_consent_change_remains_visible(session):
+    from src.analytics_cutoff import database_safe_cutoff
+    from src.modules.analytics_validity.mark_analytics_valid import (
+        mark_analytics_valid,
+    )
+    from src.modules.chat_analytics.consent_reconciliation import (
+        plan_chat_analytics_runs,
+    )
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+    session.execute(
+        text(
+            """
+            UPDATE "Course"
+            SET "analyticsFinalizedAt" = TIMESTAMP '2026-07-01 00:00:00',
+                "chatAnalyticsValidAt" = TIMESTAMP '2026-07-01 00:00:00'
+            WHERE id = :course
+            """
+        ),
+        {"course": COURSE_A},
+    )
+    session.execute(
+        text(
+            """
+            UPDATE "ChatUsageCredits"
+            SET "disclaimerAcceptedAt" = TIMESTAMP '2026-07-09 09:30:00.123',
+                "updatedAt" = TIMESTAMP '2026-07-09 09:30:00.123'
+            WHERE "participantId" = :participant
+              AND "chatbotId" = :chatbot
+            """
+        ),
+        {
+            "participant": ACCEPTED,
+            "chatbot": CHATBOT_A,
+        },
+    )
+    cutoff = database_safe_cutoff(datetime(2026, 7, 9, 9, 30, 0, 123456, tzinfo=timezone.utc))
+
+    with analytics_run_context(
+        AnalyticsRunConfig(
+            mode="finalize",
+            course_ids=(str(COURSE_A),),
+            chat_analytics_cutoff=cutoff,
+        )
+    ):
+        mark_analytics_valid(session)
+
+    marker, finalized_at = session.execute(
+        text(
+            """
+            SELECT "chatAnalyticsValidAt", "analyticsFinalizedAt"
+            FROM "Course"
+            WHERE id = :course
+            """
+        ),
+        {"course": COURSE_A},
+    ).one()
+    assert marker == datetime(2026, 7, 9, 9, 30, 0, 122000)
+    assert finalized_at == datetime(2026, 7, 1)
+    history_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in history_runs] == [([str(COURSE_A)], "2026-07-01")]
+
+    with analytics_run_context(
+        AnalyticsRunConfig(
+            mode="finalize",
+            course_ids=(str(COURSE_A),),
+            chat_analytics_cutoff=database_safe_cutoff(datetime(2026, 7, 9, 9, 30, 0, 125000, tzinfo=timezone.utc)),
+        )
+    ):
+        mark_analytics_valid(session)
+
+    marker, finalized_at = session.execute(
+        text(
+            """
+            SELECT "chatAnalyticsValidAt", "analyticsFinalizedAt"
+            FROM "Course"
+            WHERE id = :course
+            """
+        ),
+        {"course": COURSE_A},
+    ).one()
+    assert marker == datetime(2026, 7, 9, 9, 30, 0, 124000)
+    assert finalized_at > datetime(2026, 7, 1)
+    converged_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in converged_runs] == [([str(COURSE_A)], "2026-07-09")]
 
 
 @pytest.mark.integration

--- a/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
+++ b/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
@@ -5,6 +5,8 @@ from uuid import UUID
 import pytest
 from sqlalchemy import text
 
+from src.modules.utils import AnalyticsRunConfig, analytics_run_context
+
 COURSE_A = UUID("aaaa0000-0000-0000-0000-000000000001")
 COURSE_B = UUID("aaaa0000-0000-0000-0000-000000000002")
 CHATBOT_A = UUID("bbbb0000-0000-0000-0000-000000000001")
@@ -23,8 +25,12 @@ def _create_temp_tables(session) -> None:
             """
             CREATE TEMP TABLE "Course" (
               id uuid PRIMARY KEY,
+              "areAnalyticsValid" boolean NOT NULL DEFAULT false,
+              "analyticsLastComputedAt" timestamp,
+              "analyticsFinalizedAt" timestamp,
               "chatAnalyticsValidAt" timestamp
             );
+            CREATE TEMP TABLE "ParticipantAnalytics" ("courseId" uuid NOT NULL);
             CREATE TEMP TABLE "Chatbot" (
               id uuid PRIMARY KEY,
               "courseId" uuid NOT NULL,
@@ -825,8 +831,8 @@ def test_incremental_revocation_rebuilds_old_and_recent_chat_windows(session):
         is None
     )
 
-    # Script 9 can still discover the rebuild after script 8 purges stale rows:
-    # the cleared course watermark is the durable hand-off between parallel tasks.
+    # Script 9 discovers the rebuild after its script-8 parent purges stale rows:
+    # the cleared course watermark is the durable hand-off between DAG stages.
     aggregate_runs = plan_chat_analytics_runs(
         session,
         [str(COURSE_A)],
@@ -859,6 +865,117 @@ def test_incremental_revocation_rebuilds_old_and_recent_chat_windows(session):
         ).scalar_one()
         == 0
     )
+
+
+@pytest.mark.integration
+def test_acceptance_during_workflow_remains_visible_after_start_cutoff(session):
+    from src.modules.analytics_validity.mark_analytics_valid import (
+        mark_analytics_valid,
+    )
+    from src.modules.chat_analytics.compute_participant_chat_analytics import (
+        compute_participant_chat_analytics,
+    )
+    from src.modules.chat_analytics.consent_reconciliation import (
+        plan_chat_analytics_runs,
+    )
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+    session.execute(
+        text(
+            """
+            UPDATE "ChatUsageCredits"
+            SET "acceptedDisclaimerId" = NULL,
+                "disclaimerAcceptedAt" = NULL,
+                "disclaimerDeclined" = true,
+                "updatedAt" = TIMESTAMP '2026-01-01 00:00:00'
+            WHERE "participantId" = :participant
+              AND "chatbotId" = :chatbot
+            """
+        ),
+        {"participant": ACCEPTED, "chatbot": CHATBOT_A},
+    )
+
+    initial_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in initial_runs] == [([str(COURSE_A)], "2026-07-09")]
+
+    session.execute(
+        text(
+            """
+            UPDATE "ChatUsageCredits"
+            SET "acceptedDisclaimerId" = :disclaimer,
+                "disclaimerAcceptedAt" = TIMESTAMP '2026-07-10 00:00:00',
+                "disclaimerDeclined" = false,
+                "updatedAt" = TIMESTAMP '2026-07-10 00:00:00'
+            WHERE "participantId" = :participant
+              AND "chatbotId" = :chatbot
+            """
+        ),
+        {
+            "disclaimer": DISCLAIMER,
+            "participant": ACCEPTED,
+            "chatbot": CHATBOT_A,
+        },
+    )
+
+    first_cutoff = AnalyticsRunConfig(
+        mode="incremental",
+        course_ids=(str(COURSE_A),),
+        window_since="2026-07-09",
+        chat_analytics_cutoff="2026-07-09T12:00:00+00:00",
+    )
+    with analytics_run_context(first_cutoff):
+        mark_analytics_valid(session)
+
+    history_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in history_runs] == [([str(COURSE_A)], "2026-07-01")]
+
+    compute_participant_chat_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[str(COURSE_A)],
+    )
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM "ParticipantChatAnalytics"
+                WHERE "courseId" = :course
+                  AND "participantId" = :participant
+                """
+            ),
+            {"course": COURSE_A, "participant": ACCEPTED},
+        ).scalar_one()
+        == 1
+    )
+
+    second_cutoff = AnalyticsRunConfig(
+        mode="incremental",
+        course_ids=(str(COURSE_A),),
+        window_since="2026-07-09",
+        chat_analytics_cutoff="2026-07-11T00:00:00+00:00",
+    )
+    with analytics_run_context(second_cutoff):
+        mark_analytics_valid(session)
+
+    converged_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in converged_runs] == [([str(COURSE_A)], "2026-07-09")]
 
 
 @pytest.mark.integration

--- a/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
+++ b/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
@@ -21,10 +21,15 @@ def _create_temp_tables(session) -> None:
     session.execute(
         text(
             """
+            CREATE TEMP TABLE "Course" (
+              id uuid PRIMARY KEY,
+              "chatAnalyticsValidAt" timestamp
+            );
             CREATE TEMP TABLE "Chatbot" (
               id uuid PRIMARY KEY,
               "courseId" uuid NOT NULL,
-              "disclaimerId" uuid
+              "disclaimerId" uuid,
+              "updatedAt" timestamp NOT NULL
             );
             CREATE TEMP TABLE "ChatThread" (
               id uuid PRIMARY KEY,
@@ -35,8 +40,10 @@ def _create_temp_tables(session) -> None:
               "participantId" uuid NOT NULL,
               "chatbotId" uuid NOT NULL,
               "acceptedDisclaimerId" uuid,
+              "disclaimerAcceptedAt" timestamp,
               "disclaimerDeclined" boolean NOT NULL,
-              "current" numeric NOT NULL
+              "current" numeric NOT NULL,
+              "updatedAt" timestamp NOT NULL
             );
             CREATE TEMP TABLE "ChatMessage" (
               id uuid PRIMARY KEY,
@@ -151,9 +158,19 @@ def _seed_chat_sources(session) -> None:
     session.execute(
         text(
             """
-            INSERT INTO "Chatbot" (id, "courseId", "disclaimerId") VALUES
-              (:chatbot_a, :course_a, :disclaimer),
-              (:chatbot_b, :course_b, :disclaimer)
+            INSERT INTO "Course" (id, "chatAnalyticsValidAt") VALUES
+              (:course_a, TIMESTAMP '2026-07-05 00:00:00'),
+              (:course_b, TIMESTAMP '2026-07-05 00:00:00')
+            """
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "Chatbot" (id, "courseId", "disclaimerId", "updatedAt") VALUES
+              (:chatbot_a, :course_a, :disclaimer, TIMESTAMP '2026-01-01 00:00:00'),
+              (:chatbot_b, :course_b, :disclaimer, TIMESTAMP '2026-01-01 00:00:00')
             """
         ),
         params,
@@ -173,11 +190,23 @@ def _seed_chat_sources(session) -> None:
         text(
             """
             INSERT INTO "ChatUsageCredits"
-              ("participantId", "chatbotId", "acceptedDisclaimerId", "disclaimerDeclined", "current")
+              (
+                "participantId", "chatbotId", "acceptedDisclaimerId",
+                "disclaimerAcceptedAt", "disclaimerDeclined", "current", "updatedAt"
+              )
             VALUES
-              (:accepted, :chatbot_a, :disclaimer, false, 10),
-              (:stale, :chatbot_a, :stale_disclaimer, false, 10),
-              (:declined, :chatbot_a, :disclaimer, true, 10)
+              (
+                :accepted, :chatbot_a, :disclaimer,
+                TIMESTAMP '2026-01-01 00:00:00', false, 10, TIMESTAMP '2026-01-01 00:00:00'
+              ),
+              (
+                :stale, :chatbot_a, :stale_disclaimer,
+                TIMESTAMP '2026-01-01 00:00:00', false, 10, TIMESTAMP '2026-01-01 00:00:00'
+              ),
+              (
+                :declined, :chatbot_a, :disclaimer,
+                NULL, true, 10, TIMESTAMP '2026-01-01 00:00:00'
+              )
             """
         ),
         params,
@@ -407,15 +436,29 @@ def test_incremental_validity_marks_only_current_course_scope(session, monkeypat
     rows = session.execute(
         text(
             """
-            SELECT id, "areAnalyticsValid", "analyticsLastComputedAt" IS NOT NULL AS marked
+            SELECT
+              id,
+              "areAnalyticsValid",
+              "analyticsLastComputedAt" IS NOT NULL AS marked,
+              "chatAnalyticsValidAt" IS NOT NULL AS chat_marked
             FROM "Course"
             ORDER BY id
             """
         )
     ).mappings()
     assert [dict(row) for row in rows] == [
-        {"id": COURSE_A, "areAnalyticsValid": True, "marked": True},
-        {"id": COURSE_B, "areAnalyticsValid": False, "marked": False},
+        {
+            "id": COURSE_A,
+            "areAnalyticsValid": True,
+            "marked": True,
+            "chat_marked": True,
+        },
+        {
+            "id": COURSE_B,
+            "areAnalyticsValid": False,
+            "marked": False,
+            "chat_marked": False,
+        },
     ]
 
 
@@ -629,7 +672,7 @@ def test_consent_revocation_reconciles_scoped_chat_and_downstream_state(session)
         },
     )
 
-    report_source_counts(session, course_ids=[str(COURSE_A)])
+    report_source_counts(session, course_ids=[str(COURSE_A)], verbose=True)
     reconcile_chat_quiz_correlation(session, course_ids=[str(COURSE_A)])
 
     outcomes = session.execute(
@@ -680,6 +723,142 @@ def test_consent_revocation_reconciles_scoped_chat_and_downstream_state(session)
             "hasChatActivity": True,
         },
     ]
+
+
+@pytest.mark.integration
+def test_incremental_revocation_rebuilds_old_and_recent_chat_windows(session):
+    from src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics import (
+        compute_aggregated_chatbot_analytics,
+    )
+    from src.modules.chat_analytics.compute_participant_chat_analytics import (
+        compute_participant_chat_analytics,
+    )
+    from src.modules.chat_analytics.consent_reconciliation import (
+        plan_chat_analytics_runs,
+        purge_ineligible_participant_chat_analytics,
+    )
+    from src.modules.utils import iter_analytics_windows
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatMessage" (
+              id, "threadId", role, content, "chatMode", "modelId",
+              "reasoningEffort", "creditsUsed", "createdAt"
+            ) VALUES (
+              'ffff0000-0000-0000-0000-000000000004',
+              'eeee0000-0000-0000-0000-000000000001',
+              'user', '[{"type":"text","text":"recent"}]', 'tutor', NULL, NULL, 0,
+              TIMESTAMP '2026-07-15 10:00:00'
+            )
+            """
+        )
+    )
+
+    for day in ("2026-07-01", "2026-07-15"):
+        compute_participant_chat_analytics(
+            session,
+            f"{day}T00:00:00Z",
+            f"{day}T23:59:59.999Z",
+            day,
+            "DAILY",
+            course_ids=[str(COURSE_A)],
+        )
+        compute_aggregated_chatbot_analytics(
+            session,
+            f"{day}T00:00:00Z",
+            f"{day}T23:59:59.999Z",
+            day,
+            "DAILY",
+            course_ids=[str(COURSE_A)],
+        )
+
+    session.execute(
+        text(
+            """
+            UPDATE "ChatUsageCredits"
+            SET "acceptedDisclaimerId" = NULL,
+                "disclaimerAcceptedAt" = NULL,
+                "disclaimerDeclined" = true,
+                "updatedAt" = TIMESTAMP '2026-07-10 00:00:00'
+            WHERE "participantId" = :participant
+              AND "chatbotId" = :chatbot
+            """
+        ),
+        {"participant": ACCEPTED, "chatbot": CHATBOT_A},
+    )
+
+    runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in runs] == [([str(COURSE_A)], "2026-07-01")]
+
+    purge_ineligible_participant_chat_analytics(session, [str(COURSE_A)])
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM "ParticipantChatAnalytics"
+                WHERE "courseId" = :course
+                """
+            ),
+            {"course": COURSE_A},
+        ).scalar_one()
+        == 0
+    )
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT "chatAnalyticsValidAt"
+                FROM "Course"
+                WHERE id = :course
+                """
+            ),
+            {"course": COURSE_A},
+        ).scalar_one()
+        is None
+    )
+
+    # Script 9 can still discover the rebuild after script 8 purges stale rows:
+    # the cleared course watermark is the durable hand-off between parallel tasks.
+    aggregate_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in aggregate_runs] == [([str(COURSE_A)], "2026-07-01")]
+    iter_analytics_windows(
+        session,
+        compute_aggregated_chatbot_analytics,
+        start_date="2026-07-01",
+        end_date="2026-07-15",
+        compute_weekly=False,
+        compute_monthly=False,
+        compute_course=False,
+        windows_since=aggregate_runs[0].window_since,
+        course_ids=aggregate_runs[0].course_ids,
+    )
+
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM "AggregatedChatbotAnalytics"
+                WHERE "courseId" = :course
+                  AND "timestamp" IN (DATE '2026-07-01', DATE '2026-07-15')
+                """
+            ),
+            {"course": COURSE_A},
+        ).scalar_one()
+        == 0
+    )
 
 
 @pytest.mark.integration

--- a/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
+++ b/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
@@ -1,0 +1,737 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+
+COURSE_A = UUID("aaaa0000-0000-0000-0000-000000000001")
+COURSE_B = UUID("aaaa0000-0000-0000-0000-000000000002")
+CHATBOT_A = UUID("bbbb0000-0000-0000-0000-000000000001")
+CHATBOT_B = UUID("bbbb0000-0000-0000-0000-000000000002")
+DISCLAIMER = UUID("cccc0000-0000-0000-0000-000000000001")
+STALE_DISCLAIMER = UUID("cccc0000-0000-0000-0000-000000000002")
+ACCEPTED = UUID("dddd0000-0000-0000-0000-000000000001")
+STALE = UUID("dddd0000-0000-0000-0000-000000000002")
+DECLINED = UUID("dddd0000-0000-0000-0000-000000000003")
+COURSE_B_PARTICIPANT = UUID("dddd0000-0000-0000-0000-000000000004")
+
+
+def _create_temp_tables(session) -> None:
+    session.execute(
+        text(
+            """
+            CREATE TEMP TABLE "Chatbot" (
+              id uuid PRIMARY KEY,
+              "courseId" uuid NOT NULL,
+              "disclaimerId" uuid
+            );
+            CREATE TEMP TABLE "ChatThread" (
+              id uuid PRIMARY KEY,
+              "chatbotId" uuid NOT NULL,
+              "participantId" uuid NOT NULL
+            );
+            CREATE TEMP TABLE "ChatUsageCredits" (
+              "participantId" uuid NOT NULL,
+              "chatbotId" uuid NOT NULL,
+              "acceptedDisclaimerId" uuid,
+              "disclaimerDeclined" boolean NOT NULL,
+              "current" numeric NOT NULL
+            );
+            CREATE TEMP TABLE "ChatMessage" (
+              id uuid PRIMARY KEY,
+              "threadId" uuid NOT NULL,
+              role text NOT NULL,
+              content jsonb NOT NULL,
+              "chatMode" text,
+              "modelId" text,
+              "reasoningEffort" text,
+              "creditsUsed" numeric NOT NULL,
+              "createdAt" timestamp(3) NOT NULL
+            );
+            CREATE TEMP TABLE "ChatAttachment" (
+              id uuid PRIMARY KEY,
+              "messageId" uuid NOT NULL
+            );
+            CREATE TEMP TABLE "ParticipantChatAnalytics" (
+              "type" "AnalyticsType" NOT NULL,
+              "timestamp" date NOT NULL,
+              "participantId" uuid NOT NULL,
+              "chatbotId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "userMessages" integer NOT NULL,
+              "assistantMessages" integer NOT NULL,
+              threads integer NOT NULL,
+              "distinctDays" integer NOT NULL,
+              "firstMessageAt" timestamp,
+              "lastMessageAt" timestamp,
+              "msgLenMedian" real,
+              "msgLenP90" real,
+              "msgLenP99" real,
+              "messagesPerThreadP50" real,
+              "messagesPerThreadP90" real,
+              "chatModeCounts" jsonb NOT NULL,
+              "reasoningEffortCounts" jsonb NOT NULL,
+              "attachmentCount" integer NOT NULL,
+              "toolCallCount" integer NOT NULL,
+              "totalCreditsUsed" numeric NOT NULL,
+              "creditsExhausted" boolean NOT NULL,
+              "createdAt" timestamp NOT NULL,
+              "updatedAt" timestamp NOT NULL,
+              UNIQUE ("type", "participantId", "chatbotId", "timestamp")
+            );
+            CREATE TEMP TABLE "AggregatedChatbotAnalytics" (
+              "type" "AnalyticsType" NOT NULL,
+              "timestamp" date NOT NULL,
+              "chatbotId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "activeParticipants" integer NOT NULL,
+              "newParticipants" integer NOT NULL,
+              "returningParticipants" integer NOT NULL,
+              threads integer NOT NULL,
+              "userMessages" integer NOT NULL,
+              "assistantMessages" integer NOT NULL,
+              "totalCreditsUsed" numeric NOT NULL,
+              "creditExhaustionRate" real,
+              "disclaimerAcceptedCount" integer NOT NULL,
+              "disclaimerDeclinedCount" integer NOT NULL,
+              "hourOfDayDistribution" jsonb NOT NULL,
+              "modelDistribution" jsonb NOT NULL,
+              "modeDistribution" jsonb NOT NULL,
+              "reasoningEffortDistribution" jsonb NOT NULL,
+              "createdAt" timestamp NOT NULL,
+              "updatedAt" timestamp NOT NULL,
+              UNIQUE ("type", "chatbotId", "timestamp")
+            );
+            CREATE TEMP TABLE "Participation" (
+              "participantId" uuid NOT NULL,
+              "courseId" uuid NOT NULL
+            );
+            CREATE TEMP TABLE "ParticipantPerformance" (
+              "participantId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "firstErrorRate" real,
+              "lastErrorRate" real
+            );
+            CREATE TEMP TABLE "ParticipantChatOutcome" (
+              "participantId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "chatMessagesInCourse" integer NOT NULL,
+              "chatDoseBucket" "ChatDoseBucket" NOT NULL,
+              "firstErrorRate" real,
+              "lastErrorRate" real,
+              "errorRateDelta" real,
+              "hasBothModalities" boolean NOT NULL,
+              "createdAt" timestamp NOT NULL,
+              "updatedAt" timestamp NOT NULL,
+              UNIQUE ("participantId", "courseId")
+            );
+            CREATE TEMP TABLE "ParticipantCourseAnalytics" (
+              "participantId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "hasChatActivity" boolean NOT NULL
+            );
+            """
+        )
+    )
+
+
+def _seed_chat_sources(session) -> None:
+    params = {
+        "chatbot_a": CHATBOT_A,
+        "chatbot_b": CHATBOT_B,
+        "course_a": COURSE_A,
+        "course_b": COURSE_B,
+        "disclaimer": DISCLAIMER,
+        "stale_disclaimer": STALE_DISCLAIMER,
+        "accepted": ACCEPTED,
+        "stale": STALE,
+        "declined": DECLINED,
+    }
+    session.execute(
+        text(
+            """
+            INSERT INTO "Chatbot" (id, "courseId", "disclaimerId") VALUES
+              (:chatbot_a, :course_a, :disclaimer),
+              (:chatbot_b, :course_b, :disclaimer)
+            """
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatThread" (id, "chatbotId", "participantId") VALUES
+              ('eeee0000-0000-0000-0000-000000000001', :chatbot_a, :accepted),
+              ('eeee0000-0000-0000-0000-000000000002', :chatbot_a, :stale),
+              ('eeee0000-0000-0000-0000-000000000003', :chatbot_a, :declined)
+            """
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatUsageCredits"
+              ("participantId", "chatbotId", "acceptedDisclaimerId", "disclaimerDeclined", "current")
+            VALUES
+              (:accepted, :chatbot_a, :disclaimer, false, 10),
+              (:stale, :chatbot_a, :stale_disclaimer, false, 10),
+              (:declined, :chatbot_a, :disclaimer, true, 10)
+            """
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatMessage"
+              (id, "threadId", role, content, "chatMode", "modelId",
+               "reasoningEffort", "creditsUsed", "createdAt")
+            VALUES
+              (
+                'ffff0000-0000-0000-0000-000000000001',
+                'eeee0000-0000-0000-0000-000000000001',
+                'user', '[{"type":"text","text":"accepted"}]', 'tutor', NULL, NULL, 0,
+                TIMESTAMP '2026-07-01 10:00:00'
+              ),
+              (
+                'ffff0000-0000-0000-0000-000000000002',
+                'eeee0000-0000-0000-0000-000000000002',
+                'user', '[{"type":"text","text":"stale"}]', 'tutor', NULL, NULL, 0,
+                TIMESTAMP '2026-07-01 10:00:00'
+              ),
+              (
+                'ffff0000-0000-0000-0000-000000000003',
+                'eeee0000-0000-0000-0000-000000000003',
+                'user', '[{"type":"text","text":"declined"}]', 'tutor', NULL, NULL, 0,
+                TIMESTAMP '2026-07-01 10:00:00'
+              )
+            """
+        ),
+        params,
+    )
+
+
+def _create_participant_scope_tables(session) -> None:
+    session.execute(
+        text(
+            """
+            CREATE TEMP TABLE "Course" (
+              id uuid PRIMARY KEY,
+              "startDate" timestamp NOT NULL,
+              "endDate" timestamp NOT NULL
+            );
+            CREATE TEMP TABLE "PracticeQuiz" (
+              id uuid PRIMARY KEY,
+              name text NOT NULL,
+              "displayName" text NOT NULL,
+              description text,
+              "pointsMultiplier" integer NOT NULL,
+              "resetTimeDays" integer NOT NULL,
+              status "PublicationStatus" NOT NULL,
+              "isGamificationEnabled" boolean NOT NULL,
+              "isAssessmentEnabled" boolean NOT NULL,
+              "isDeleted" boolean NOT NULL,
+              "ownerId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "createdAt" timestamp NOT NULL,
+              "updatedAt" timestamp NOT NULL
+            );
+            CREATE TEMP TABLE "MicroLearning" (
+              id uuid PRIMARY KEY,
+              name text NOT NULL,
+              "displayName" text NOT NULL,
+              "pointsMultiplier" integer NOT NULL,
+              description text,
+              status "PublicationStatus" NOT NULL,
+              "scheduledStartAt" timestamp NOT NULL,
+              "scheduledEndAt" timestamp NOT NULL,
+              "isGamificationEnabled" boolean NOT NULL,
+              "isAssessmentEnabled" boolean NOT NULL,
+              "isDeleted" boolean NOT NULL,
+              "ownerId" uuid NOT NULL,
+              "courseId" uuid NOT NULL,
+              "createdAt" timestamp NOT NULL,
+              "updatedAt" timestamp NOT NULL
+            );
+            CREATE TEMP TABLE "QuestionResponseDetail" (
+              id integer PRIMARY KEY,
+              score double precision NOT NULL,
+              "pointsAwarded" double precision,
+              "xpAwarded" double precision NOT NULL,
+              "timeSpent" double precision NOT NULL,
+              response jsonb NOT NULL,
+              "participantId" uuid NOT NULL,
+              "participationId" integer NOT NULL,
+              "elementInstanceId" integer NOT NULL,
+              "practiceQuizId" uuid,
+              "microLearningId" uuid,
+              "createdAt" timestamp NOT NULL,
+              "updatedAt" timestamp NOT NULL
+            );
+            """
+        )
+    )
+
+
+@pytest.mark.integration
+def test_participant_response_scope_excludes_other_course_in_database(session):
+    from src.modules.participant_analytics.get_participant_responses import (
+        get_participant_responses,
+    )
+
+    quiz_a = UUID("11110000-0000-0000-0000-000000000001")
+    quiz_b = UUID("11110000-0000-0000-0000-000000000002")
+    owner = UUID("11110000-0000-0000-0000-000000000003")
+    participant = UUID("11110000-0000-0000-0000-000000000004")
+    _create_participant_scope_tables(session)
+    session.execute(
+        text(
+            """
+            INSERT INTO "Course" (id, "startDate", "endDate") VALUES
+              (:course_a, TIMESTAMP '2026-01-01', TIMESTAMP '2026-12-31'),
+              (:course_b, TIMESTAMP '2026-01-01', TIMESTAMP '2026-12-31');
+            """
+        ),
+        {"course_a": COURSE_A, "course_b": COURSE_B},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "PracticeQuiz" (
+              id, name, "displayName", "pointsMultiplier", "resetTimeDays",
+              status, "isGamificationEnabled", "isAssessmentEnabled",
+              "isDeleted", "ownerId", "courseId", "createdAt", "updatedAt"
+            ) VALUES
+              (
+                :quiz_a, 'a', 'a', 1, 1, 'PUBLISHED', false, false, false,
+                :owner, :course_a, NOW(), NOW()
+              ),
+              (
+                :quiz_b, 'b', 'b', 1, 1, 'PUBLISHED', false, false, false,
+                :owner, :course_b, NOW(), NOW()
+              )
+            """
+        ),
+        {
+            "quiz_a": quiz_a,
+            "quiz_b": quiz_b,
+            "owner": owner,
+            "course_a": COURSE_A,
+            "course_b": COURSE_B,
+        },
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "QuestionResponseDetail" (
+              id, score, "pointsAwarded", "xpAwarded", "timeSpent", response,
+              "participantId", "participationId", "elementInstanceId",
+              "practiceQuizId", "createdAt", "updatedAt"
+            ) VALUES
+              (
+                1, 1, 1, 1, 1, '{}'::jsonb, :participant, 1, 1, :quiz_a,
+                TIMESTAMP '2026-07-01 10:00:00', NOW()
+              ),
+              (
+                2, 1, 1, 1, 1, '{}'::jsonb, :participant, 2, 2, :quiz_b,
+                TIMESTAMP '2026-07-01 10:00:00', NOW()
+              )
+            """
+        ),
+        {
+            "participant": participant,
+            "quiz_a": quiz_a,
+            "quiz_b": quiz_b,
+        },
+    )
+
+    details = get_participant_responses(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        course_ids=[str(COURSE_A)],
+    )
+
+    assert details["courseId"].tolist() == [str(COURSE_A)]
+    assert details["id"].tolist() == [1]
+
+
+@pytest.mark.integration
+def test_incremental_validity_marks_only_current_course_scope(session, monkeypatch):
+    from src.modules.analytics_validity.mark_analytics_valid import (
+        mark_analytics_valid,
+    )
+
+    session.execute(
+        text(
+            """
+            CREATE TEMP TABLE "Course" (
+              id uuid PRIMARY KEY,
+              "areAnalyticsValid" boolean NOT NULL,
+              "analyticsLastComputedAt" timestamp,
+              "analyticsFinalizedAt" timestamp,
+              "chatAnalyticsValidAt" timestamp
+            );
+            CREATE TEMP TABLE "ParticipantAnalytics" ("courseId" uuid NOT NULL);
+            CREATE TEMP TABLE "ParticipantChatAnalytics" ("courseId" uuid NOT NULL);
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "Course" (id, "areAnalyticsValid") VALUES
+              (:course_a, false),
+              (:course_b, false)
+            """
+        ),
+        {"course_a": COURSE_A, "course_b": COURSE_B},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ParticipantAnalytics" ("courseId") VALUES
+              (:course_a),
+              (:course_b)
+            """
+        ),
+        {"course_a": COURSE_A, "course_b": COURSE_B},
+    )
+    monkeypatch.setenv("ANALYTICS_MODE", "incremental")
+    monkeypatch.setenv("ANALYTICS_COURSE_IDS", str(COURSE_A))
+
+    mark_analytics_valid(session)
+
+    rows = session.execute(
+        text(
+            """
+            SELECT id, "areAnalyticsValid", "analyticsLastComputedAt" IS NOT NULL AS marked
+            FROM "Course"
+            ORDER BY id
+            """
+        )
+    ).mappings()
+    assert [dict(row) for row in rows] == [
+        {"id": COURSE_A, "areAnalyticsValid": True, "marked": True},
+        {"id": COURSE_B, "areAnalyticsValid": False, "marked": False},
+    ]
+
+
+@pytest.mark.integration
+def test_consent_revocation_reconciles_scoped_chat_and_downstream_state(session):
+    from src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics import (
+        compute_aggregated_chatbot_analytics,
+    )
+    from src.modules.chat_analytics.compute_participant_chat_analytics import (
+        compute_participant_chat_analytics,
+    )
+    from src.modules.chat_quiz_correlation.compute_chat_quiz_correlation import (
+        reconcile_chat_quiz_correlation,
+        report_source_counts,
+    )
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+
+    compute_participant_chat_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[str(COURSE_A)],
+    )
+    compute_aggregated_chatbot_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[str(COURSE_A)],
+    )
+
+    participant_rows = session.execute(
+        text(
+            """
+            SELECT "participantId", "userMessages"
+            FROM "ParticipantChatAnalytics"
+            WHERE "courseId" = :course_id
+            """
+        ),
+        {"course_id": COURSE_A},
+    ).mappings()
+    assert [dict(row) for row in participant_rows] == [{"participantId": ACCEPTED, "userMessages": 1}]
+
+    aggregate = (
+        session.execute(
+            text(
+                """
+            SELECT "activeParticipants", "userMessages"
+            FROM "AggregatedChatbotAnalytics"
+            WHERE "courseId" = :course_id
+            """
+            ),
+            {"course_id": COURSE_A},
+        )
+        .mappings()
+        .one()
+    )
+    assert dict(aggregate) == {"activeParticipants": 1, "userMessages": 1}
+
+    session.execute(
+        text(
+            """
+            INSERT INTO "ParticipantChatAnalytics" (
+              "type", "timestamp", "participantId", "chatbotId", "courseId",
+              "userMessages", "assistantMessages", threads, "distinctDays",
+              "chatModeCounts", "reasoningEffortCounts", "attachmentCount",
+              "toolCallCount", "totalCreditsUsed", "creditsExhausted",
+              "createdAt", "updatedAt"
+            ) VALUES (
+              'DAILY', DATE '2026-07-01', :participant, :chatbot, :course,
+              9, 0, 1, 1, '{}'::jsonb, '{}'::jsonb, 0, 0, 0, false, NOW(), NOW()
+            )
+            """
+        ),
+        {
+            "participant": COURSE_B_PARTICIPANT,
+            "chatbot": CHATBOT_B,
+            "course": COURSE_B,
+        },
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "AggregatedChatbotAnalytics" (
+              "type", "timestamp", "chatbotId", "courseId",
+              "activeParticipants", "newParticipants", "returningParticipants",
+              threads, "userMessages", "assistantMessages", "totalCreditsUsed",
+              "disclaimerAcceptedCount", "disclaimerDeclinedCount",
+              "hourOfDayDistribution", "modelDistribution", "modeDistribution",
+              "reasoningEffortDistribution", "createdAt", "updatedAt"
+            ) VALUES (
+              'DAILY', DATE '2026-07-01', :chatbot, :course,
+              9, 0, 0, 1, 9, 0, 0, 0, 0,
+              '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, NOW(), NOW()
+            )
+            """
+        ),
+        {
+            "participant": COURSE_B_PARTICIPANT,
+            "chatbot": CHATBOT_B,
+            "course": COURSE_B,
+        },
+    )
+
+    session.execute(
+        text(
+            """
+            UPDATE "ChatUsageCredits"
+            SET "disclaimerDeclined" = true
+            WHERE "participantId" = :participant
+            """
+        ),
+        {"participant": ACCEPTED},
+    )
+    compute_participant_chat_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[str(COURSE_A)],
+    )
+    compute_aggregated_chatbot_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[str(COURSE_A)],
+    )
+
+    counts = (
+        session.execute(
+            text(
+                """
+            SELECT
+              (SELECT COUNT(*) FROM "ParticipantChatAnalytics"
+               WHERE "courseId" = :course_a) AS participant_a,
+              (SELECT COUNT(*) FROM "ParticipantChatAnalytics"
+               WHERE "courseId" = :course_b) AS participant_b,
+              (SELECT COUNT(*) FROM "AggregatedChatbotAnalytics"
+               WHERE "courseId" = :course_a) AS aggregate_a,
+              (SELECT COUNT(*) FROM "AggregatedChatbotAnalytics"
+               WHERE "courseId" = :course_b) AS aggregate_b
+            """
+            ),
+            {"course_a": COURSE_A, "course_b": COURSE_B},
+        )
+        .mappings()
+        .one()
+    )
+    assert dict(counts) == {
+        "participant_a": 0,
+        "participant_b": 1,
+        "aggregate_a": 0,
+        "aggregate_b": 1,
+    }
+
+    session.execute(
+        text(
+            """
+            INSERT INTO "Participation" ("participantId", "courseId")
+            VALUES (:accepted, :course_a)
+            """
+        ),
+        {
+            "accepted": ACCEPTED,
+            "course_a": COURSE_A,
+        },
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ParticipantChatOutcome" (
+              "participantId", "courseId", "chatMessagesInCourse",
+              "chatDoseBucket", "hasBothModalities", "createdAt", "updatedAt"
+            ) VALUES
+              (:stale, :course_a, 3, 'HIGH', false, NOW(), NOW()),
+              (:course_b_participant, :course_b, 3, 'HIGH', false, NOW(), NOW())
+            """
+        ),
+        {
+            "stale": STALE,
+            "course_b_participant": COURSE_B_PARTICIPANT,
+            "course_a": COURSE_A,
+            "course_b": COURSE_B,
+        },
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ParticipantCourseAnalytics" (
+              "participantId", "courseId", "hasChatActivity"
+            ) VALUES
+              (:accepted, :course_a, true),
+              (:stale, :course_a, true),
+              (:course_b_participant, :course_b, true)
+            """
+        ),
+        {
+            "accepted": ACCEPTED,
+            "stale": STALE,
+            "course_b_participant": COURSE_B_PARTICIPANT,
+            "course_a": COURSE_A,
+            "course_b": COURSE_B,
+        },
+    )
+
+    report_source_counts(session, course_ids=[str(COURSE_A)])
+    reconcile_chat_quiz_correlation(session, course_ids=[str(COURSE_A)])
+
+    outcomes = session.execute(
+        text(
+            """
+            SELECT "participantId", "courseId", "chatMessagesInCourse"
+            FROM "ParticipantChatOutcome"
+            ORDER BY "courseId", "participantId"
+            """
+        )
+    ).mappings()
+    assert [dict(row) for row in outcomes] == [
+        {
+            "participantId": ACCEPTED,
+            "courseId": COURSE_A,
+            "chatMessagesInCourse": 0,
+        },
+        {
+            "participantId": COURSE_B_PARTICIPANT,
+            "courseId": COURSE_B,
+            "chatMessagesInCourse": 3,
+        },
+    ]
+
+    activity = session.execute(
+        text(
+            """
+            SELECT "participantId", "courseId", "hasChatActivity"
+            FROM "ParticipantCourseAnalytics"
+            ORDER BY "courseId", "participantId"
+            """
+        )
+    ).mappings()
+    assert [dict(row) for row in activity] == [
+        {
+            "participantId": ACCEPTED,
+            "courseId": COURSE_A,
+            "hasChatActivity": False,
+        },
+        {
+            "participantId": STALE,
+            "courseId": COURSE_A,
+            "hasChatActivity": False,
+        },
+        {
+            "participantId": COURSE_B_PARTICIPANT,
+            "courseId": COURSE_B,
+            "hasChatActivity": True,
+        },
+    ]
+
+
+@pytest.mark.integration
+def test_chat_window_delete_rolls_back_when_recompute_fails(session, monkeypatch):
+    from src.modules.aggregated_chat_analytics import (
+        compute_aggregated_chatbot_analytics as module,
+    )
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+    session.execute(
+        text(
+            """
+            INSERT INTO "AggregatedChatbotAnalytics" (
+              "type", "timestamp", "chatbotId", "courseId",
+              "activeParticipants", "newParticipants", "returningParticipants",
+              threads, "userMessages", "assistantMessages", "totalCreditsUsed",
+              "disclaimerAcceptedCount", "disclaimerDeclinedCount",
+              "hourOfDayDistribution", "modelDistribution", "modeDistribution",
+              "reasoningEffortDistribution", "createdAt", "updatedAt"
+            ) VALUES (
+              'DAILY', DATE '2026-07-01', :chatbot, :course,
+              1, 0, 0, 1, 1, 0, 0, 1, 0,
+              '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, NOW(), NOW()
+            )
+            """
+        ),
+        {"chatbot": CHATBOT_A, "course": COURSE_A},
+    )
+    session.flush()
+
+    savepoint = session.begin_nested()
+    monkeypatch.setattr(module, "_SQL_DEFAULT", "SELECT 1 / 0")
+    with pytest.raises(Exception, match="division by zero"):
+        module.compute_aggregated_chatbot_analytics(
+            session,
+            "2026-07-01T00:00:00Z",
+            "2026-07-02T00:00:00Z",
+            "2026-07-01",
+            "DAILY",
+            course_ids=[str(COURSE_A)],
+        )
+    savepoint.rollback()
+
+    remaining = session.execute(
+        text(
+            """
+            SELECT "userMessages"
+            FROM "AggregatedChatbotAnalytics"
+            WHERE "courseId" = :course_id
+            """
+        ),
+        {"course_id": COURSE_A},
+    ).scalar_one()
+    assert remaining == 1

--- a/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
+++ b/apps/analytics/tests/test_chat_privacy_reconciliation_sql.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 import pytest
 from sqlalchemy import text
 
-from src.modules.utils import AnalyticsRunConfig, analytics_run_context
+from src.modules.utils import (
+    AnalyticsMode,
+    AnalyticsRunConfig,
+    analytics_run_context,
+)
 
 COURSE_A = UUID("aaaa0000-0000-0000-0000-000000000001")
 COURSE_B = UUID("aaaa0000-0000-0000-0000-000000000002")
@@ -436,6 +441,7 @@ def test_incremental_validity_marks_only_current_course_scope(session, monkeypat
     )
     monkeypatch.setenv("ANALYTICS_MODE", "incremental")
     monkeypatch.setenv("ANALYTICS_COURSE_IDS", str(COURSE_A))
+    monkeypatch.setenv("ANALYTICS_CHAT_CUTOFF", "2026-07-09T09:30:00Z")
 
     mark_analytics_valid(session)
 
@@ -868,7 +874,11 @@ def test_incremental_revocation_rebuilds_old_and_recent_chat_windows(session):
 
 
 @pytest.mark.integration
-def test_acceptance_during_workflow_remains_visible_after_start_cutoff(session):
+@pytest.mark.parametrize("mode", ["incremental", "finalize"])
+def test_acceptance_during_workflow_remains_visible_after_start_cutoff(
+    session,
+    mode: AnalyticsMode,
+):
     from src.modules.analytics_validity.mark_analytics_valid import (
         mark_analytics_valid,
     )
@@ -923,13 +933,26 @@ def test_acceptance_during_workflow_remains_visible_after_start_cutoff(session):
     )
 
     first_cutoff = AnalyticsRunConfig(
-        mode="incremental",
+        mode=mode,
         course_ids=(str(COURSE_A),),
         window_since="2026-07-09",
         chat_analytics_cutoff="2026-07-09T12:00:00+00:00",
     )
     with analytics_run_context(first_cutoff):
         mark_analytics_valid(session)
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT "analyticsFinalizedAt"
+                FROM "Course"
+                WHERE id = :course
+                """
+            ),
+            {"course": COURSE_A},
+        ).scalar_one()
+        is None
+    )
 
     history_runs = plan_chat_analytics_runs(
         session,
@@ -962,7 +985,7 @@ def test_acceptance_during_workflow_remains_visible_after_start_cutoff(session):
     )
 
     second_cutoff = AnalyticsRunConfig(
-        mode="incremental",
+        mode=mode,
         course_ids=(str(COURSE_A),),
         window_since="2026-07-09",
         chat_analytics_cutoff="2026-07-11T00:00:00+00:00",
@@ -976,6 +999,148 @@ def test_acceptance_during_workflow_remains_visible_after_start_cutoff(session):
         "2026-07-09",
     )
     assert [(run.course_ids, run.window_since) for run in converged_runs] == [([str(COURSE_A)], "2026-07-09")]
+    finalized_at = session.execute(
+        text(
+            """
+            SELECT "analyticsFinalizedAt"
+            FROM "Course"
+            WHERE id = :course
+            """
+        ),
+        {"course": COURSE_A},
+    ).scalar_one()
+    assert (finalized_at is not None) is (mode == "finalize")
+
+
+@pytest.mark.integration
+def test_revocation_during_finalize_remains_eligible_for_follow_up(session):
+    from src.modules.analytics_validity.mark_analytics_valid import (
+        mark_analytics_valid,
+    )
+    from src.modules.chat_analytics.compute_participant_chat_analytics import (
+        compute_participant_chat_analytics,
+    )
+    from src.modules.chat_analytics.consent_reconciliation import (
+        plan_chat_analytics_runs,
+        purge_ineligible_participant_chat_analytics,
+    )
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+    compute_participant_chat_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[str(COURSE_A)],
+    )
+    initial_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in initial_runs] == [([str(COURSE_A)], "2026-07-09")]
+
+    session.execute(
+        text(
+            """
+            UPDATE "ChatUsageCredits"
+            SET "acceptedDisclaimerId" = NULL,
+                "disclaimerAcceptedAt" = NULL,
+                "disclaimerDeclined" = true,
+                "updatedAt" = TIMESTAMP '2026-07-10 00:00:00'
+            WHERE "participantId" = :participant
+              AND "chatbotId" = :chatbot
+            """
+        ),
+        {"participant": ACCEPTED, "chatbot": CHATBOT_A},
+    )
+    first_cutoff = AnalyticsRunConfig(
+        mode="finalize",
+        course_ids=(str(COURSE_A),),
+        chat_analytics_cutoff="2026-07-09T12:00:00+00:00",
+    )
+    with analytics_run_context(first_cutoff):
+        mark_analytics_valid(session)
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT "analyticsFinalizedAt"
+                FROM "Course"
+                WHERE id = :course
+                """
+            ),
+            {"course": COURSE_A},
+        ).scalar_one()
+        is None
+    )
+
+    history_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in history_runs] == [([str(COURSE_A)], "2026-07-01")]
+    purge_ineligible_participant_chat_analytics(session, [str(COURSE_A)])
+
+    second_cutoff = AnalyticsRunConfig(
+        mode="finalize",
+        course_ids=(str(COURSE_A),),
+        chat_analytics_cutoff="2026-07-11T00:00:00+00:00",
+    )
+    with analytics_run_context(second_cutoff):
+        mark_analytics_valid(session)
+    assert (
+        session.execute(
+            text(
+                """
+                SELECT "analyticsFinalizedAt" IS NOT NULL
+                FROM "Course"
+                WHERE id = :course
+                """
+            ),
+            {"course": COURSE_A},
+        ).scalar_one()
+        is True
+    )
+    converged_runs = plan_chat_analytics_runs(
+        session,
+        [str(COURSE_A)],
+        "2026-07-09",
+    )
+    assert [(run.course_ids, run.window_since) for run in converged_runs] == [([str(COURSE_A)], "2026-07-09")]
+
+
+@pytest.mark.integration
+def test_chat_cutoff_is_stored_as_utc_naive_in_non_utc_session(session):
+    from src.modules.analytics_validity.mark_analytics_valid import (
+        mark_analytics_valid,
+    )
+
+    _create_temp_tables(session)
+    _seed_chat_sources(session)
+    session.execute(text("SET LOCAL TIME ZONE 'Europe/Zurich'"))
+    config = AnalyticsRunConfig(
+        mode="incremental",
+        course_ids=(str(COURSE_A),),
+        chat_analytics_cutoff="2026-07-09T09:30:00+00:00",
+    )
+    with analytics_run_context(config):
+        mark_analytics_valid(session)
+
+    stored_cutoff = session.execute(
+        text(
+            """
+            SELECT "chatAnalyticsValidAt"
+            FROM "Course"
+            WHERE id = :course
+            """
+        ),
+        {"course": COURSE_A},
+    ).scalar_one()
+    assert stored_cutoff == datetime(2026, 7, 9, 9, 30)
 
 
 @pytest.mark.integration

--- a/apps/analytics/tests/test_chat_quiz_correlation_buffer.py
+++ b/apps/analytics/tests/test_chat_quiz_correlation_buffer.py
@@ -38,31 +38,26 @@ def _populate(buffer: CaptureBuffer) -> None:
     buffer.record("ParticipantPerformance", _PERF_ROWS)
 
 
-def test_assert_preconditions_raises_when_buffer_empty():
+def test_report_source_counts_accepts_empty_buffer():
     from src.modules.chat_quiz_correlation.compute_chat_quiz_correlation import (
-        AnalyticsNotReadyError,
-        assert_preconditions,
+        report_source_counts,
     )
 
     buffer = CaptureBuffer()
     with intercept_writes(buffer):
-        try:
-            assert_preconditions(session=None, course_ids=["c1"])
-        except AnalyticsNotReadyError:
-            return
-    raise AssertionError("expected AnalyticsNotReadyError for empty buffer")
+        report_source_counts(session=None, course_ids=["c1"])
 
 
-def test_assert_preconditions_passes_when_buffer_has_rows():
+def test_report_source_counts_accepts_populated_buffer():
     from src.modules.chat_quiz_correlation.compute_chat_quiz_correlation import (
-        assert_preconditions,
+        report_source_counts,
     )
 
     buffer = CaptureBuffer()
     _populate(buffer)
     with intercept_writes(buffer):
         # No exception — DB is never touched because buffer_registry is active.
-        assert_preconditions(session=None, course_ids=["c1"])
+        report_source_counts(session=None, course_ids=["c1"])
 
 
 def test_compute_outcomes_writes_rows_into_buffer_with_expected_columns():

--- a/apps/analytics/tests/test_chat_quiz_correlation_buffer.py
+++ b/apps/analytics/tests/test_chat_quiz_correlation_buffer.py
@@ -45,7 +45,7 @@ def test_report_source_counts_accepts_empty_buffer():
 
     buffer = CaptureBuffer()
     with intercept_writes(buffer):
-        report_source_counts(session=None, course_ids=["c1"])
+        report_source_counts(session=None, course_ids=["c1"], verbose=True)
 
 
 def test_report_source_counts_accepts_populated_buffer():
@@ -57,7 +57,7 @@ def test_report_source_counts_accepts_populated_buffer():
     _populate(buffer)
     with intercept_writes(buffer):
         # No exception — DB is never touched because buffer_registry is active.
-        report_source_counts(session=None, course_ids=["c1"])
+        report_source_counts(session=None, course_ids=["c1"], verbose=True)
 
 
 def test_compute_outcomes_writes_rows_into_buffer_with_expected_columns():

--- a/apps/analytics/tests/test_chat_topic_clustering_script.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_script.py
@@ -16,12 +16,28 @@ _MISSING = object()
 def isolate_database_modules() -> Iterator[None]:
     """Do not retain modules imported under a test-only DATABASE_URL."""
     previous = {name: sys.modules.get(name, _MISSING) for name in _DATABASE_MODULES}
+    previous_parent_attributes = {}
+    for name in _DATABASE_MODULES:
+        parent_name, attribute = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        previous_parent_attributes[(parent_name, attribute)] = (
+            getattr(parent, attribute, _MISSING) if parent is not None else _MISSING
+        )
     yield
     for name, module in previous.items():
         if module is _MISSING:
             sys.modules.pop(name, None)
         else:
             sys.modules[name] = cast(types.ModuleType, module)
+    for (parent_name, attribute), value in previous_parent_attributes.items():
+        parent = sys.modules.get(parent_name)
+        if parent is None:
+            continue
+        if value is _MISSING:
+            if hasattr(parent, attribute):
+                delattr(parent, attribute)
+        else:
+            setattr(parent, attribute, value)
 
 
 class _Scalars:

--- a/apps/analytics/tests/test_chat_topic_clustering_script.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_script.py
@@ -3,8 +3,25 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from collections.abc import Iterator
+from typing import cast
 
 import pytest
+
+_DATABASE_MODULES = ("src.db", "src.scripts.10_chat_topic_clustering")
+_MISSING = object()
+
+
+@pytest.fixture(autouse=True)
+def isolate_database_modules() -> Iterator[None]:
+    """Do not retain modules imported under a test-only DATABASE_URL."""
+    previous = {name: sys.modules.get(name, _MISSING) for name in _DATABASE_MODULES}
+    yield
+    for name, module in previous.items():
+        if module is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = cast(types.ModuleType, module)
 
 
 class _Scalars:

--- a/apps/analytics/tests/test_chat_topic_clustering_script.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_script.py
@@ -4,40 +4,19 @@ import importlib
 import sys
 import types
 from collections.abc import Iterator
-from typing import cast
 
 import pytest
 
+from tests.module_isolation import preserve_imported_modules
+
 _DATABASE_MODULES = ("src.db", "src.scripts.10_chat_topic_clustering")
-_MISSING = object()
 
 
 @pytest.fixture(autouse=True)
 def isolate_database_modules() -> Iterator[None]:
     """Do not retain modules imported under a test-only DATABASE_URL."""
-    previous = {name: sys.modules.get(name, _MISSING) for name in _DATABASE_MODULES}
-    previous_parent_attributes = {}
-    for name in _DATABASE_MODULES:
-        parent_name, attribute = name.rsplit(".", 1)
-        parent = sys.modules.get(parent_name)
-        previous_parent_attributes[(parent_name, attribute)] = (
-            getattr(parent, attribute, _MISSING) if parent is not None else _MISSING
-        )
-    yield
-    for name, module in previous.items():
-        if module is _MISSING:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = cast(types.ModuleType, module)
-    for (parent_name, attribute), value in previous_parent_attributes.items():
-        parent = sys.modules.get(parent_name)
-        if parent is None:
-            continue
-        if value is _MISSING:
-            if hasattr(parent, attribute):
-                delattr(parent, attribute)
-        else:
-            setattr(parent, attribute, value)
+    with preserve_imported_modules(_DATABASE_MODULES):
+        yield
 
 
 class _Scalars:

--- a/apps/analytics/tests/test_course_scope_sql.py
+++ b/apps/analytics/tests/test_course_scope_sql.py
@@ -90,10 +90,11 @@ def test_participant_chat_analytics_uses_zero_attachment_fallback_when_table_mis
         course_ids=None,
     )
 
-    assert len(session.statements) == 2
+    assert len(session.statements) == 3
     assert "information_schema.tables" in session.statements[0]
-    assert '"ChatAttachment"' not in session.statements[1]
-    assert "attachment_rollup" in session.statements[1]
+    assert 'DELETE FROM "ParticipantChatAnalytics"' in session.statements[1]
+    assert '"ChatAttachment"' not in session.statements[2]
+    assert "attachment_rollup" in session.statements[2]
 
 
 def test_attachment_support_is_not_cached_without_a_stable_bind_url():
@@ -130,7 +131,7 @@ def test_aggregated_chatbot_analytics_renders_course_filter_for_weekly():
         course_ids=[course_id],
     )
 
-    assert f"""AND cb."courseId" IN ('{course_id}')""" in session.statements[0]
+    assert f"""AND cb."courseId" IN ('{course_id}')""" in session.statements[1]
 
 
 @pytest.mark.parametrize("analytics_type", ["DAILY", "WEEKLY", "MONTHLY", "COURSE"])
@@ -195,15 +196,15 @@ def test_chat_quiz_correlation_renders_course_filters():
     assert f"""AND pca."courseId" IN ('{course_id}')""" in update_session.statements[0]
 
 
-def test_chat_quiz_correlation_preconditions_scope_to_selected_course():
+def test_chat_quiz_correlation_source_counts_scope_to_selected_course():
     from src.modules.chat_quiz_correlation.compute_chat_quiz_correlation import (
-        assert_preconditions,
+        report_source_counts,
     )
 
     course_id = str(uuid.uuid4())
     session = _CaptureSession(scalars=[1, 1])
 
-    assert_preconditions(session, course_ids=[course_id])
+    report_source_counts(session, course_ids=[course_id])
 
     assert len(session.statements) == 2
     assert f""""courseId" IN ('{course_id}')""" in session.statements[0]

--- a/apps/analytics/tests/test_course_scope_sql.py
+++ b/apps/analytics/tests/test_course_scope_sql.py
@@ -204,7 +204,7 @@ def test_chat_quiz_correlation_source_counts_scope_to_selected_course():
     course_id = str(uuid.uuid4())
     session = _CaptureSession(scalars=[1, 1])
 
-    report_source_counts(session, course_ids=[course_id])
+    report_source_counts(session, course_ids=[course_id], verbose=True)
 
     assert len(session.statements) == 2
     assert f""""courseId" IN ('{course_id}')""" in session.statements[0]

--- a/apps/analytics/tests/test_dryrun_buffer_registry.py
+++ b/apps/analytics/tests/test_dryrun_buffer_registry.py
@@ -80,6 +80,29 @@ def test_registry_returns_empty_rows_for_known_table_with_no_rows():
         assert columns == ["type", "userMessages"]
 
 
+def test_chat_consent_reconciliation_bypasses_database_in_dryrun():
+    from src.modules.chat_analytics.consent_reconciliation import (
+        plan_chat_analytics_runs,
+        purge_ineligible_participant_chat_analytics,
+    )
+
+    buffer = CaptureBuffer()
+
+    with intercept_writes(buffer):
+        runs = plan_chat_analytics_runs(
+            session=None,
+            course_ids=["course-1"],
+            window_since="2026-07-09",
+        )
+        purged = purge_ineligible_participant_chat_analytics(
+            session=None,
+            course_ids=["course-1"],
+        )
+
+    assert [(run.course_ids, run.window_since) for run in runs] == [(["course-1"], "2026-07-09")]
+    assert purged == 0
+
+
 # ---------------------------------------------------------------------------
 # load_participant_analytics buffer-first path
 # ---------------------------------------------------------------------------

--- a/apps/analytics/tests/test_native_hatchet_worker.py
+++ b/apps/analytics/tests/test_native_hatchet_worker.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -14,9 +15,23 @@ class FakeTask:
         self.name = options["name"]
 
 
+class FakeRunsClient:
+    def __init__(self, workflow_created_at: datetime | None) -> None:
+        self.workflow_created_at = workflow_created_at
+
+    def get(self, _run_id: str) -> Any:
+        return SimpleNamespace(run=SimpleNamespace(created_at=self.workflow_created_at))
+
+
 class FakeContext:
-    def __init__(self, done: bool = False) -> None:
+    def __init__(
+        self,
+        done: bool = False,
+        workflow_created_at: datetime | None = None,
+    ) -> None:
         self._done = done
+        self.workflow_run_id = "workflow-run-1"
+        self.runs_client = FakeRunsClient(workflow_created_at)
 
     def done(self) -> bool:
         return self._done
@@ -188,6 +203,9 @@ def test_analytics_dags_split_concurrency_and_preserve_task_contract() -> None:
         assert [parent.name for parent in tasks["s13-platform-semester-analytics"].options["parents"]] == [
             "s2-course-heatmap"
         ]
+        assert [parent.name for parent in tasks["s9-aggregated-chatbot-analytics"].options["parents"]] == [
+            "s8-chat-analytics"
+        ]
         assert [parent.name for parent in tasks["s11-chat-quiz-correlation"].options["parents"]] == [
             "s4-participant-perf",
             "s8-chat-analytics",
@@ -215,6 +233,18 @@ def test_analytics_dags_split_concurrency_and_preserve_task_contract() -> None:
         mode="full",
         course_ids=("course-2",),
         window_since=None,
+    )
+
+    cutoff = datetime(2026, 7, 23, 9, 30, tzinfo=timezone.utc)
+    freshness_tasks["s99-mark-analytics-valid"].fn(
+        hatchet_worker.AnalyticsRunInput(courseId="course-1"),
+        FakeContext(workflow_created_at=cutoff),
+    )
+    assert calls[2][1] == hatchet_worker.AnalyticsRunConfig(
+        mode="finalize",
+        course_ids=("course-1",),
+        window_since=None,
+        chat_analytics_cutoff="2026-07-23T09:30:00+00:00",
     )
 
     with pytest.raises(ValueError, match="ANALYTICS_ALLOW_FULL"):
@@ -249,3 +279,8 @@ def test_cancelled_script_is_non_retryable_at_hatchet_boundary() -> None:
         )
 
     assert isinstance(exc_info.value.__cause__, hatchet_worker.AnalyticsRunCancelled)
+
+
+def test_workflow_run_cutoff_requires_hatchet_creation_timestamp() -> None:
+    with pytest.raises(RuntimeError, match="no creation timestamp"):
+        hatchet_worker.workflow_run_cutoff(cast(Any, FakeContext()))

--- a/apps/analytics/tests/test_native_hatchet_worker.py
+++ b/apps/analytics/tests/test_native_hatchet_worker.py
@@ -235,7 +235,7 @@ def test_analytics_dags_split_concurrency_and_preserve_task_contract() -> None:
         window_since=None,
     )
 
-    cutoff = datetime(2026, 7, 23, 9, 30, tzinfo=timezone.utc)
+    cutoff = datetime(2026, 7, 23, 9, 30, 0, 123456, tzinfo=timezone.utc)
     freshness_tasks["s99-mark-analytics-valid"].fn(
         hatchet_worker.AnalyticsRunInput(courseId="course-1"),
         FakeContext(workflow_created_at=cutoff),
@@ -244,7 +244,7 @@ def test_analytics_dags_split_concurrency_and_preserve_task_contract() -> None:
         mode="finalize",
         course_ids=("course-1",),
         window_since=None,
-        chat_analytics_cutoff="2026-07-23T09:30:00+00:00",
+        chat_analytics_cutoff="2026-07-23T09:30:00.122+00:00",
     )
 
     with pytest.raises(ValueError, match="ANALYTICS_ALLOW_FULL"):

--- a/apps/analytics/tests/test_privacy_and_scope.py
+++ b/apps/analytics/tests/test_privacy_and_scope.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import importlib
 import uuid
+from typing import Any, cast
 from unittest import mock
+
+import pytest
 
 from src.modules.analytics_validity.mark_analytics_valid import _render_sql
 
@@ -155,7 +158,27 @@ def test_incremental_scope_filters_completion_watermarks():
     statement = _render_sql(False, [COURSE_A])
 
     assert f"AND c.id IN ('{COURSE_A}')" in statement
-    assert '\n  "analyticsFinalizedAt" = NOW(),' not in statement
+    assert '"analyticsFinalizedAt" = CASE' not in statement
+
+
+def test_finalize_scope_defers_terminal_marker_for_pending_consent():
+    statement = _render_sql(True, [COURSE_A])
+
+    assert '"analyticsFinalizedAt" = CASE' in statement
+    assert "pending_chat_changes pending" in statement
+    assert f"""cb."courseId" IN ('{COURSE_A}')""" in statement
+    assert 'AND c."analyticsFinalizedAt" IS NULL' in statement
+
+
+def test_validity_marker_fails_closed_without_immutable_cutoff(monkeypatch):
+    from src.modules.analytics_validity.mark_analytics_valid import (
+        mark_analytics_valid,
+    )
+
+    monkeypatch.delenv("ANALYTICS_CHAT_CUTOFF", raising=False)
+
+    with pytest.raises(RuntimeError, match="immutable workflow cutoff"):
+        mark_analytics_valid(cast(Any, None))
 
 
 def test_empty_incremental_scope_updates_no_course():

--- a/apps/analytics/tests/test_privacy_and_scope.py
+++ b/apps/analytics/tests/test_privacy_and_scope.py
@@ -167,7 +167,7 @@ def test_finalize_scope_defers_terminal_marker_for_pending_consent():
     assert '"analyticsFinalizedAt" = CASE' in statement
     assert "pending_chat_changes pending" in statement
     assert f"""cb."courseId" IN ('{COURSE_A}')""" in statement
-    assert 'AND c."analyticsFinalizedAt" IS NULL' in statement
+    assert 'AND c."analyticsFinalizedAt" IS NULL' not in statement
 
 
 def test_validity_marker_fails_closed_without_immutable_cutoff(monkeypatch):

--- a/apps/analytics/tests/test_privacy_and_scope.py
+++ b/apps/analytics/tests/test_privacy_and_scope.py
@@ -140,7 +140,7 @@ def test_empty_chat_source_reconciles_scoped_outcomes_and_activity(monkeypatch):
     monkeypatch.setattr(module.buffer_registry, "is_active", lambda: False)
     session = _CaptureSession(scalars=[0, 0])
 
-    module.report_source_counts(session, course_ids=[COURSE_A])
+    module.report_source_counts(session, course_ids=[COURSE_A], verbose=True)
     result = module.reconcile_chat_quiz_correlation(session, course_ids=[COURSE_A])
 
     statements = [str(statement) for statement in session.statements]

--- a/apps/analytics/tests/test_privacy_and_scope.py
+++ b/apps/analytics/tests/test_privacy_and_scope.py
@@ -1,248 +1,162 @@
 from __future__ import annotations
 
 import importlib
-import unittest
-from contextlib import AbstractContextManager
-from datetime import timedelta
-from types import TracebackType
+import uuid
 from unittest import mock
 
-import pandas as pd
-
 from src.modules.analytics_validity.mark_analytics_valid import _render_sql
-from src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics import (
-    _DELETE_SQL as _DELETE_AGGREGATE_SQL,
-)
-from src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics import (
-    _SQL_WEEKLY,
-    compute_aggregated_chatbot_analytics,
-)
-from src.modules.chat_analytics.compute_participant_chat_analytics import (
-    _DELETE_SQL as _DELETE_PARTICIPANT_SQL,
-    _SQL,
-    compute_participant_chat_analytics,
-)
-from src.modules.chat_quiz_correlation.compute_chat_quiz_correlation import (
-    _DELETE_OUTCOMES_SQL,
-    reconcile_chat_quiz_correlation,
-    report_source_counts,
-)
-
-cluster_module = importlib.import_module("src.modules.chat_topic_clustering.cluster_chatbot")
-responses_module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
 
 COURSE_A = "aaaa0000-0000-0000-0000-000000000001"
 COURSE_B = "aaaa0000-0000-0000-0000-000000000002"
 
 
-class _ParticipantTable:
-    def __init__(self) -> None:
-        self.where = None
-        self.include = None
+class _Result:
+    def __init__(self, *, rowcount: int = 7, scalar: int = 0):
+        self.rowcount = rowcount
+        self._scalar = scalar
 
-    def find_many(self, *, where=None, include=None):
-        self.where = where
-        self.include = include
+    def scalar_one(self):
+        return self._scalar
+
+    def scalars(self):
+        return self
+
+    def all(self):
         return []
 
 
-class _ParticipantDb:
-    def __init__(self) -> None:
-        self.participant = _ParticipantTable()
+class _CaptureSession:
+    def __init__(self, scalars: list[int] | None = None):
+        self.statements: list[object] = []
+        self.params: list[dict[str, object] | None] = []
+        self.scalars = list(scalars or [])
+        self.commits = 0
+
+    def execute(self, statement, params=None):
+        self.statements.append(statement)
+        self.params.append(params)
+        scalar = self.scalars.pop(0) if self.scalars else 0
+        return _Result(scalar=scalar)
+
+    def commit(self):
+        self.commits += 1
 
 
-class _Transaction:
-    def __init__(self) -> None:
-        self.calls: list[tuple[object, ...]] = []
+def test_participant_response_query_scopes_both_activity_types():
+    module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
+    session = _CaptureSession()
 
-    def execute_raw(self, *args: object) -> int:
-        self.calls.append(args)
-        return 7
+    result = module.get_participant_responses(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        course_ids=[COURSE_A, COURSE_B],
+    )
 
-
-class _TransactionContext(AbstractContextManager[_Transaction]):
-    def __init__(self, transaction: _Transaction) -> None:
-        self.transaction = transaction
-
-    def __enter__(self) -> _Transaction:
-        return self.transaction
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        return None
+    statement = str(session.statements[0])
+    params = session.statements[0].compile().params
+    assert 'FROM "PracticeQuiz"' in statement
+    assert 'FROM "MicroLearning"' in statement
+    assert '"PracticeQuiz"."courseId" IN ' in statement
+    assert '"MicroLearning"."courseId" IN ' in statement
+    assert [COURSE_A, COURSE_B] in params.values()
+    assert result.empty
 
 
-class _ChatDb:
-    def __init__(self) -> None:
-        self.transaction = _Transaction()
-        self.timeout = None
+def test_participant_chat_window_replaces_only_scoped_rows():
+    module = importlib.import_module("src.modules.chat_analytics.compute_participant_chat_analytics")
+    session = _CaptureSession(scalars=[0])
 
-    def tx(self, *, timeout=None):
-        self.timeout = timeout
-        return _TransactionContext(self.transaction)
+    rows = module.compute_participant_chat_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-02T00:00:00Z",
+        "2026-07-01",
+        "DAILY",
+        course_ids=[COURSE_A],
+    )
 
-
-class _CorrelationDb(_ChatDb):
-    def query_raw(self, *_args: object) -> list[dict[str, int]]:
-        return [{"n": 0}]
-
-
-class ParticipantScopeTests(unittest.TestCase):
-    def test_course_scope_is_applied_to_parent_and_nested_detail_queries(self):
-        db = _ParticipantDb()
-
-        with mock.patch.object(
-            responses_module,
-            "convert_to_df",
-            return_value=pd.DataFrame(),
-        ):
-            responses_module.get_participant_responses(
-                db,
-                "2026-07-01T00:00:00Z",
-                "2026-07-02T00:00:00Z",
-                course_ids=[COURSE_A, COURSE_B],
-            )
-
-        detail_where = {
-            "createdAt": {
-                "gte": "2026-07-01T00:00:00Z",
-                "lte": "2026-07-02T00:00:00Z",
-            },
-            "OR": [
-                {"practiceQuiz": {"is": {"courseId": {"in": [COURSE_A, COURSE_B]}}}},
-                {"microLearning": {"is": {"courseId": {"in": [COURSE_A, COURSE_B]}}}},
-            ],
-        }
-        self.assertEqual(
-            db.participant.where,
-            {"detailQuestionResponses": {"some": detail_where}},
-        )
-        self.assertEqual(
-            db.participant.include["detailQuestionResponses"]["where"],
-            detail_where,
-        )
+    statements = [str(statement) for statement in session.statements]
+    assert rows == 7
+    assert 'DELETE FROM "ParticipantChatAnalytics"' in statements[1]
+    assert f""""courseId" IN ('{COURSE_A}')""" in statements[1]
+    assert f"""cb."courseId" IN ('{COURSE_A}')""" in statements[2]
+    assert session.commits == 1
 
 
-class ConsentReconciliationTests(unittest.TestCase):
-    def test_participant_chat_window_is_replaced_atomically(self):
-        db = _ChatDb()
+def test_aggregate_chat_window_replaces_only_scoped_rows():
+    module = importlib.import_module("src.modules.aggregated_chat_analytics.compute_aggregated_chatbot_analytics")
+    session = _CaptureSession()
 
-        rows = compute_participant_chat_analytics(
-            db,
+    rows = module.compute_aggregated_chatbot_analytics(
+        session,
+        "2026-07-01T00:00:00Z",
+        "2026-07-08T00:00:00Z",
+        "2026-07-07",
+        "WEEKLY",
+        course_ids=[COURSE_A],
+    )
+
+    statements = [str(statement) for statement in session.statements]
+    assert rows == 7
+    assert 'DELETE FROM "AggregatedChatbotAnalytics"' in statements[0]
+    assert f""""courseId" IN ('{COURSE_A}')""" in statements[0]
+    assert f"""cb."courseId" IN ('{COURSE_A}')""" in statements[1]
+    assert session.commits == 1
+
+
+def test_below_threshold_clustering_clears_previous_rows():
+    module = importlib.import_module("src.modules.chat_topic_clustering.cluster_chatbot")
+    session = object()
+
+    with (
+        mock.patch.object(module, "load_user_text", return_value=[]),
+        mock.patch.object(module, "save_clusters", return_value=0) as save,
+    ):
+        result = module.cluster_chatbot(
+            session,
+            str(uuid.uuid4()),
             "2026-07-01T00:00:00Z",
             "2026-07-02T00:00:00Z",
-            "2026-07-01",
-            "DAILY",
-        )
-
-        self.assertEqual(rows, 7)
-        self.assertEqual(db.timeout, timedelta(minutes=30))
-        self.assertEqual(
-            db.transaction.calls,
-            [
-                (_DELETE_PARTICIPANT_SQL, "DAILY", "2026-07-01"),
-                (
-                    _SQL,
-                    "2026-07-01T00:00:00Z",
-                    "2026-07-02T00:00:00Z",
-                    "DAILY",
-                    "2026-07-01",
-                ),
-            ],
-        )
-
-    def test_aggregate_chat_window_is_replaced_atomically(self):
-        db = _ChatDb()
-
-        rows = compute_aggregated_chatbot_analytics(
-            db,
-            "2026-07-01T00:00:00Z",
-            "2026-07-08T00:00:00Z",
-            "2026-07-07",
-            "WEEKLY",
-        )
-
-        self.assertEqual(rows, 7)
-        self.assertEqual(db.timeout, timedelta(minutes=30))
-        self.assertEqual(
-            db.transaction.calls,
-            [
-                (_DELETE_AGGREGATE_SQL, "WEEKLY", "2026-07-07"),
-                (
-                    _SQL_WEEKLY,
-                    "2026-07-01T00:00:00Z",
-                    "2026-07-08T00:00:00Z",
-                    "2026-07-07",
-                ),
-            ],
-        )
-
-    def test_below_threshold_clustering_clears_previous_rows(self):
-        db = object()
-
-        with (
-            mock.patch.object(cluster_module, "load_user_text", return_value=[]),
-            mock.patch.object(cluster_module, "save_clusters", return_value=0) as save,
-        ):
-            result = cluster_module.cluster_chatbot(
-                db,
-                "chatbot-a",
-                "2026-07-01T00:00:00Z",
-                "2026-07-02T00:00:00Z",
-                "COURSE",
-                "1970-01-01",
-            )
-
-        self.assertEqual(result, 0)
-        save.assert_called_once_with(
-            db,
-            "chatbot-a",
             "COURSE",
             "1970-01-01",
-            {},
-            [],
-            [],
-            verbose=False,
         )
 
-    def test_empty_chat_source_reconciles_outcomes_and_activity(self):
-        db = _CorrelationDb()
-
-        report_source_counts(db)
-        correlation_module = importlib.import_module("src.modules.chat_quiz_correlation.compute_chat_quiz_correlation")
-        with (
-            mock.patch.object(correlation_module, "_load", side_effect=["outcome SQL", "activity SQL"]),
-        ):
-            result = reconcile_chat_quiz_correlation(db)
-
-        self.assertEqual(result, (7, 7))
-        self.assertEqual(db.timeout, timedelta(minutes=30))
-        self.assertEqual(
-            db.transaction.calls,
-            [
-                (_DELETE_OUTCOMES_SQL,),
-                ("outcome SQL",),
-                ("activity SQL",),
-            ],
-        )
+    assert result == 0
+    save.assert_called_once_with(
+        session,
+        mock.ANY,
+        "COURSE",
+        "1970-01-01",
+        {},
+        [],
+        [],
+        verbose=False,
+    )
 
 
-class AnalyticsValidityScopeTests(unittest.TestCase):
-    def test_incremental_scope_filters_completion_watermarks(self):
-        statement = _render_sql(False, [COURSE_A])
+def test_empty_chat_source_reconciles_scoped_outcomes_and_activity(monkeypatch):
+    module = importlib.import_module("src.modules.chat_quiz_correlation.compute_chat_quiz_correlation")
+    monkeypatch.setattr(module.buffer_registry, "is_active", lambda: False)
+    session = _CaptureSession(scalars=[0, 0])
 
-        self.assertIn(f"AND c.id IN ('{COURSE_A}')", statement)
-        self.assertNotIn('\n  "analyticsFinalizedAt" = NOW(),', statement)
+    module.report_source_counts(session, course_ids=[COURSE_A])
+    result = module.reconcile_chat_quiz_correlation(session, course_ids=[COURSE_A])
 
-    def test_empty_incremental_scope_updates_no_course(self):
-        statement = _render_sql(False, [])
+    statements = [str(statement) for statement in session.statements]
+    assert result == (7, 7)
+    assert 'DELETE FROM "ParticipantChatOutcome"' in statements[2]
+    assert f""""courseId" IN ('{COURSE_A}')""" in statements[2]
+    assert f"""pca."courseId" IN ('{COURSE_A}')""" in statements[4]
+    assert session.commits == 1
 
-        self.assertIn("AND false", statement)
+
+def test_incremental_scope_filters_completion_watermarks():
+    statement = _render_sql(False, [COURSE_A])
+
+    assert f"AND c.id IN ('{COURSE_A}')" in statement
+    assert '\n  "analyticsFinalizedAt" = NOW(),' not in statement
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_empty_incremental_scope_updates_no_course():
+    assert "AND false" in _render_sql(False, [])

--- a/apps/analytics/tests/test_utils.py
+++ b/apps/analytics/tests/test_utils.py
@@ -22,6 +22,7 @@ from src.modules.utils import (  # noqa: E402
     AnalyticsRunConfig,
     analytics_mode,
     analytics_run_context,
+    analytics_run_config_from_env,
     analytics_window_since,
     apply_course_scope,
     iter_analytics_windows,
@@ -62,6 +63,14 @@ def test_window_since_returns_none_when_unset():
 def test_window_since_returns_trimmed_value():
     with mock.patch.dict(os.environ, {"ANALYTICS_WINDOW_SINCE": "  2026-04-01  "}):
         assert analytics_window_since() == "2026-04-01"
+
+
+def test_cli_run_config_reads_immutable_chat_cutoff():
+    with mock.patch.dict(
+        os.environ,
+        {"ANALYTICS_CHAT_CUTOFF": " 2026-07-23T09:30:00Z "},
+    ):
+        assert analytics_run_config_from_env().chat_analytics_cutoff == "2026-07-23T09:30:00Z"
 
 
 # --- should_skip_window ----------------------------------------------------

--- a/docs/learning-analytics-operations.md
+++ b/docs/learning-analytics-operations.md
@@ -106,6 +106,13 @@ For the first staging rollout, run the non-mutating
 a known low-volume course. Confirm task completion, expected analytics rows,
 and the course status before increasing scope.
 
+Before enabling the production cron, run one guarded `FULL` rebuild in a
+reviewed maintenance window. This establishes a consent-correct baseline for
+analytics rows created before the native worker tracked consent changes. After
+that baseline, incremental runs retain the 14-day fast path for unaffected
+courses and automatically rebuild older chat windows only where current
+disclaimer consent changed.
+
 ## Trigger modes
 
 Course admins can trigger the existing GraphQL mutation:

--- a/docs/learning-analytics-operations.md
+++ b/docs/learning-analytics-operations.md
@@ -125,7 +125,9 @@ mutation RecomputeCourseAnalytics($courseId: String!, $mode: AnalyticsMode!) {
 
 - `INCREMENTAL` — scoped course recompute with the default 14-day window.
 - `FINALIZE` — scoped course recompute without the incremental window; the
-  nightly scanner uses this route for ended courses.
+  nightly scanner uses this route for ended courses. If consent changes after
+  the workflow starts, the terminal marker stays unset and the scanner retries
+  the course on its next pass.
 - `FULL` — guarded rebuild through the protected full workflow. It fails
   closed unless the worker was explicitly deployed with `allowFull=true`.
 
@@ -174,6 +176,9 @@ only `s99-mark-analytics-valid` should mark a successful run valid.
    prerequisites, and script 10 clustering/model memory pressure.
 3. Prefer retriggering the complete course workflow with the original mode.
    Do not replay `s99-mark-analytics-valid` in isolation.
+   The final marker requires the immutable workflow cutoff; the legacy
+   `_initialize_analytics.sh` launcher supplies the same cutoff to every
+   script when that cold rollback path is used.
 4. Ordinary tasks have two automatic retries. Script 10 has no automatic retry
    because its CPU/memory-heavy work should not repeat without operator review.
 5. A superseded freshness run is intentionally canceled and is not an incident

--- a/docs/learning-analytics-operations.md
+++ b/docs/learning-analytics-operations.md
@@ -125,9 +125,10 @@ mutation RecomputeCourseAnalytics($courseId: String!, $mode: AnalyticsMode!) {
 
 - `INCREMENTAL` — scoped course recompute with the default 14-day window.
 - `FINALIZE` — scoped course recompute without the incremental window; the
-  nightly scanner uses this route for ended courses. If consent changes after
-  the workflow starts, the terminal marker stays unset and the scanner retries
-  the course on its next pass.
+  nightly scanner uses this route for ended courses. It also requeues an
+  already-finalized course when its chat privacy state changed after the last
+  successful cutoff, so a consent change racing with finalization is reconciled
+  on the next scan.
 - `FULL` — guarded rebuild through the protected full workflow. It fails
   closed unless the worker was explicitly deployed with `allowFull=true`.
 

--- a/packages/hatchet/src/tasks.ts
+++ b/packages/hatchet/src/tasks.ts
@@ -1,5 +1,6 @@
 import { Priority, type HatchetClient } from '@hatchet-dev/typescript-sdk'
 import { prisma } from '@klicker-uzh/prisma'
+import { Prisma } from '@klicker-uzh/prisma/client'
 import {
   HATCHET_EVENTS,
   type HatchetHandlers,
@@ -17,6 +18,7 @@ export function prepareHatchetTasks({
   redisAssessmentExec,
   redisCache,
   handlers,
+  database = prisma,
 }: {
   hatchet: HatchetClient
   pubSub: PubSub<any>
@@ -25,6 +27,7 @@ export function prepareHatchetTasks({
   redisAssessmentExec: Redis
   redisCache?: Redis
   handlers: HatchetHandlers
+  database?: Pick<typeof prisma, '$queryRaw'>
 }) {
   const globalContext = {
     hatchet,
@@ -305,13 +308,56 @@ export function prepareHatchetTasks({
         Number.isFinite(graceDays) && graceDays >= 0 ? graceDays : 7
       const cutoff = new Date(Date.now() - effectiveGrace * 24 * 60 * 60 * 1000)
 
-      const candidates = await prisma.course.findMany({
-        where: {
-          analyticsFinalizedAt: null,
-          OR: [{ endDate: { lte: cutoff } }, { isArchived: true }],
-        },
-        select: { id: true },
-      })
+      const candidates = await database.$queryRaw<{ id: string }[]>(
+        Prisma.sql`
+          WITH dirty_chat_courses AS MATERIALIZED (
+            SELECT cb."courseId"
+            FROM "ChatUsageCredits" cuc
+            JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+            JOIN "Course" dirty_course ON dirty_course.id = cb."courseId"
+            WHERE (
+              cuc."disclaimerAcceptedAt" > dirty_course."chatAnalyticsValidAt"
+              OR (
+                cuc."disclaimerDeclined" = true
+                AND cuc."updatedAt" > dirty_course."chatAnalyticsValidAt"
+              )
+              OR (
+                cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
+                AND cb."updatedAt" > dirty_course."chatAnalyticsValidAt"
+              )
+            )
+
+            UNION
+
+            SELECT pca."courseId"
+            FROM "ParticipantChatAnalytics" pca
+            JOIN "Chatbot" cb ON cb.id = pca."chatbotId"
+            LEFT JOIN "ChatUsageCredits" cuc
+              ON cuc."participantId" = pca."participantId"
+             AND cuc."chatbotId" = pca."chatbotId"
+            WHERE (
+              cuc."participantId" IS NULL
+              OR cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
+              OR cuc."disclaimerDeclined" = true
+            )
+          )
+          SELECT c.id
+          FROM "Course" c
+          WHERE (
+            c."endDate" <= ${cutoff}
+            OR c."isArchived" = true
+          )
+          AND (
+            c."analyticsFinalizedAt" IS NULL
+            OR c."chatAnalyticsValidAt" IS NULL
+            OR EXISTS (
+              SELECT 1
+              FROM dirty_chat_courses dirty
+              WHERE dirty."courseId" = c.id
+            )
+          )
+        `
+      )
 
       await executionContext.logger.info(
         `[scanEndedCourses] graceDays=${effectiveGrace} cutoff=${cutoff.toISOString()} candidates=${candidates.length}`

--- a/packages/hatchet/src/tasks.ts
+++ b/packages/hatchet/src/tasks.ts
@@ -310,27 +310,39 @@ export function prepareHatchetTasks({
 
       const candidates = await database.$queryRaw<{ id: string }[]>(
         Prisma.sql`
-          WITH dirty_chat_courses AS MATERIALIZED (
-            SELECT cb."courseId"
-            FROM "ChatUsageCredits" cuc
-            JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
-            JOIN "Course" dirty_course ON dirty_course.id = cb."courseId"
+          WITH ended_courses AS MATERIALIZED (
+            SELECT
+              c.id,
+              c."analyticsFinalizedAt",
+              c."chatAnalyticsValidAt"
+            FROM "Course" c
             WHERE (
-              cuc."disclaimerAcceptedAt" > dirty_course."chatAnalyticsValidAt"
+              c."endDate" <= ${cutoff}
+              OR c."isArchived" = true
+            )
+          ),
+          dirty_chat_courses AS MATERIALIZED (
+            SELECT cb."courseId"
+            FROM ended_courses ended
+            JOIN "Chatbot" cb ON cb."courseId" = ended.id
+            JOIN "ChatUsageCredits" cuc ON cuc."chatbotId" = cb.id
+            WHERE (
+              cuc."disclaimerAcceptedAt" > ended."chatAnalyticsValidAt"
               OR (
                 cuc."disclaimerDeclined" = true
-                AND cuc."updatedAt" > dirty_course."chatAnalyticsValidAt"
+                AND cuc."updatedAt" > ended."chatAnalyticsValidAt"
               )
               OR (
                 cuc."acceptedDisclaimerId" IS DISTINCT FROM cb."disclaimerId"
-                AND cb."updatedAt" > dirty_course."chatAnalyticsValidAt"
+                AND cb."updatedAt" > ended."chatAnalyticsValidAt"
               )
             )
 
             UNION
 
             SELECT pca."courseId"
-            FROM "ParticipantChatAnalytics" pca
+            FROM ended_courses ended
+            JOIN "ParticipantChatAnalytics" pca ON pca."courseId" = ended.id
             JOIN "Chatbot" cb ON cb.id = pca."chatbotId"
             LEFT JOIN "ChatUsageCredits" cuc
               ON cuc."participantId" = pca."participantId"
@@ -341,19 +353,15 @@ export function prepareHatchetTasks({
               OR cuc."disclaimerDeclined" = true
             )
           )
-          SELECT c.id
-          FROM "Course" c
+          SELECT ended.id
+          FROM ended_courses ended
           WHERE (
-            c."endDate" <= ${cutoff}
-            OR c."isArchived" = true
-          )
-          AND (
-            c."analyticsFinalizedAt" IS NULL
-            OR c."chatAnalyticsValidAt" IS NULL
+            ended."analyticsFinalizedAt" IS NULL
+            OR ended."chatAnalyticsValidAt" IS NULL
             OR EXISTS (
               SELECT 1
               FROM dirty_chat_courses dirty
-              WHERE dirty."courseId" = c.id
+              WHERE dirty."courseId" = ended.id
             )
           )
         `

--- a/packages/hatchet/test/analytics-cutover.test.mjs
+++ b/packages/hatchet/test/analytics-cutover.test.mjs
@@ -73,17 +73,18 @@ test('ended-course scanner reactivates finalized courses with dirty chat privacy
   assert.deepEqual(result, { success: true, emitted: 1 })
   assert.equal(queries.length, 1)
   const queryText = queries[0].strings.join('')
-  assert.match(queryText, /c\."analyticsFinalizedAt" IS NULL/)
+  assert.match(queryText, /ended\."analyticsFinalizedAt" IS NULL/)
   assert.match(
     queryText,
-    /cuc\."disclaimerAcceptedAt" > dirty_course\."chatAnalyticsValidAt"/
+    /cuc\."disclaimerAcceptedAt" > ended\."chatAnalyticsValidAt"/
   )
   assert.match(
     queryText,
     /cuc\."acceptedDisclaimerId" IS DISTINCT FROM cb\."disclaimerId"/
   )
-  assert.match(queryText, /WITH dirty_chat_courses AS MATERIALIZED/)
-  assert.match(queryText, /FROM "ParticipantChatAnalytics" pca/)
+  assert.match(queryText, /WITH ended_courses AS MATERIALIZED/)
+  assert.match(queryText, /dirty_chat_courses AS MATERIALIZED/)
+  assert.match(queryText, /JOIN "ParticipantChatAnalytics" pca/)
   assert.equal(pushedEvents.length, 1)
   assert.equal(pushedEvents[0][0], 'course-ended')
   assert.deepEqual(pushedEvents[0][1], {

--- a/packages/hatchet/test/analytics-cutover.test.mjs
+++ b/packages/hatchet/test/analytics-cutover.test.mjs
@@ -3,10 +3,12 @@ import test from 'node:test'
 
 import { prepareHatchetTasks } from '../src/tasks.ts'
 
-function makeHatchet() {
+function makeHatchet(pushedEvents = []) {
   return {
     events: {
-      push: async () => undefined,
+      push: async (...args) => {
+        pushedEvents.push(args)
+      },
     },
     task(definition) {
       return definition
@@ -36,4 +38,56 @@ test('TypeScript keeps the ended-course scanner without registering an analytics
   assert.equal('recomputeLearningAnalytics' in prepared, false)
   assert.equal(prepared.scanEndedCourses.name, 'scan-ended-courses')
   assert.deepEqual(prepared.scanEndedCourses.onCrons, ['0 1 * * *'])
+})
+
+test('ended-course scanner reactivates finalized courses with dirty chat privacy state', async () => {
+  const handlers = new Proxy(
+    {},
+    {
+      get: () => async () => true,
+    }
+  )
+  const pushedEvents = []
+  const queries = []
+  const hatchet = makeHatchet(pushedEvents)
+  const prepared = prepareHatchetTasks({
+    hatchet,
+    pubSub: {},
+    emitter: {},
+    redisExec: {},
+    redisAssessmentExec: {},
+    handlers,
+    database: {
+      $queryRaw: async (query) => {
+        queries.push(query)
+        return [{ id: 'course-with-late-consent' }]
+      },
+    },
+  })
+
+  const result = await prepared.scanEndedCourses.fn(
+    {},
+    { logger: { info: async () => undefined } }
+  )
+
+  assert.deepEqual(result, { success: true, emitted: 1 })
+  assert.equal(queries.length, 1)
+  const queryText = queries[0].strings.join('')
+  assert.match(queryText, /c\."analyticsFinalizedAt" IS NULL/)
+  assert.match(
+    queryText,
+    /cuc\."disclaimerAcceptedAt" > dirty_course\."chatAnalyticsValidAt"/
+  )
+  assert.match(
+    queryText,
+    /cuc\."acceptedDisclaimerId" IS DISTINCT FROM cb\."disclaimerId"/
+  )
+  assert.match(queryText, /WITH dirty_chat_courses AS MATERIALIZED/)
+  assert.match(queryText, /FROM "ParticipantChatAnalytics" pca/)
+  assert.equal(pushedEvents.length, 1)
+  assert.equal(pushedEvents[0][0], 'course-ended')
+  assert.deepEqual(pushedEvents[0][1], {
+    mode: 'finalize',
+    courseId: 'course-with-late-consent',
+  })
 })

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -12,7 +12,8 @@ the existing Hatchet control plane.
 - Plan: `project/2026-07-23-learning-analytics-production-plan.md`
 - Phase 1 branch: `chat-analytics`
 - Phase 1 target: `v3`
-- Phase 1 PR: none yet
+- Phase 1 PR:
+  [#5199](https://github.com/uzh-bf/klicker-uzh/pull/5199)
 - Phase 1 worktree:
   `trees/chat-analytics-integration`
 - Phase 2 branch: `analytics-phase-a`
@@ -864,9 +865,32 @@ the repository script that replaces it before continuing.
   `ANALYTICS_ALLOW_FULL` gate. Image CVE scanning and live
   ExternalSecret/Infisical readiness remain explicit pre-deployment gates
   because no scanner or live environment access is available here.
-- Active: Commit and independently review the test-isolation adjustment, run
-  the final whole-branch maintainability review, then publish and read back
-  both stacked draft PRs without merging or deploying.
+- 2026-07-24: Final Phase 1 review found four related privacy/correctness gaps:
+  aggregate message metrics did not apply current consent, consent revocation
+  retained participant/aggregate rows and downstream outcomes, a
+  below-threshold recluster retained old topics, and scoped runs still read or
+  timestamped courses outside the current scope. Commits `3510240467` and
+  `f11b17c20` address those gaps while preserving the existing GraphQL and
+  analytics stack.
+- 2026-07-24: The corrections are translated into the Phase 2 SQLAlchemy path.
+  Scoped chat windows now delete and rebuild atomically; empty valid results
+  reconcile outcomes and activity flags; participant response reads and
+  validity watermarks stay inside the current course scope; and aggregate
+  messages require current, non-declined consent.
+- 2026-07-24: Focused native-worker verification passes Ruff and 79 tests.
+  Four new PostgreSQL regressions pass against the disposable migrated
+  database: declined/stale consent exclusion, revocation cleanup, preservation
+  of another course during scoped runs, empty downstream reconciliation,
+  rollback after a failed rebuild, database-level participant-read scoping,
+  and scoped validity marking.
+- 2026-07-24: The complete database-enabled analytics suite passes 188 tests
+  with 18 existing dependency/dataframe warnings in 5 minutes 49 seconds.
+- 2026-07-24: The environment publication gate rejected the updated Phase 1
+  push despite the approved draft-PR workflow. Both branches will remain local
+  until the user explicitly reconfirms publication.
+- Active: Finish the refreshed base merge, run the complete database suite and
+  final reviews, then request publication confirmation for both stacked draft
+  PRs.
 
 ## Finish evidence
 
@@ -880,7 +904,9 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit the accepted test-isolation review adjustment.
-2. Run the final whole-branch maintainability and branch reviews.
-3. Publish `chat-analytics` against `v3`, refresh the stacked
-   `analytics-phase-a` draft, and read back CI without merging or deploying.
+1. Complete and commit the refreshed Phase 1 merge plus privacy/scope
+   regressions.
+2. Run the complete database-enabled suite and final review gates.
+3. After explicit publication confirmation, update `chat-analytics` against
+   `v3`, refresh the stacked `analytics-phase-a` draft, and read back CI
+   without merging or deploying.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -885,12 +885,26 @@ the repository script that replaces it before continuing.
   and scoped validity marking.
 - 2026-07-24: The complete database-enabled analytics suite passes 188 tests
   with 18 existing dependency/dataframe warnings in 5 minutes 49 seconds.
+- 2026-07-24: Exact-merge review found one remaining release blocker:
+  incremental consent revocation only reconciled the 14-day lookback and
+  retained older participant and aggregate windows. Phase 2 now purges
+  ineligible participant rows across retained history, splits consent-affected
+  courses into targeted historical rebuilds from their earliest affected
+  message or aggregate, and clears then refreshes the scoped chat watermark so
+  participant and aggregate Hatchet roots coordinate safely when concurrent.
+  The new old-window PostgreSQL regression passes before and after the
+  participant purge.
+- 2026-07-24: The refreshed complete suite passes 189 tests with 18 existing
+  dependency/dataframe warnings in 5 minutes 47 seconds; Ruff formatting and
+  lint pass across 129 files. The accepted simplification avoids source-count
+  queries when logging is disabled, and the strict maintainability follow-up
+  centralizes test module restoration.
 - 2026-07-24: The environment publication gate rejected the updated Phase 1
   push despite the approved draft-PR workflow. Both branches will remain local
   until the user explicitly reconfirms publication.
-- Active: Finish the refreshed base merge, run the complete database suite and
-  final reviews, then request publication confirmation for both stacked draft
-  PRs.
+- Active: Commit and independently re-review the incremental consent fix,
+  complete final branch gates, then request publication confirmation for both
+  stacked draft PRs.
 
 ## Finish evidence
 
@@ -904,9 +918,8 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Complete and commit the refreshed Phase 1 merge plus privacy/scope
-   regressions.
-2. Run the complete database-enabled suite and final review gates.
+1. Commit and independently review the incremental consent-history fix.
+2. Run the final branch security and maintainability gates.
 3. After explicit publication confirmation, update `chat-analytics` against
    `v3`, refresh the stacked `analytics-phase-a` draft, and read back CI
    without merging or deploying.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -891,7 +891,7 @@ the repository script that replaces it before continuing.
   ineligible participant rows across retained history, splits consent-affected
   courses into targeted historical rebuilds from their earliest affected
   message or aggregate, and clears then refreshes the scoped chat watermark so
-  participant and aggregate Hatchet roots coordinate safely when concurrent.
+  participant and aggregate stages coordinate through a durable handoff.
   The new old-window PostgreSQL regression passes before and after the
   participant purge.
 - 2026-07-24: The refreshed complete suite passes 189 tests with 18 existing
@@ -902,7 +902,19 @@ the repository script that replaces it before continuing.
 - 2026-07-24: The environment publication gate rejected the updated Phase 1
   push despite the approved draft-PR workflow. Both branches will remain local
   until the user explicitly reconfirms publication.
-- Active: Commit and independently re-review the incremental consent fix,
+- 2026-07-24: Final sequencing review found that independent script-8 and
+  script-9 roots could let the validity marker swallow a consent change.
+  Script 9 now waits for script 8, preserving the watermark handoff. Dry runs
+  bypass consent-history queries and purges while the capture buffer is active.
+- 2026-07-24: The same review reproduced acceptance arriving after script 8
+  but before the final marker. The native worker now binds Hatchet's immutable
+  workflow-creation time into the final SQL instead of stamping completion
+  time, leaving mid-run consent changes visible for the next rebuild.
+- 2026-07-24: A disposable Hatchet v0.73.1 task using the pinned Python SDK
+  read the workflow creation timestamp from its live task context and matched
+  it exactly against REST readback. The six-case PostgreSQL privacy suite,
+  including the acceptance-interleaving convergence regression, passes.
+- Active: Verify, commit, and independently re-review the sequencing fix,
   complete final branch gates, then request publication confirmation for both
   stacked draft PRs.
 

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -880,7 +880,7 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit and independently review the final security adjustments.
-2. Run the final maintainability, simplification, and branch reviews.
+1. Commit the accepted test-isolation review adjustment.
+2. Run the final whole-branch maintainability and branch reviews.
 3. Publish `chat-analytics` against `v3`, refresh the stacked
    `analytics-phase-a` draft, and read back CI without merging or deploying.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -929,7 +929,21 @@ the repository script that replaces it before continuing.
   hygiene, and a focused 293-rule Opengrep scan pass.
 - 2026-07-24: The refreshed complete database-backed analytics suite passes
   192 tests with 18 existing dependency/dataframe warnings in 6 minutes.
-- Active: Verify, commit, and independently re-review the sequencing fix,
+- 2026-07-24: Final race review found that a consent change committing after
+  the final-marker snapshot could leave an ended course finalized and outside
+  the nightly scanner. The scanner now also requeues finalized courses whose
+  chat cutoff is missing or older than current consent/disclaimer state, or
+  whose participant chat rows are no longer eligible. Requeued finalized
+  courses can pass through the final marker again and converge.
+- 2026-07-24: Hatchet workflow creation times are normalized to the
+  PostgreSQL `TIMESTAMP(3)` boundary and shifted back one millisecond before
+  use. The supported shell launcher calls the same helper. A PostgreSQL
+  regression proves a consent timestamp in the workflow's creation
+  millisecond remains visible, and a direct scanner query selects late
+  consent, never-finalized, and stale-row cases while excluding clean and
+  active courses. The focused privacy/finalization suite passes 26 tests;
+  Hatchet typecheck and both scanner tests pass.
+- Active: Commit and independently re-review the finalization-race fix,
   complete final branch gates, then request publication confirmation for both
   stacked draft PRs.
 
@@ -945,7 +959,7 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit and independently review the incremental consent-history fix.
+1. Commit and independently review the finalization-race fix.
 2. Run the final branch security and maintainability gates.
 3. After explicit publication confirmation, update `chat-analytics` against
    `v3`, refresh the stacked `analytics-phase-a` draft, and read back CI

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -914,6 +914,21 @@ the repository script that replaces it before continuing.
   read the workflow creation timestamp from its live task context and matched
   it exactly against REST readback. The six-case PostgreSQL privacy suite,
   including the acceptance-interleaving convergence regression, passes.
+- 2026-07-24: Exact-commit review confirmed the incremental sequencing races
+  are closed, then reproduced three remaining production boundaries:
+  mid-run consent could be stranded by finalization, the supported shell
+  launcher had no shared cutoff, and non-UTC sessions shifted a UTC cursor.
+  Finalization now stays pending until a follow-up converges, the launcher
+  exports one fail-closed cutoff, and SQL stores it explicitly as UTC-naive.
+  Simplification review's accepted cleanup also makes the final marker read
+  mode, scope, and cutoff from one immutable run-config snapshot.
+- 2026-07-24: Nine PostgreSQL privacy cases now pass, including acceptance and
+  revocation during finalize plus a Europe/Zurich session-timezone regression.
+  A fake-pnpm launcher smoke observed one identical UTC cutoff across all 15
+  scripts. Bash syntax, 47 focused unit tests, full Ruff, Prettier, diff
+  hygiene, and a focused 293-rule Opengrep scan pass.
+- 2026-07-24: The refreshed complete database-backed analytics suite passes
+  192 tests with 18 existing dependency/dataframe warnings in 6 minutes.
 - Active: Verify, commit, and independently re-review the sequencing fix,
   complete final branch gates, then request publication confirmation for both
   stacked draft PRs.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -943,6 +943,14 @@ the repository script that replaces it before continuing.
   consent, never-finalized, and stale-row cases while excluding clean and
   active courses. The focused privacy/finalization suite passes 26 tests;
   Hatchet typecheck and both scanner tests pass.
+- 2026-07-24: Review found that the first scanner query materialized dirty
+  privacy state from all retained chat rows before applying the ended-course
+  filter. A disposable benchmark with 1,000 courses, 10,000 chatbots, one
+  million consent rows, and 500,000 participant-chat rows reduced the warm
+  plan from about 382 ms to 99 ms by materializing the 50 ended courses first.
+  A `ChatUsageCredits(chatbotId)` index reduced it further to about 46 ms, but
+  that extra write/index cost is not justified for a once-daily 99 ms query
+  without representative staging evidence, so no speculative index is added.
 - Active: Commit and independently re-review the finalization-race fix,
   complete final branch gates, then request publication confirmation for both
   stacked draft PRs.

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -366,7 +366,7 @@ Focused slices run the relevant subset. Slice 6 reruns the complete matrix:
 | Diff hygiene | `git diff --check` | No errors |
 | Dependency policy | `volta run --node 24.16.0 pnpm run check:syncpack` | Exit 0 |
 | Analytics format | `cd apps/analytics && uv run ruff format --check . && uv run ruff check .` | Exit 0 |
-| Analytics types | `cd apps/analytics && uv run pyright` | Exit 0 |
+| Analytics types | Focused strict Pyright on changed typed boundaries; record the full Phase A baseline | No new findings in changed typed boundaries |
 | Analytics tests | `cd apps/analytics && uv run pytest` | All tests pass |
 | Hatchet packages | `volta run --node 24.16.0 pnpm exec turbo run check --filter=@klicker-uzh/hatchet --filter=@klicker-uzh/hatchet-worker-general` | Exit 0 |
 | GraphQL package | `volta run --node 24.16.0 pnpm exec turbo run check --filter=@klicker-uzh/graphql` | Exit 0 |
@@ -827,9 +827,46 @@ the repository script that replaces it before continuing.
   between image stages. Fresh ARM64 and AMD64 builds retain their separate
   runtime packages and both pass the non-root, no-network, read-only model,
   license, snapshot, and CPU-only smoke.
-- Active: Commit and review the final simplification, reconcile independent
-  branch findings, then run the finish gates and publish both stacked draft
-  PRs.
+- 2026-07-23: The refreshed Phase 1 base received three final correctness
+  commits (`3ba307ccef`, `f6df11d3a9`, and `1da4c868ba`). They correct
+  participant/instance first-and-last live-quiz attempts, require current
+  non-declined chatbot-disclaimer consent, and make daily through monthly
+  windows UTC-safe with exclusive next-midnight ends. Independent review found
+  no remaining Phase 1 blocker.
+- 2026-07-23: Merged final `chat-analytics` head `1da4c868ba` into Phase 2 as
+  `a23627c147`. The commit hook passed all 24 runnable repository typechecks,
+  lint, formatting, Syncpack, AGENTS validation, and Prisma schema sync.
+- 2026-07-23: The final database-backed SQL checks pass for current consent,
+  UTC window parameters, live-quiz first/last ranking, and clustering queries.
+  The complete database-enabled analytics suite passes 178 tests in
+  5 minutes 44 seconds. The run exposed and then verified a test-only
+  isolation defect: runtime tests imported `src.db` under fake database URLs
+  and retained those modules for later database tests. Autouse fixtures now
+  restore the prior module state after those tests.
+- 2026-07-23: Final local verification also passes Ruff formatting/lint across
+  125 files, uv lock validation, focused strict Pyright on the changed native
+  worker/runtime/model and SQL-test boundaries, Syncpack, GraphQL and Hatchet
+  typechecks, three GraphQL event-routing tests, the TypeScript cutover test,
+  Prisma schema-mirror validation, strict staging/production Helm lint and
+  renders, guarded `allowFull` rendering, and immutable-action workflow
+  validation. Full Phase A Pyright remains the recorded existing baseline of
+  about 2,300 findings rather than a false all-green gate.
+- 2026-07-23: Final ARM64 and AMD64 images rebuilt from the stacked head and
+  passed non-root, no-network, read-only, capability-dropped model and license
+  smoke. A final ARM64 worker registered the proof task and both 15-task DAGs
+  against disposable Hatchet v0.73.1, completed the proof task with the
+  expected immutable input, and exited gracefully.
+- 2026-07-23: Final security review found no high-confidence exploitable
+  vulnerability. Four focused Opengrep findings are allowlisted dynamic
+  imports or UUID-validated values interpolated into static SQL templates.
+  The GraphQL recompute mutation still requires full user access and course
+  administration; full rebuilds additionally require the server-side
+  `ANALYTICS_ALLOW_FULL` gate. Image CVE scanning and live
+  ExternalSecret/Infisical readiness remain explicit pre-deployment gates
+  because no scanner or live environment access is available here.
+- Active: Commit and independently review the test-isolation adjustment, run
+  the final whole-branch maintainability review, then publish and read back
+  both stacked draft PRs without merging or deploying.
 
 ## Finish evidence
 

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -951,9 +951,47 @@ the repository script that replaces it before continuing.
   A `ChatUsageCredits(chatbotId)` index reduced it further to about 46 ms, but
   that extra write/index cost is not justified for a once-daily 99 ms query
   without representative staging evidence, so no speculative index is added.
-- Active: Commit and independently re-review the finalization-race fix,
-  complete final branch gates, then request publication confirmation for both
-  stacked draft PRs.
+- 2026-07-24: The refreshed complete database-backed analytics suite passes
+  199 tests with 18 existing dependency/dataframe warnings in 5 minutes
+  57 seconds. The focused privacy/finalization suite passes 26 tests; Ruff
+  formatting and lint pass across 130 files; the uv lock, Hatchet typecheck,
+  scanner tests, direct PostgreSQL scanner semantics, launcher cutoff smoke,
+  and diff hygiene all pass. A focused 452-rule Opengrep scan reports no
+  findings.
+- 2026-07-24: Independent correctness review of commits `871e7b8ce4` and
+  `9e43cb9326` found no remaining correctness or performance finding at
+  confidence 75 or higher. Independent simplification review found no safe
+  smaller form for the cutoff helper, launcher, scanner query, or
+  same-millisecond regression. The repeated privacy predicate across Python
+  reconciliation and the TypeScript scanner remains a future data-model
+  concern; centralizing it safely would require a database view or synchronous
+  invalidation design rather than a local cleanup.
+- 2026-07-24: Exact code head `9e43cb9326` produced fresh ARM64 and AMD64
+  images with digests
+  `sha256:15ffa6c1bfbcf55c591900b2ba879e9326b7a6400d9825e15f30cf673a31e45e`
+  and
+  `sha256:ae1a98a888b4f12be149e048f611736fb9692cc4064ffc76115c57dfcdac176f`.
+  Both passed non-root UID 10001, no-network, read-only-root,
+  capability-dropped, CPU-only model/license/embedding smoke. The ARM64 worker
+  then registered the proof task and both complete 15-task DAGs against
+  disposable Hatchet v0.73.1, reported healthy with one slot, completed the
+  immutable-input proof workflow, and stopped cleanly.
+- 2026-07-24: The final security gate found no high-confidence vulnerability
+  in the cutoff or scanner change. The scanner uses static SQL identifiers and
+  a parameterized server-generated `Date`; the worker and shell launcher use
+  one server-controlled immutable cutoff. The full branch still requires image
+  CVE scanning and live ExternalSecret/Infisical readiness verification before
+  deployment because neither capability is available in this environment.
+- 2026-07-24: The strict maintainability gate does not approve the complete
+  Phase A branch without a conscious disposition. The branch adds the
+  1,898-line `dryrun/interceptor.py` and the 1,295-line privacy SQL regression
+  module. Neither is on the production worker path, and the final cutoff and
+  scanner changes add no comparable structural regression, but both files
+  should be decomposed before merge or explicitly waived with ownership and a
+  follow-up.
+- Active: Final evidence is complete locally. Request explicit publication
+  confirmation for both stacked draft PRs; after publication, read CI to a
+  terminal result without merging or deploying.
 
 ## Finish evidence
 
@@ -967,8 +1005,15 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. Commit and independently review the finalization-race fix.
-2. Run the final branch security and maintainability gates.
-3. After explicit publication confirmation, update `chat-analytics` against
-   `v3`, refresh the stacked `analytics-phase-a` draft, and read back CI
-   without merging or deploying.
+1. After explicit publication confirmation, push `chat-analytics` and
+   `analytics-phase-a`, update both stacked draft PR descriptions, and read CI
+   to a terminal result without merging or deploying.
+2. Before merge, decompose the two oversized Phase A files or record an
+   explicit maintainability waiver with an owner and follow-up.
+3. Before staging, scan the exact image digest for CVEs, confirm the deployed
+   Hatchet control-plane compatibility, and verify the owning
+   ExternalSecret/Infisical sync is ready.
+4. Cold-cut over in staging with one replica and one slot. Run the proof task
+   and one scoped incremental/finalize course, compare rows and privacy
+   convergence, and measure duration, query plans, memory, and CPU before
+   changing resources or enabling the schedule.

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "globalEnv": [
+    "ANALYTICS_CHAT_CUTOFF",
     "ANALYTICS_FINALIZE_GRACE_DAYS",
     "API_DOMAIN",
     "APP_CONTROL_DOMAIN",


### PR DESCRIPTION
## What

This is layer 11 of 14. It makes consent reconciliation and course finalization converge under retries and timing races.

- reconciles historical consent changes before chat-derived computation
- preserves current consent state during course finalization
- recovers courses whose finalization raced with privacy reconciliation
- narrows the scanner to courses that still require work
- improves database module isolation in the test suite

## Branch coverage

- Base: `analytics-stack-10-native-hatchet-cutover` at `f25ccfb1ac`
- Head: `5c7b8c11c0`
- Reviewed: 9 commits, 35 files, 2,491 insertions, 470 deletions
- Covered: reconciliation tasks, native-worker ordering, finalization state, scanner scope, SQL contracts, database tests, operations docs, and final production gates

## Review focus

- Check the ordering between consent reconciliation, chat-derived tasks, and final validity.
- Confirm a consent withdrawal removes derived Analytics data without deleting operational chat records.
- Confirm retries converge after a finalization or privacy race.

## Verification

Current layer:

- GitHub CI is required after publication.

Current stack head:

- Analytics Ruff checks passed.
- Analytics tests passed 184 cases with 15 PostgreSQL-only skips.

Earlier verification of the identical implementation tree:

- Ten PostgreSQL privacy cases and the full 199-test database-enabled suite passed.
- Repository `check:all` and the Node 24 build passed.

## Security / privacy

This layer is the main privacy convergence gate. It removes derived chat Analytics when consent is no longer valid while preserving operational records outside the Analytics deletion scope.

## Blocking before merge

- [ ] Layer 10 is merged first.
- [ ] Required GitHub checks pass.
- [ ] Maintainer and privacy review are complete.

## Follow-up after merge

- Layer 12 separates curated runtime models from raw diagnostic generation and decomposes the dry-run tooling.
