### PR TITLE
chore(analytics): reconcile runtime v3 integration

### DIFF
--- a/apps/analytics/src/db_helpers.py
+++ b/apps/analytics/src/db_helpers.py
@@ -11,7 +11,7 @@
 """
 
 from datetime import date, datetime, time, timezone
-from typing import Iterable, Mapping, Sequence
+from typing import Mapping, Sequence
 
 from sqlalchemy import Column, inspect
 from sqlalchemy.dialects.postgresql import insert as postgres_insert
@@ -49,9 +49,9 @@ def bulk_upsert(
             raise ValueError(f"bulk_upsert row {index} must have the same columns as row 0")
 
     stmt = postgres_insert(Model).values(list(rows))
-    effective_update_cols = list(update_cols) if update_cols is not None else [
-        c for c in rows[0].keys() if c not in conflict_cols
-    ]
+    effective_update_cols = (
+        list(update_cols) if update_cols is not None else [c for c in rows[0].keys() if c not in conflict_cols]
+    )
     if not effective_update_cols:
         # No columns to refresh on conflict — degrade to DO NOTHING so we still
         # honour the conflict target rather than erroring.
@@ -104,9 +104,7 @@ def coerce_timestamp(value: object) -> datetime:
         except Exception as exc:
             raise ValueError(f"invalid timestamp string: {value!r}") from exc
     else:
-        raise TypeError(
-            f"expected ISO date string, timestamp string, date, or datetime; got {type(value)!r}"
-        )
+        raise TypeError(f"expected ISO date string, timestamp string, date, or datetime; got {type(value)!r}")
 
     if ts.tzinfo is not None:
         ts = ts.tz_convert(timezone.utc).tz_localize(None)
@@ -147,8 +145,4 @@ def row_to_dict(row: object) -> dict:
         return dict(row)  # type: ignore[arg-type]
     state = inspect(row)
     unloaded = set(state.unloaded)
-    return {
-        col.key: getattr(row, col.key)
-        for col in mapper.column_attrs
-        if col.key not in unloaded
-    }
+    return {col.key: getattr(row, col.key) for col in mapper.column_attrs if col.key not in unloaded}

--- a/apps/analytics/src/dryrun/runner.py
+++ b/apps/analytics/src/dryrun/runner.py
@@ -108,12 +108,8 @@ _SCRIPT_DOMAIN: dict[str, str] = {
 }
 
 _INTENTIONAL_SKIP_REASONS: dict[str, str] = {
-    "src.scripts.13_platform_semester_analytics": (
-        "skipped: intentionally omitted for course-scoped dryrun"
-    ),
-    "src.scripts.99_mark_analytics_valid": (
-        "skipped: dryrun omits analytics validity watermark updates"
-    ),
+    "src.scripts.13_platform_semester_analytics": ("skipped: intentionally omitted for course-scoped dryrun"),
+    "src.scripts.99_mark_analytics_valid": ("skipped: dryrun omits analytics validity watermark updates"),
 }
 
 
@@ -122,10 +118,7 @@ def _detect_missing_tables(connection: Connection, names: set[str]) -> set[str]:
         return set()
     present = set(
         connection.execute(
-            text(
-                "SELECT tablename FROM pg_tables "
-                "WHERE schemaname = 'public' AND tablename = ANY(:names)"
-            ),
+            text("SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = ANY(:names)"),
             {"names": list(names)},
         )
         .scalars()
@@ -176,14 +169,8 @@ def _rows_written_since(
     expected_tables: Sequence[str],
 ) -> int:
     if expected_tables:
-        return sum(
-            max(0, buffer.row_count(table) - before_counts.get(table, 0))
-            for table in expected_tables
-        )
-    return sum(
-        max(0, buffer.row_count(table) - before_counts.get(table, 0))
-        for table in buffer.table_status
-    )
+        return sum(max(0, buffer.row_count(table) - before_counts.get(table, 0)) for table in expected_tables)
+    return sum(max(0, buffer.row_count(table) - before_counts.get(table, 0)) for table in buffer.table_status)
 
 
 def _mark_expected_tables(
@@ -200,10 +187,7 @@ def _mark_expected_tables(
 def _intentional_skip_reason(module_name: str, *, scope_mode: str) -> str | None:
     if module_name == "src.scripts.99_mark_analytics_valid":
         return _INTENTIONAL_SKIP_REASONS[module_name]
-    if (
-        scope_mode == "course"
-        and module_name == "src.scripts.13_platform_semester_analytics"
-    ):
+    if scope_mode == "course" and module_name == "src.scripts.13_platform_semester_analytics":
         return _INTENTIONAL_SKIP_REASONS[module_name]
     return None
 
@@ -264,9 +248,7 @@ def _collect_reference_lookups(
     participants = {}
     if participant_ids:
         rows = connection.execute(
-            text(
-                'SELECT id, username, email FROM "Participant" WHERE id = ANY(:ids)'
-            ),
+            text('SELECT id, username, email FROM "Participant" WHERE id = ANY(:ids)'),
             {"ids": list(participant_ids)},
         ).all()
         participants = {
@@ -301,14 +283,10 @@ def _collect_reference_lookups(
     element_instances: dict[str, str] = {}
     if instance_ids:
         rows = connection.execute(
-            text(
-                'SELECT id, "elementData" FROM "ElementInstance" WHERE id = ANY(:ids)'
-            ),
+            text('SELECT id, "elementData" FROM "ElementInstance" WHERE id = ANY(:ids)'),
             {"ids": list(instance_ids)},
         ).all()
-        element_instances = {
-            str(row[0]): _extract_element_name(row[1]) for row in rows
-        }
+        element_instances = {str(row[0]): _extract_element_name(row[1]) for row in rows}
 
     return {
         "course_name": courses.get(course_id, ""),
@@ -396,10 +374,7 @@ def _assert_read_only_role(
     touched by ``99_mark_analytics_valid``.
     """
     row = connection.execute(
-        text(
-            'SELECT current_user AS u, '
-            'has_table_privilege(current_user, \'"Course"\', \'INSERT\') AS can_insert'
-        )
+        text("SELECT current_user AS u, has_table_privilege(current_user, '\"Course\"', 'INSERT') AS can_insert")
     ).one()
     current_user = row.u
     can_insert = bool(row.can_insert)
@@ -567,10 +542,7 @@ def run_dryrun(
                     rows_written = _rows_written_since(
                         buffer, before_counts, _SCRIPT_OUTPUT_TABLES.get(module_name, ())
                     )
-                    if (
-                        _SCRIPT_OUTPUT_TABLES.get(module_name)
-                        and rows_written == 0
-                    ):
+                    if _SCRIPT_OUTPUT_TABLES.get(module_name) and rows_written == 0:
                         status = "empty"
                         _mark_expected_tables(
                             buffer,
@@ -592,9 +564,7 @@ def run_dryrun(
                         status=status,
                         note=error,
                     )
-                rows_written = _rows_written_since(
-                    buffer, before_counts, _SCRIPT_OUTPUT_TABLES.get(module_name, ())
-                )
+                rows_written = _rows_written_since(buffer, before_counts, _SCRIPT_OUTPUT_TABLES.get(module_name, ()))
                 buffer.record_script(
                     module_name,
                     elapsed,
@@ -628,14 +598,11 @@ def run_dryrun(
         "aborted_with_error": run_error or "",
         "omitted_domains": "Platform",
         "dryrun_omissions": (
-            "Platform analytics omitted for course-scoped export; analytics validity "
-            "watermark step omitted in dryrun."
+            "Platform analytics omitted for course-scoped export; analytics validity watermark step omitted in dryrun."
         ),
         "lookups": lookups,
         "script_domains": _SCRIPT_DOMAIN,
-        "omitted_domain_notes": {
-            "Platform": "Intentionally omitted for course-scoped dry run."
-        },
+        "omitted_domain_notes": {"Platform": "Intentionally omitted for course-scoped dry run."},
     }
     write_excel(buffer, output_path, metadata)
     print(f"[dryrun] wrote {output_path}", flush=True)

--- a/apps/analytics/src/log.py
+++ b/apps/analytics/src/log.py
@@ -16,7 +16,6 @@ fabricating a fake count.
 """
 
 import json
-import sys
 import time
 from typing import Any
 

--- a/apps/analytics/src/models.py
+++ b/apps/analytics/src/models.py
@@ -21,7 +21,6 @@ from decimal import Decimal
 from typing import Any, Optional
 
 from sqlalchemy import (
-    BigInteger,
     Boolean,
     Date,
     DateTime,
@@ -30,11 +29,10 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     Numeric,
-    SmallInteger,
     String,
     Text,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, ENUM, JSONB, UUID
+from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 Uuid = UUID(as_uuid=False)
@@ -46,19 +44,11 @@ class Base(DeclarativeBase):
 
 # ----- Enums ---------------------------------------------------------------
 
-AnalyticsType = ENUM(
-    "DAILY", "WEEKLY", "MONTHLY", "COURSE", name="AnalyticsType", create_type=False
-)
+AnalyticsType = ENUM("DAILY", "WEEKLY", "MONTHLY", "COURSE", name="AnalyticsType", create_type=False)
 ActivityLevel = ENUM("LOW", "MEDIUM", "HIGH", name="ActivityLevel", create_type=False)
-PerformanceLevel = ENUM(
-    "LOW", "MEDIUM", "HIGH", name="PerformanceLevel", create_type=False
-)
-ChatDoseBucket = ENUM(
-    "NONE", "LOW", "MED", "HIGH", name="ChatDoseBucket", create_type=False
-)
-ResponseCorrectness = ENUM(
-    "CORRECT", "PARTIAL", "WRONG", name="ResponseCorrectness", create_type=False
-)
+PerformanceLevel = ENUM("LOW", "MEDIUM", "HIGH", name="PerformanceLevel", create_type=False)
+ChatDoseBucket = ENUM("NONE", "LOW", "MED", "HIGH", name="ChatDoseBucket", create_type=False)
+ResponseCorrectness = ENUM("CORRECT", "PARTIAL", "WRONG", name="ResponseCorrectness", create_type=False)
 Locale = ENUM("en", "de", name="Locale", create_type=False)
 CourseAuthType = ENUM("SSO", "PIN", name="CourseAuthType", create_type=False)
 ElementType = ENUM(
@@ -127,15 +117,9 @@ class Course(Base):
     endDate: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     notificationEmail: Mapped[Optional[str]] = mapped_column(String)
     areAnalyticsValid: Mapped[bool] = mapped_column(Boolean, default=False)
-    analyticsLastComputedAt: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True)
-    )
-    chatAnalyticsValidAt: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True)
-    )
-    analyticsFinalizedAt: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True)
-    )
+    analyticsLastComputedAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    chatAnalyticsValidAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    analyticsFinalizedAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     isArchived: Mapped[bool] = mapped_column(Boolean, default=False)
     authType: Mapped[str] = mapped_column(CourseAuthType, default="PIN")
     pinCode: Mapped[Optional[int]] = mapped_column(Integer)
@@ -169,9 +153,7 @@ class Participant(Base):
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     participations: Mapped[list["Participation"]] = relationship(back_populates="participant")
-    detailQuestionResponses: Mapped[list["QuestionResponseDetail"]] = relationship(
-        back_populates="participant"
-    )
+    detailQuestionResponses: Mapped[list["QuestionResponseDetail"]] = relationship(back_populates="participant")
 
 
 class Participation(Base):
@@ -187,12 +169,8 @@ class Participation(Base):
 
     course: Mapped[Course] = relationship(back_populates="participations")
     participant: Mapped[Participant] = relationship(back_populates="participations")
-    responses: Mapped[list["QuestionResponse"]] = relationship(
-        back_populates="participation"
-    )
-    detailResponses: Mapped[list["QuestionResponseDetail"]] = relationship(
-        back_populates="participation"
-    )
+    responses: Mapped[list["QuestionResponse"]] = relationship(back_populates="participation")
+    detailResponses: Mapped[list["QuestionResponseDetail"]] = relationship(back_populates="participation")
 
 
 # ----- Element & quiz models ------------------------------------------------
@@ -238,9 +216,7 @@ class ElementInstance(Base):
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     stack: Mapped[Optional["ElementStack"]] = relationship(back_populates="elements")
-    responses: Mapped[list["QuestionResponse"]] = relationship(
-        back_populates="elementInstance"
-    )
+    responses: Mapped[list["QuestionResponse"]] = relationship(back_populates="elementInstance")
 
 
 class ElementStack(Base):
@@ -251,22 +227,14 @@ class ElementStack(Base):
     order: Mapped[int] = mapped_column(Integer)
     displayName: Mapped[Optional[str]] = mapped_column(String)
     description: Mapped[Optional[str]] = mapped_column(String)
-    practiceQuizId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("PracticeQuiz.id")
-    )
-    microLearningId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("MicroLearning.id")
-    )
+    practiceQuizId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("PracticeQuiz.id"))
+    microLearningId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("MicroLearning.id"))
     groupActivityId: Mapped[Optional[str]] = mapped_column(Uuid)
     courseId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("Course.id"))
 
     elements: Mapped[list[ElementInstance]] = relationship(back_populates="stack")
-    practiceQuiz: Mapped[Optional["PracticeQuiz"]] = relationship(
-        back_populates="stacks"
-    )
-    microLearning: Mapped[Optional["MicroLearning"]] = relationship(
-        back_populates="stacks"
-    )
+    practiceQuiz: Mapped[Optional["PracticeQuiz"]] = relationship(back_populates="stacks")
+    microLearning: Mapped[Optional["MicroLearning"]] = relationship(back_populates="stacks")
 
 
 class PracticeQuiz(Base):
@@ -289,9 +257,7 @@ class PracticeQuiz(Base):
 
     course: Mapped[Course] = relationship(back_populates="practiceQuizzes")
     stacks: Mapped[list[ElementStack]] = relationship(back_populates="practiceQuiz")
-    responses: Mapped[list["QuestionResponse"]] = relationship(
-        back_populates="practiceQuiz"
-    )
+    responses: Mapped[list["QuestionResponse"]] = relationship(back_populates="practiceQuiz")
 
 
 class MicroLearning(Base):
@@ -315,9 +281,7 @@ class MicroLearning(Base):
 
     course: Mapped[Course] = relationship(back_populates="microLearnings")
     stacks: Mapped[list[ElementStack]] = relationship(back_populates="microLearning")
-    responses: Mapped[list["QuestionResponse"]] = relationship(
-        back_populates="microLearning"
-    )
+    responses: Mapped[list["QuestionResponse"]] = relationship(back_populates="microLearning")
 
 
 class LiveQuiz(Base):
@@ -359,9 +323,7 @@ class QuestionResponse(Base):
     correctCountStreak: Mapped[int] = mapped_column(Integer, default=0)
     lastCorrectAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     partialCorrectCount: Mapped[int] = mapped_column(Integer, default=0)
-    lastPartialCorrectAt: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True)
-    )
+    lastPartialCorrectAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     wrongCount: Mapped[int] = mapped_column(Integer, default=0)
     lastWrongAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     eFactor: Mapped[float] = mapped_column(Float, default=2.5)
@@ -374,15 +336,9 @@ class QuestionResponse(Base):
     aggregatedResponses: Mapped[Optional[dict]] = mapped_column(JSONB)
     participantId: Mapped[str] = mapped_column(Uuid, ForeignKey("Participant.id"))
     participationId: Mapped[int] = mapped_column(Integer, ForeignKey("Participation.id"))
-    elementInstanceId: Mapped[int] = mapped_column(
-        Integer, ForeignKey("ElementInstance.id")
-    )
-    practiceQuizId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("PracticeQuiz.id")
-    )
-    microLearningId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("MicroLearning.id")
-    )
+    elementInstanceId: Mapped[int] = mapped_column(Integer, ForeignKey("ElementInstance.id"))
+    practiceQuizId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("PracticeQuiz.id"))
+    microLearningId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("MicroLearning.id"))
     courseId: Mapped[str] = mapped_column(Uuid, ForeignKey("Course.id"))
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
@@ -405,15 +361,9 @@ class QuestionResponseDetail(Base):
     response: Mapped[dict] = mapped_column(JSONB)
     participantId: Mapped[str] = mapped_column(Uuid, ForeignKey("Participant.id"))
     participationId: Mapped[int] = mapped_column(Integer, ForeignKey("Participation.id"))
-    elementInstanceId: Mapped[int] = mapped_column(
-        Integer, ForeignKey("ElementInstance.id")
-    )
-    practiceQuizId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("PracticeQuiz.id")
-    )
-    microLearningId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("MicroLearning.id")
-    )
+    elementInstanceId: Mapped[int] = mapped_column(Integer, ForeignKey("ElementInstance.id"))
+    practiceQuizId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("PracticeQuiz.id"))
+    microLearningId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("MicroLearning.id"))
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
@@ -506,19 +456,13 @@ class ChatUsageCredits(Base):
 
     total: Mapped[Decimal] = mapped_column(Numeric(18, 6), default=0)
     current: Mapped[Decimal] = mapped_column(Numeric(18, 6), default=0)
-    participantId: Mapped[str] = mapped_column(
-        Uuid, ForeignKey("Participant.id"), primary_key=True
-    )
-    chatbotId: Mapped[str] = mapped_column(
-        Uuid, ForeignKey("Chatbot.id"), primary_key=True
-    )
+    participantId: Mapped[str] = mapped_column(Uuid, ForeignKey("Participant.id"), primary_key=True)
+    chatbotId: Mapped[str] = mapped_column(Uuid, ForeignKey("Chatbot.id"), primary_key=True)
     periodStartedAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     lastResetAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     resetCount: Mapped[int] = mapped_column(Integer, default=0)
     acceptedDisclaimerId: Mapped[Optional[str]] = mapped_column(Uuid)
-    disclaimerAcceptedAt: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True)
-    )
+    disclaimerAcceptedAt: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     disclaimerDeclined: Mapped[bool] = mapped_column(Boolean, default=False)
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
@@ -604,9 +548,7 @@ class AggregatedCourseAnalytics(Base):
     chatParticipantCount: Mapped[int] = mapped_column(Integer, default=0)
     quizParticipantCount: Mapped[int] = mapped_column(Integer, default=0)
     bothChatAndQuizCount: Mapped[int] = mapped_column(Integer, default=0)
-    courseId: Mapped[str] = mapped_column(
-        Uuid, ForeignKey("Course.id"), unique=True
-    )
+    courseId: Mapped[str] = mapped_column(Uuid, ForeignKey("Course.id"), unique=True)
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
@@ -642,9 +584,7 @@ class InstancePerformance(Base):
     totalErrorRate: Mapped[float] = mapped_column(Float)
     totalPartialRate: Mapped[float] = mapped_column(Float)
     totalCorrectRate: Mapped[float] = mapped_column(Float)
-    instanceId: Mapped[int] = mapped_column(
-        Integer, ForeignKey("ElementInstance.id"), unique=True
-    )
+    instanceId: Mapped[int] = mapped_column(Integer, ForeignKey("ElementInstance.id"), unique=True)
     courseId: Mapped[str] = mapped_column(Uuid, ForeignKey("Course.id"))
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
@@ -663,12 +603,8 @@ class ActivityPerformance(Base):
     totalErrorRate: Mapped[float] = mapped_column(Float)
     totalPartialRate: Mapped[float] = mapped_column(Float)
     totalCorrectRate: Mapped[float] = mapped_column(Float)
-    practiceQuizId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("PracticeQuiz.id"), unique=True
-    )
-    microLearningId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("MicroLearning.id"), unique=True
-    )
+    practiceQuizId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("PracticeQuiz.id"), unique=True)
+    microLearningId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("MicroLearning.id"), unique=True)
     courseId: Mapped[str] = mapped_column(Uuid, ForeignKey("Course.id"))
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
@@ -681,12 +617,8 @@ class ParticipantActivityPerformance(Base):
     totalScore: Mapped[int] = mapped_column(Integer)
     completion: Mapped[float] = mapped_column(Float)
     participantId: Mapped[str] = mapped_column(Uuid, ForeignKey("Participant.id"))
-    practiceQuizId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("PracticeQuiz.id")
-    )
-    microLearningId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("MicroLearning.id")
-    )
+    practiceQuizId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("PracticeQuiz.id"))
+    microLearningId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("MicroLearning.id"))
 
 
 class ActivityProgress(Base):
@@ -697,12 +629,8 @@ class ActivityProgress(Base):
     startedCount: Mapped[int] = mapped_column(Integer)
     completedCount: Mapped[int] = mapped_column(Integer)
     repeatedCount: Mapped[Optional[int]] = mapped_column(Integer)
-    practiceQuizId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("PracticeQuiz.id"), unique=True
-    )
-    microLearningId: Mapped[Optional[str]] = mapped_column(
-        Uuid, ForeignKey("MicroLearning.id"), unique=True
-    )
+    practiceQuizId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("PracticeQuiz.id"), unique=True)
+    microLearningId: Mapped[Optional[str]] = mapped_column(Uuid, ForeignKey("MicroLearning.id"), unique=True)
     courseId: Mapped[str] = mapped_column(Uuid, ForeignKey("Course.id"))
     createdAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updatedAt: Mapped[datetime] = mapped_column(DateTime(timezone=True))
@@ -818,9 +746,7 @@ class AggregatedLiveQuizAnalytics(Base):
     __tablename__ = "AggregatedLiveQuizAnalytics"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    liveQuizId: Mapped[str] = mapped_column(
-        Uuid, ForeignKey("LiveQuiz.id"), unique=True
-    )
+    liveQuizId: Mapped[str] = mapped_column(Uuid, ForeignKey("LiveQuiz.id"), unique=True)
     courseId: Mapped[str] = mapped_column(Uuid, ForeignKey("Course.id"))
     participantCount: Mapped[int] = mapped_column(Integer, default=0)
     responseCount: Mapped[int] = mapped_column(Integer, default=0)

--- a/apps/analytics/src/modules/activity_progress/get_course_progress_activities.py
+++ b/apps/analytics/src/modules/activity_progress/get_course_progress_activities.py
@@ -19,24 +19,32 @@ def _quiz_to_dict(quiz) -> dict:
 
 
 def get_course_progress_activities(session: Session, course_id: str):
-    pqs = session.execute(
-        select(PracticeQuiz)
-        .where(PracticeQuiz.courseId == course_id)
-        .options(
-            selectinload(PracticeQuiz.stacks).selectinload(ElementStack.elements),
-            selectinload(PracticeQuiz.responses),
+    pqs = (
+        session.execute(
+            select(PracticeQuiz)
+            .where(PracticeQuiz.courseId == course_id)
+            .options(
+                selectinload(PracticeQuiz.stacks).selectinload(ElementStack.elements),
+                selectinload(PracticeQuiz.responses),
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     pqs_list = [_quiz_to_dict(q) for q in pqs]
 
-    mls = session.execute(
-        select(MicroLearning)
-        .where(MicroLearning.courseId == course_id)
-        .options(
-            selectinload(MicroLearning.stacks).selectinload(ElementStack.elements),
-            selectinload(MicroLearning.responses),
+    mls = (
+        session.execute(
+            select(MicroLearning)
+            .where(MicroLearning.courseId == course_id)
+            .options(
+                selectinload(MicroLearning.stacks).selectinload(ElementStack.elements),
+                selectinload(MicroLearning.responses),
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     mls_list = [_quiz_to_dict(ml) for ml in mls]
 
     return pqs_list, mls_list

--- a/apps/analytics/src/modules/aggregated_analytics/compute_aggregated_analytics.py
+++ b/apps/analytics/src/modules/aggregated_analytics/compute_aggregated_analytics.py
@@ -22,23 +22,14 @@ def compute_aggregated_analytics(
     )
 
     # aggregate all participant analytics values by course
-    df_aggregated_analytics = aggregate_participant_analytics(
-        df_participant_analytics, verbose
-    )
+    df_aggregated_analytics = aggregate_participant_analytics(df_participant_analytics, verbose)
 
     if df_aggregated_analytics is not None and verbose:
         print("Aggregated analytics for time range:" + start_date + " to " + end_date)
         print(df_aggregated_analytics.head())
     elif df_aggregated_analytics is None:
-        print(
-            "No aggregated analytics to compute for time range:"
-            + start_date
-            + " to "
-            + end_date
-        )
+        print("No aggregated analytics to compute for time range:" + start_date + " to " + end_date)
 
     # store the computed aggregated analytics in the database
     if df_aggregated_analytics is not None:
-        save_aggregated_analytics(
-            db, df_aggregated_analytics, timestamp, analytics_type
-        )
+        save_aggregated_analytics(db, df_aggregated_analytics, timestamp, analytics_type)

--- a/apps/analytics/src/modules/aggregated_analytics/load_participant_analytics.py
+++ b/apps/analytics/src/modules/aggregated_analytics/load_participant_analytics.py
@@ -34,9 +34,7 @@ def load_participant_analytics(
         df = _filter_buffered_rows_by_timestamp(buffered_rows, timestamp_value)
         if verbose:
             print(
-                "Found {} analytics for timestamp={} type={} (buffer)".format(
-                    len(df), timestamp_value, analytics_type
-                )
+                "Found {} analytics for timestamp={} type={} (buffer)".format(len(df), timestamp_value, analytics_type)
             )
         return df
 
@@ -61,9 +59,7 @@ def load_participant_analytics(
     return pd.DataFrame([row_to_dict(item) for item in participant_analytics])
 
 
-def _filter_buffered_rows_by_timestamp(
-    rows: list[dict], timestamp_value
-) -> pd.DataFrame:
+def _filter_buffered_rows_by_timestamp(rows: list[dict], timestamp_value) -> pd.DataFrame:
     matches: list[dict] = []
     for row in rows:
         row_ts = row.get("timestamp")

--- a/apps/analytics/src/modules/aggregated_analytics/save_aggregated_analytics.py
+++ b/apps/analytics/src/modules/aggregated_analytics/save_aggregated_analytics.py
@@ -11,20 +11,28 @@ from src.models import (
 
 
 def _count_elements_for_course(session: Session, course_id: str) -> int:
-    practice_quizzes = session.execute(
-        select(PracticeQuiz)
-        .where(PracticeQuiz.courseId == course_id)
-        .options(
-            selectinload(PracticeQuiz.stacks).selectinload(ElementStack.elements),
+    practice_quizzes = (
+        session.execute(
+            select(PracticeQuiz)
+            .where(PracticeQuiz.courseId == course_id)
+            .options(
+                selectinload(PracticeQuiz.stacks).selectinload(ElementStack.elements),
+            )
         )
-    ).scalars().all()
-    micro_learnings = session.execute(
-        select(MicroLearning)
-        .where(MicroLearning.courseId == course_id)
-        .options(
-            selectinload(MicroLearning.stacks).selectinload(ElementStack.elements),
+        .scalars()
+        .all()
+    )
+    micro_learnings = (
+        session.execute(
+            select(MicroLearning)
+            .where(MicroLearning.courseId == course_id)
+            .options(
+                selectinload(MicroLearning.stacks).selectinload(ElementStack.elements),
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     total = 0
     for pq in practice_quizzes:
@@ -36,9 +44,7 @@ def _count_elements_for_course(session: Session, course_id: str) -> int:
     return total
 
 
-def save_aggregated_analytics(
-    session: Session, df_analytics, timestamp, analytics_type="DAILY"
-):
+def save_aggregated_analytics(session: Session, df_analytics, timestamp, analytics_type="DAILY"):
     if df_analytics is None or df_analytics.empty:
         return
 
@@ -94,7 +100,6 @@ def save_aggregated_analytics(
         AggregatedAnalytics,
         rows,
         conflict_cols=["type", "courseId", "timestamp"],
-        update_cols=[c for c in rows[0].keys()
-                     if c not in ("type", "courseId", "timestamp", "createdAt")],
+        update_cols=[c for c in rows[0].keys() if c not in ("type", "courseId", "timestamp", "createdAt")],
     )
     session.commit()

--- a/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics.sql
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics.sql
@@ -8,8 +8,8 @@
 -- meaningful at WEEKLY granularity) — see aggregated_chatbot_analytics_weekly.sql.
 
 WITH params AS (
-  SELECT CAST(:win_start AS timestamptz) AS win_start,
-         CAST(:win_end AS timestamptz) AS win_end
+  SELECT (CAST(:win_start AS timestamptz) AT TIME ZONE 'UTC') AS win_start,
+         (CAST(:win_end AS timestamptz) AT TIME ZONE 'UTC') AS win_end
 ),
 eligible_pairs AS (
   SELECT cuc."participantId", cuc."chatbotId"
@@ -52,8 +52,8 @@ assistant_rollup AS (
 hour_of_day_raw AS (
   SELECT
     "chatbotId",
-    EXTRACT(ISODOW FROM "createdAt" AT TIME ZONE 'UTC')::int AS iso_dow,
-    EXTRACT(HOUR   FROM "createdAt" AT TIME ZONE 'UTC')::int AS hr,
+    EXTRACT(ISODOW FROM "createdAt")::int AS iso_dow,
+    EXTRACT(HOUR   FROM "createdAt")::int AS hr,
     COUNT(*) AS cnt
   FROM user_msgs GROUP BY 1, 2, 3
 ),
@@ -97,10 +97,15 @@ disclaimer_counts AS (
   -- Snapshot counts (NOT window-scoped). Overwritten on every run — reflects the
   -- current state of consent, not the state at the time the window was computed.
   SELECT
-    "chatbotId",
-    COUNT(*) FILTER (WHERE "acceptedDisclaimerId" IS NOT NULL) AS disclaimer_accepted,
-    COUNT(*) FILTER (WHERE "disclaimerDeclined" = true)        AS disclaimer_declined
-  FROM "ChatUsageCredits" GROUP BY 1
+    cuc."chatbotId",
+    COUNT(*) FILTER (
+      WHERE cuc."acceptedDisclaimerId" = cb."disclaimerId"
+        AND cuc."disclaimerDeclined" = false
+    ) AS disclaimer_accepted,
+    COUNT(*) FILTER (WHERE cuc."disclaimerDeclined" = true) AS disclaimer_declined
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  GROUP BY 1
 ),
 credit_exhaustion AS (
   -- Snapshot of the live "current" balance, same caveat as disclaimer_counts.

--- a/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics_weekly.sql
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/aggregated_chatbot_analytics_weekly.sql
@@ -10,8 +10,8 @@
 -- metric) can skip the expensive scan.
 
 WITH params AS (
-  SELECT CAST(:win_start AS timestamptz) AS win_start,
-         CAST(:win_end AS timestamptz) AS win_end
+  SELECT (CAST(:win_start AS timestamptz) AT TIME ZONE 'UTC') AS win_start,
+         (CAST(:win_end AS timestamptz) AT TIME ZONE 'UTC') AS win_end
 ),
 eligible_pairs AS (
   SELECT cuc."participantId", cuc."chatbotId"
@@ -74,8 +74,8 @@ new_returning AS (
 hour_of_day_raw AS (
   SELECT
     "chatbotId",
-    EXTRACT(ISODOW FROM "createdAt" AT TIME ZONE 'UTC')::int AS iso_dow,
-    EXTRACT(HOUR   FROM "createdAt" AT TIME ZONE 'UTC')::int AS hr,
+    EXTRACT(ISODOW FROM "createdAt")::int AS iso_dow,
+    EXTRACT(HOUR   FROM "createdAt")::int AS hr,
     COUNT(*) AS cnt
   FROM user_msgs GROUP BY 1, 2, 3
 ),
@@ -117,10 +117,15 @@ effort_counts AS (
 ),
 disclaimer_counts AS (
   SELECT
-    "chatbotId",
-    COUNT(*) FILTER (WHERE "acceptedDisclaimerId" IS NOT NULL) AS disclaimer_accepted,
-    COUNT(*) FILTER (WHERE "disclaimerDeclined" = true)        AS disclaimer_declined
-  FROM "ChatUsageCredits" GROUP BY 1
+    cuc."chatbotId",
+    COUNT(*) FILTER (
+      WHERE cuc."acceptedDisclaimerId" = cb."disclaimerId"
+        AND cuc."disclaimerDeclined" = false
+    ) AS disclaimer_accepted,
+    COUNT(*) FILTER (WHERE cuc."disclaimerDeclined" = true) AS disclaimer_declined
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  GROUP BY 1
 ),
 credit_exhaustion AS (
   SELECT

--- a/apps/analytics/src/modules/aggregated_chat_analytics/compute_aggregated_chatbot_analytics.py
+++ b/apps/analytics/src/modules/aggregated_chat_analytics/compute_aggregated_chatbot_analytics.py
@@ -20,11 +20,7 @@ __all__ = ["compute_aggregated_chatbot_analytics", "COURSE_TIMESTAMP"]
 
 
 def _prepare_sql(template: str, course_ids: list[str] | None) -> str:
-    clause = (
-        ""
-        if course_ids is None
-        else render_uuid_in_clause('cb."courseId"', course_ids)
-    )
+    clause = "" if course_ids is None else render_uuid_in_clause('cb."courseId"', course_ids)
     return template.replace(_PLACEHOLDER, clause)
 
 
@@ -52,10 +48,7 @@ def compute_aggregated_chatbot_analytics(
         raise ValueError(f"Unknown analytics type: {analytics_type}")
 
     if verbose:
-        print(
-            f"[aggregated_chat_analytics] {analytics_type} "
-            f"{win_start}..{win_end} -> {timestamp}"
-        )
+        print(f"[aggregated_chat_analytics] {analytics_type} {win_start}..{win_end} -> {timestamp}")
 
     params = {"analytics_type": analytics_type, "ts": timestamp}
     session.execute(text(_prepare_delete_sql(course_ids)), params)

--- a/apps/analytics/src/modules/aggregated_course_analytics/compute_weekday_activity.py
+++ b/apps/analytics/src/modules/aggregated_course_analytics/compute_weekday_activity.py
@@ -12,8 +12,12 @@ from src.models import AggregatedCourseAnalytics, ParticipantAnalytics
 
 def compute_weekday_activity(session: Session, course):
     course_id = course["id"]
-    course_start = course["startDate"].date() if hasattr(course["startDate"], "date") else pd.Timestamp(course["startDate"]).date()
-    course_end = course["endDate"].date() if hasattr(course["endDate"], "date") else pd.Timestamp(course["endDate"]).date()
+    course_start = (
+        course["startDate"].date() if hasattr(course["startDate"], "date") else pd.Timestamp(course["startDate"]).date()
+    )
+    course_end = (
+        course["endDate"].date() if hasattr(course["endDate"], "date") else pd.Timestamp(course["endDate"]).date()
+    )
     total_course_participants = len(course["participations"])
 
     df_daily = _load_daily_participant_analytics(session, course_id)
@@ -63,9 +67,7 @@ def compute_weekday_activity(session: Session, course):
 def single_weekday_activity(weekdays, df_daily):
     collector = []
     for weekday in weekdays:
-        df_weekday = df_daily[
-            df_daily["timestamp"] == pd.Timestamp(weekday).tz_localize("UTC")
-        ]
+        df_weekday = df_daily[df_daily["timestamp"] == pd.Timestamp(weekday).tz_localize("UTC")]
         if df_weekday.empty:
             collector.append(0)
         collector.append(len(df_weekday))
@@ -90,12 +92,16 @@ def _load_daily_participant_analytics(session: Session, course_id: str) -> pd.Da
             df["timestamp"] = df["timestamp"].apply(_to_utc_timestamp)
         return df
 
-    daily_analytics = session.execute(
-        select(ParticipantAnalytics).where(
-            ParticipantAnalytics.type == "DAILY",
-            ParticipantAnalytics.courseId == course_id,
+    daily_analytics = (
+        session.execute(
+            select(ParticipantAnalytics).where(
+                ParticipantAnalytics.type == "DAILY",
+                ParticipantAnalytics.courseId == course_id,
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     return pd.DataFrame([row_to_dict(daily) for daily in daily_analytics])
 
 

--- a/apps/analytics/src/modules/chat_analytics/participant_chat_analytics.sql
+++ b/apps/analytics/src/modules/chat_analytics/participant_chat_analytics.sql
@@ -4,16 +4,18 @@
 --   :win_end         timestamptz — window end (exclusive)
 --   :analytics_type  text        — AnalyticsType ('DAILY' | 'WEEKLY' | 'MONTHLY' | 'COURSE')
 --   :ts              date        — timestamp column value (for COURSE use the sentinel 1970-01-01)
--- Only participants with acceptedDisclaimerId IS NOT NULL are included (§3.9 privacy gate).
+-- Only participants who accepted the chatbot's current disclaimer are included (§3.9 privacy gate).
 
 WITH params AS (
-  SELECT CAST(:win_start AS timestamptz) AS win_start,
-         CAST(:win_end AS timestamptz) AS win_end
+  SELECT (CAST(:win_start AS timestamptz) AT TIME ZONE 'UTC') AS win_start,
+         (CAST(:win_end AS timestamptz) AT TIME ZONE 'UTC') AS win_end
 ),
 eligible_pairs AS (
-  SELECT "participantId", "chatbotId"
-  FROM "ChatUsageCredits"
-  WHERE "acceptedDisclaimerId" IS NOT NULL
+  SELECT cuc."participantId", cuc."chatbotId"
+  FROM "ChatUsageCredits" cuc
+  JOIN "Chatbot" cb ON cb.id = cuc."chatbotId"
+  WHERE cuc."acceptedDisclaimerId" = cb."disclaimerId"
+    AND cuc."disclaimerDeclined" = false
 ),
 messages AS (
   SELECT

--- a/apps/analytics/src/modules/chat_topic_clustering/derive_cluster_labels.py
+++ b/apps/analytics/src/modules/chat_topic_clustering/derive_cluster_labels.py
@@ -35,9 +35,7 @@ def _surface_forms(texts: Sequence[str]) -> Dict[str, str]:
     return {lower: c.most_common(1)[0][0] for lower, c in counts.items()}
 
 
-def _select_non_overlapping(
-    ranked_terms: Sequence[Tuple[str, float]], k: int
-) -> List[str]:
+def _select_non_overlapping(ranked_terms: Sequence[Tuple[str, float]], k: int) -> List[str]:
     """Greedy pick up to k terms that share no tokens with already-picked ones.
 
     TF-IDF over a pseudo-document will happily surface both a bigram and its
@@ -98,11 +96,7 @@ def _top_terms_per_cluster(
             labels[cid] = f"cluster-{cid}"
             continue
         top_indices = row_arr.argsort()[::-1][:candidate_pool]
-        ranked = [
-            (feature_names[i], float(row_arr[i]))
-            for i in top_indices
-            if row_arr[i] > 0
-        ]
+        ranked = [(feature_names[i], float(row_arr[i])) for i in top_indices if row_arr[i] > 0]
         picked = _select_non_overlapping(ranked, k=top_k)
         if not picked:
             labels[cid] = f"cluster-{cid}"

--- a/apps/analytics/src/modules/chat_topic_clustering/load_user_text.py
+++ b/apps/analytics/src/modules/chat_topic_clustering/load_user_text.py
@@ -20,10 +20,16 @@ SELECT
   COALESCE(m.content::jsonb->0->>'text', '') AS text
 FROM "ChatMessage" m
 JOIN "ChatThread" ct ON ct.id = m."threadId"
+JOIN "Chatbot" cb ON cb.id = ct."chatbotId"
+JOIN "ChatUsageCredits" cuc
+  ON cuc."participantId" = ct."participantId"
+  AND cuc."chatbotId" = ct."chatbotId"
+  AND cuc."acceptedDisclaimerId" = cb."disclaimerId"
+  AND cuc."disclaimerDeclined" = false
 WHERE m.role = 'user'
   AND ct."chatbotId" = CAST(:chatbot_id AS uuid)
-  AND m."createdAt" >= CAST(:win_start AS timestamptz)
-  AND m."createdAt" <  CAST(:win_end AS timestamptz)
+  AND m."createdAt" >= (CAST(:win_start AS timestamptz) AT TIME ZONE 'UTC')
+  AND m."createdAt" <  (CAST(:win_end AS timestamptz) AT TIME ZONE 'UTC')
 """
 
 

--- a/apps/analytics/src/modules/chat_topic_clustering/save_topic_clusters.py
+++ b/apps/analytics/src/modules/chat_topic_clustering/save_topic_clusters.py
@@ -68,11 +68,7 @@ def save_clusters(
         else:
             kept.append((cluster_labels.get(cid, f"cluster-{cid}"), msg_count, p_count))
 
-    noise_messages = [
-        (cid, pid)
-        for cid, pid in zip(cluster_ids_per_message, participant_ids_per_message)
-        if cid < 0
-    ]
+    noise_messages = [(cid, pid) for cid, pid in zip(cluster_ids_per_message, participant_ids_per_message) if cid < 0]
     other_msg += len(noise_messages)
     for _, pid in noise_messages:
         other_participants.add(pid)

--- a/apps/analytics/src/modules/instance_activity_performance/get_course_activities.py
+++ b/apps/analytics/src/modules/instance_activity_performance/get_course_activities.py
@@ -20,25 +20,33 @@ def _activity_to_dict(activity) -> dict:
 
 
 def get_course_activities(session: Session, course_id: str):
-    pqs = session.execute(
-        select(PracticeQuiz)
-        .where(PracticeQuiz.courseId == course_id)
-        .options(
-            selectinload(PracticeQuiz.stacks)
-            .selectinload(ElementStack.elements)
-            .selectinload(ElementInstance.responses)
+    pqs = (
+        session.execute(
+            select(PracticeQuiz)
+            .where(PracticeQuiz.courseId == course_id)
+            .options(
+                selectinload(PracticeQuiz.stacks)
+                .selectinload(ElementStack.elements)
+                .selectinload(ElementInstance.responses)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
-    mls = session.execute(
-        select(MicroLearning)
-        .where(MicroLearning.courseId == course_id)
-        .options(
-            selectinload(MicroLearning.stacks)
-            .selectinload(ElementStack.elements)
-            .selectinload(ElementInstance.responses)
+    mls = (
+        session.execute(
+            select(MicroLearning)
+            .where(MicroLearning.courseId == course_id)
+            .options(
+                selectinload(MicroLearning.stacks)
+                .selectinload(ElementStack.elements)
+                .selectinload(ElementInstance.responses)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     return (
         [_activity_to_dict(q) for q in pqs],

--- a/apps/analytics/src/modules/instance_activity_performance/save_activity_performance.py
+++ b/apps/analytics/src/modules/instance_activity_performance/save_activity_performance.py
@@ -41,8 +41,7 @@ def save_activity_performance(
         conflict_col = "microLearningId"
     else:
         raise ValueError(
-            "Either practice_quiz_id or microlearning_id must be provided for "
-            "activity performance creation/update"
+            "Either practice_quiz_id or microlearning_id must be provided for activity performance creation/update"
         )
 
     update_cols = [c for c in values.keys() if c != conflict_col and c != "createdAt"]

--- a/apps/analytics/src/modules/instance_activity_performance/save_instance_performances.py
+++ b/apps/analytics/src/modules/instance_activity_performance/save_instance_performances.py
@@ -6,9 +6,7 @@ from src.db_helpers import bulk_upsert
 from src.models import InstancePerformance
 
 
-def save_instance_performances(
-    session: Session, df_instance_performance, course_id: str, total_only: bool = False
-):
+def save_instance_performances(session: Session, df_instance_performance, course_id: str, total_only: bool = False):
     if df_instance_performance is None or df_instance_performance.empty:
         return
 

--- a/apps/analytics/src/modules/live_quiz_analytics/aggregated_live_quiz_analytics.sql
+++ b/apps/analytics/src/modules/live_quiz_analytics/aggregated_live_quiz_analytics.sql
@@ -15,10 +15,9 @@ WITH assessment_responses AS (
       PARTITION BY lqr."participantId", lqr."instanceId"
       ORDER BY lqr."submittedAt" ASC, lqr.id ASC
     ) AS attempt_asc,
-    ROW_NUMBER() OVER (
+    COUNT(*) OVER (
       PARTITION BY lqr."participantId", lqr."instanceId"
-      ORDER BY lqr."submittedAt" DESC, lqr.id DESC
-    ) AS attempt_desc
+    ) AS attempt_count
   FROM "LiveQuizResponse" lqr
   JOIN "ElementInstance" ei ON ei.id = lqr."instanceId"
   JOIN "ElementBlock"    eb ON eb.id = ei."elementBlockId"
@@ -45,7 +44,7 @@ rollup AS (
     COUNT(id) AS response_count,
     AVG(CASE WHEN attempt_asc = 1 THEN (correctness = 'CORRECT')::int END)::real
       AS mean_first_correctness,
-    AVG(CASE WHEN attempt_desc = 1 THEN (correctness = 'CORRECT')::int END)::real
+    AVG(CASE WHEN attempt_asc = attempt_count THEN (correctness = 'CORRECT')::int END)::real
       AS mean_last_correctness
   FROM assessment_responses
   GROUP BY "liveQuizId", "courseId"
@@ -53,11 +52,10 @@ rollup AS (
 late_rate AS (
   SELECT
     "liveQuizId",
-    CASE WHEN COUNT(*) = 0 THEN NULL
-         ELSE SUM(CASE WHEN live_quiz_finished_at IS NOT NULL
-                         AND first_submitted_at > live_quiz_finished_at
-                       THEN 1 ELSE 0 END)::float / COUNT(*)
-    END::real AS late_submitter_rate
+    AVG((
+      live_quiz_finished_at IS NOT NULL
+      AND first_submitted_at > live_quiz_finished_at
+    )::int)::real AS late_submitter_rate
   FROM participant_firsts
   GROUP BY "liveQuizId"
 )

--- a/apps/analytics/src/modules/live_quiz_analytics/compute_live_quiz_analytics.py
+++ b/apps/analytics/src/modules/live_quiz_analytics/compute_live_quiz_analytics.py
@@ -13,9 +13,7 @@ _PLACEHOLDER = "/*COURSE_FILTER*/"
 
 
 def _prepare_sql(template: str, course_ids: list[str] | None) -> str:
-    clause = (
-        "" if course_ids is None else render_uuid_in_clause('lq."courseId"', course_ids)
-    )
+    clause = "" if course_ids is None else render_uuid_in_clause('lq."courseId"', course_ids)
     return template.replace(_PLACEHOLDER, clause)
 
 

--- a/apps/analytics/src/modules/participant_activity_performance/prepare_participant_activity_data.py
+++ b/apps/analytics/src/modules/participant_activity_performance/prepare_participant_activity_data.py
@@ -13,27 +13,35 @@ from src.modules.utils import check_analytics_cancellation
 
 
 def prepare_participant_activity_data(session: Session, course_id: str):
-    practice_quizzes = session.execute(
-        select(PracticeQuiz)
-        .where(PracticeQuiz.courseId == course_id)
-        .options(
-            selectinload(PracticeQuiz.stacks)
-            .selectinload(ElementStack.elements)
-            .selectinload(ElementInstance.responses)
+    practice_quizzes = (
+        session.execute(
+            select(PracticeQuiz)
+            .where(PracticeQuiz.courseId == course_id)
+            .options(
+                selectinload(PracticeQuiz.stacks)
+                .selectinload(ElementStack.elements)
+                .selectinload(ElementInstance.responses)
+            )
         )
-    ).scalars().all()
-    micro_learnings = session.execute(
-        select(MicroLearning)
-        .where(MicroLearning.courseId == course_id)
-        .options(
-            selectinload(MicroLearning.stacks)
-            .selectinload(ElementStack.elements)
-            .selectinload(ElementInstance.responses)
+        .scalars()
+        .all()
+    )
+    micro_learnings = (
+        session.execute(
+            select(MicroLearning)
+            .where(MicroLearning.courseId == course_id)
+            .options(
+                selectinload(MicroLearning.stacks)
+                .selectinload(ElementStack.elements)
+                .selectinload(ElementInstance.responses)
+            )
         )
-    ).scalars().all()
-    participant_ids = session.execute(
-        select(Participation.participantId).where(Participation.courseId == course_id)
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
+    participant_ids = (
+        session.execute(select(Participation.participantId).where(Participation.courseId == course_id)).scalars().all()
+    )
 
     published_statuses = {"PUBLISHED", "ENDED", "GRADED"}
     practice_quizzes = [pq for pq in practice_quizzes if pq.status in published_statuses]
@@ -44,16 +52,13 @@ def prepare_participant_activity_data(session: Session, course_id: str):
             {
                 "id": activity.id,
                 "type": activity_type,
-                "instanceCount": sum(
-                    len(stack.elements) for stack in activity.stacks
-                ),
+                "instanceCount": sum(len(stack.elements) for stack in activity.stacks),
             }
             for activity in activities
         ]
 
     df_activities = pd.DataFrame(
-        _activity_rows(practice_quizzes, "practiceQuizzes")
-        + _activity_rows(micro_learnings, "microLearnings")
+        _activity_rows(practice_quizzes, "practiceQuizzes") + _activity_rows(micro_learnings, "microLearnings")
     )
 
     responses = []

--- a/apps/analytics/src/modules/participant_activity_performance/save_participant_activity_performance.py
+++ b/apps/analytics/src/modules/participant_activity_performance/save_participant_activity_performance.py
@@ -5,9 +5,7 @@ from src.db_helpers import bulk_upsert
 from src.models import ParticipantActivityPerformance
 
 
-def save_participant_activity_performance(
-    session: Session, df_activity_performance, activity_type: str
-):
+def save_participant_activity_performance(session: Session, df_activity_performance, activity_type: str):
     if df_activity_performance is None or df_activity_performance.empty:
         return
 

--- a/apps/analytics/src/modules/participant_analytics/save_participant_analytics.py
+++ b/apps/analytics/src/modules/participant_analytics/save_participant_analytics.py
@@ -4,9 +4,7 @@ from src.db_helpers import bulk_upsert, coerce_date, utcnow
 from src.models import ParticipantAnalytics
 
 
-def save_participant_analytics(
-    session: Session, df_analytics, timestamp, analytics_type="DAILY"
-):
+def save_participant_analytics(session: Session, df_analytics, timestamp, analytics_type="DAILY"):
     if df_analytics is None or df_analytics.empty:
         return
 
@@ -69,7 +67,8 @@ def save_participant_analytics(
         ParticipantAnalytics,
         rows,
         conflict_cols=["type", "courseId", "participantId", "timestamp"],
-        update_cols=[c for c in rows[0].keys()
-                     if c not in ("type", "courseId", "participantId", "timestamp", "createdAt")],
+        update_cols=[
+            c for c in rows[0].keys() if c not in ("type", "courseId", "participantId", "timestamp", "createdAt")
+        ],
     )
     session.commit()

--- a/apps/analytics/src/modules/participant_course_analytics/compute_participant_activity.py
+++ b/apps/analytics/src/modules/participant_course_analytics/compute_participant_activity.py
@@ -8,9 +8,7 @@ from src.models import ParticipantAnalytics
 from src.modules.utils import check_analytics_cancellation
 
 
-def compute_participant_activity(
-    session: Session, df_activity, course_id, course_start, course_end
-):
+def compute_participant_activity(session: Session, df_activity, course_id, course_start, course_end):
     course_duration = (course_end - course_start).days + 1
     week_end_dates = pd.date_range(start=course_start, end=course_end, freq="W")
 
@@ -23,13 +21,17 @@ def compute_participant_activity(
         if daily_by_participant is not None:
             daily_analytics = daily_by_participant.get(str(participant_id), [])
         else:
-            daily_rows = session.execute(
-                select(ParticipantAnalytics).where(
-                    ParticipantAnalytics.type == "DAILY",
-                    ParticipantAnalytics.courseId == course_id,
-                    ParticipantAnalytics.participantId == participant_id,
+            daily_rows = (
+                session.execute(
+                    select(ParticipantAnalytics).where(
+                        ParticipantAnalytics.type == "DAILY",
+                        ParticipantAnalytics.courseId == course_id,
+                        ParticipantAnalytics.participantId == participant_id,
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             daily_analytics = [row_to_dict(d) for d in daily_rows]
 
         response_count = sum(d["responseCount"] for d in daily_analytics)
@@ -46,9 +48,7 @@ def compute_participant_activity(
                 week_analytics = sum_active_days_per_week(week_end, daily_analytics)
                 active_days_week.append(len(week_analytics))
 
-        df_activity.loc[idx, "activeDaysPerWeek"] = sum(active_days_week) / len(
-            active_days_week
-        )
+        df_activity.loc[idx, "activeDaysPerWeek"] = sum(active_days_week) / len(active_days_week)
 
     return df_activity
 
@@ -71,8 +71,4 @@ def _buffered_daily_by_participant(course_id) -> dict[str, list[dict]] | None:
 def sum_active_days_per_week(week_end, daily_analytics):
     week_start = pd.Timestamp(week_end) - pd.DateOffset(days=6)
     end_ts = pd.Timestamp(week_end)
-    return [
-        d
-        for d in daily_analytics
-        if week_start <= pd.Timestamp(d["timestamp"]) <= end_ts
-    ]
+    return [d for d in daily_analytics if week_start <= pd.Timestamp(d["timestamp"]) <= end_ts]

--- a/apps/analytics/src/modules/participant_course_analytics/get_active_weeks.py
+++ b/apps/analytics/src/modules/participant_course_analytics/get_active_weeks.py
@@ -22,7 +22,9 @@ def get_active_weeks(session: Session, course):
             active_weeks = weekly_counts_by_participant.get(str(participant_id), 0)
         else:
             active_weeks = session.execute(
-                select(func.count()).select_from(ParticipantAnalytics).where(
+                select(func.count())
+                .select_from(ParticipantAnalytics)
+                .where(
                     ParticipantAnalytics.type == "WEEKLY",
                     ParticipantAnalytics.courseId == course_id,
                     ParticipantAnalytics.participantId == participant_id,

--- a/apps/analytics/src/modules/participant_course_analytics/get_running_past_courses.py
+++ b/apps/analytics/src/modules/participant_course_analytics/get_running_past_courses.py
@@ -13,9 +13,7 @@ def get_running_past_courses(session: Session) -> pd.DataFrame:
     curr_date = datetime.now()
     scope = scoped_course_ids(session)
 
-    stmt = select(Course.id, Course.startDate, Course.endDate).where(
-        Course.startDate <= curr_date
-    )
+    stmt = select(Course.id, Course.startDate, Course.endDate).where(Course.startDate <= curr_date)
     stmt = apply_course_scope(scope, stmt, Course.id)
     if stmt is None:
         print("[get_running_past_courses] empty scope — returning no courses")
@@ -27,14 +25,10 @@ def get_running_past_courses(session: Session) -> pd.DataFrame:
     participations_by_course: dict[str, list[dict[str, object]]] = defaultdict(list)
     if course_ids:
         participation_rows = session.execute(
-            select(Participation.courseId, Participation.participantId).where(
-                Participation.courseId.in_(course_ids)
-            )
+            select(Participation.courseId, Participation.participantId).where(Participation.courseId.in_(course_ids))
         ).mappings()
         for row in participation_rows:
-            participations_by_course[str(row["courseId"])].append(
-                {"participantId": row["participantId"]}
-            )
+            participations_by_course[str(row["courseId"])].append({"participantId": row["participantId"]})
 
     rows = []
     for course in courses:
@@ -44,7 +38,5 @@ def get_running_past_courses(session: Session) -> pd.DataFrame:
 
     df_courses = pd.DataFrame(rows)
     scope_note = f" (scoped to {len(scope)} ids)" if scope is not None else ""
-    print(
-        f"Found {len(df_courses)} courses with a start date before {curr_date}{scope_note}"
-    )
+    print(f"Found {len(df_courses)} courses with a start date before {curr_date}{scope_note}")
     return df_courses

--- a/apps/analytics/src/modules/utils.py
+++ b/apps/analytics/src/modules/utils.py
@@ -36,12 +36,6 @@ ComputeFn = Callable[..., object]
 AnalyticsMode = Literal["full", "incremental", "finalize"]
 
 
-def exclusive_day_end(day: str) -> str:
-    """Return midnight after ``day`` for use with exclusive SQL window ends."""
-    next_day = datetime.strptime(day, "%Y-%m-%d") + timedelta(days=1)
-    return next_day.strftime("%Y-%m-%dT00:00:00.000Z")
-
-
 @dataclass(frozen=True, slots=True)
 class AnalyticsRunConfig:
     """Immutable configuration for one analytics task execution."""
@@ -103,6 +97,12 @@ def analytics_run_config_from_env() -> AnalyticsRunConfig:
         window_since=analytics_window_since(),
         chat_analytics_cutoff=(os.environ.get("ANALYTICS_CHAT_CUTOFF") or "").strip() or None,
     )
+
+
+def exclusive_day_end(day: str) -> str:
+    """Return midnight after ``day`` for use with exclusive SQL window ends."""
+    next_day = datetime.strptime(day, "%Y-%m-%d") + timedelta(days=1)
+    return next_day.strftime("%Y-%m-%dT00:00:00.000Z")
 
 
 def _parse_window_since(windows_since: str | None) -> pd.Timestamp | None:
@@ -182,7 +182,7 @@ def iter_analytics_windows(
             compute_fn(
                 session,
                 day + "T00:00:00.000Z",
-                day + "T23:59:59.999Z",
+                exclusive_day_end(day),
                 day,
                 "DAILY",
                 verbose=verbose,
@@ -200,7 +200,7 @@ def iter_analytics_windows(
             compute_fn(
                 session,
                 win_start + "T00:00:00.000Z",
-                week_end + "T23:59:59.999Z",
+                exclusive_day_end(week_end),
                 week_end,
                 "WEEKLY",
                 verbose=verbose,
@@ -218,7 +218,7 @@ def iter_analytics_windows(
             compute_fn(
                 session,
                 win_start + "T00:00:00.000Z",
-                month_end + "T23:59:59.999Z",
+                exclusive_day_end(month_end),
                 month_end,
                 "MONTHLY",
                 verbose=verbose,
@@ -231,7 +231,7 @@ def iter_analytics_windows(
         compute_fn(
             session,
             start_date + "T00:00:00.000Z",
-            end_date + "T23:59:59.999Z",
+            exclusive_day_end(end_date),
             COURSE_TIMESTAMP,
             "COURSE",
             verbose=verbose,

--- a/apps/analytics/src/scripts/10_chat_topic_clustering.py
+++ b/apps/analytics/src/scripts/10_chat_topic_clustering.py
@@ -18,6 +18,7 @@ from src.modules.utils import (
     analytics_mode,
     analytics_window_since,
     check_analytics_cancellation,
+    exclusive_day_end,
     scoped_course_ids,
 )
 
@@ -37,24 +38,18 @@ def main() -> None:
         )
         if scope is not None:
             if not scope:
-                print(
-                    "[10_chat_topic_clustering] empty course scope — nothing to cluster"
-                )
+                print("[10_chat_topic_clustering] empty course scope — nothing to cluster")
                 chatbots = []
             else:
-                chatbots = session.execute(
-                    select(Chatbot).where(Chatbot.courseId.in_(scope))
-                ).scalars().all()
+                chatbots = session.execute(select(Chatbot).where(Chatbot.courseId.in_(scope))).scalars().all()
         else:
             chatbots = session.execute(select(Chatbot)).scalars().all()
 
-        scope_note = (
-            f" (scoped to {len(scope)} course ids)" if scope is not None else ""
-        )
+        scope_note = f" (scoped to {len(scope)} course ids)" if scope is not None else ""
         print(f"Found {len(chatbots)} chatbots to cluster{scope_note}")
 
         win_start = "2022-10-23T00:00:00.000Z"
-        win_end = datetime.now().strftime("%Y-%m-%d") + "T23:59:59.999Z"
+        win_end = exclusive_day_end(datetime.now().strftime("%Y-%m-%d"))
 
         total_rows = 0
         failures = []

--- a/apps/analytics/src/scripts/1_initial_aggregated_analytics.py
+++ b/apps/analytics/src/scripts/1_initial_aggregated_analytics.py
@@ -56,9 +56,7 @@ def main() -> None:
                     continue
                 day_start = specific_date + "T00:00:00.000Z"
                 day_end = specific_date + "T23:59:59.999Z"
-                print(
-                    f"Computing daily aggregated analytics (course) for {specific_date}"
-                )
+                print(f"Computing daily aggregated analytics (course) for {specific_date}")
                 compute_aggregated_analytics(
                     session,
                     day_start,
@@ -76,13 +74,8 @@ def main() -> None:
                 if should_skip_window(week_end_date, windows_since):
                     continue
                 week_end = week_end_date + "T23:59:59.999Z"
-                week_start = (curr_date - pd.DateOffset(days=6)).strftime(
-                    "%Y-%m-%d"
-                ) + "T00:00:00.000Z"
-                print(
-                    f"Computing weekly aggregated analytics (course) for "
-                    f"{week_start} to {week_end}"
-                )
+                week_start = (curr_date - pd.DateOffset(days=6)).strftime("%Y-%m-%d") + "T00:00:00.000Z"
+                print(f"Computing weekly aggregated analytics (course) for {week_start} to {week_end}")
                 compute_aggregated_analytics(
                     session,
                     week_start,
@@ -100,13 +93,8 @@ def main() -> None:
                 if should_skip_window(month_end_date, windows_since):
                     continue
                 month_end = month_end_date + "T23:59:59.999Z"
-                month_start = (curr_date - pd.offsets.MonthBegin(1)).strftime(
-                    "%Y-%m-%d"
-                ) + "T00:00:00.000Z"
-                print(
-                    f"Computing monthly aggregated analytics (course) for "
-                    f"{month_start} to {month_end}"
-                )
+                month_start = (curr_date - pd.offsets.MonthBegin(1)).strftime("%Y-%m-%d") + "T00:00:00.000Z"
+                print(f"Computing monthly aggregated analytics (course) for {month_start} to {month_end}")
                 compute_aggregated_analytics(
                     session,
                     month_start,

--- a/apps/analytics/src/scripts/4_initial_participant_performance.py
+++ b/apps/analytics/src/scripts/4_initial_participant_performance.py
@@ -47,13 +47,11 @@ def main() -> None:
         for idx, course in df_courses.iterrows():
             check_analytics_cancellation()
             course_id = course["id"]
-            print(
-                f"Processing course", idx, "of", len(df_courses), "with id", course_id
-            )
+            print("Processing course", idx, "of", len(df_courses), "with id", course_id)
 
-            responses = session.execute(
-                select(QuestionResponse).where(QuestionResponse.courseId == course_id)
-            ).scalars().all()
+            responses = (
+                session.execute(select(QuestionResponse).where(QuestionResponse.courseId == course_id)).scalars().all()
+            )
             df_responses = pd.DataFrame([row_to_dict(r) for r in responses])
 
             if df_responses.empty:

--- a/apps/analytics/src/scripts/7_participant_activity_performance.py
+++ b/apps/analytics/src/scripts/7_participant_activity_performance.py
@@ -39,7 +39,7 @@ def main() -> None:
         for idx, base_course in df_courses.iterrows():
             check_analytics_cancellation()
             print(
-                f"Processing course",
+                "Processing course",
                 idx,
                 "of",
                 len(df_courses),
@@ -47,16 +47,12 @@ def main() -> None:
                 base_course["id"],
             )
 
-            df_activities, df_responses, participant_ids = (
-                prepare_participant_activity_data(session, base_course["id"])
-            )
+            df_activities, df_responses, participant_ids = prepare_participant_activity_data(session, base_course["id"])
 
             if df_responses.empty:
                 continue
 
-            agg_participant_activity_performance(
-                session, df_responses, df_activities, participant_ids
-            )
+            agg_participant_activity_performance(session, df_responses, df_activities, participant_ids)
 
         script_exit(script=__name__, started=started, rows_written=None)
 

--- a/apps/analytics/src/scripts/export_dryrun.py
+++ b/apps/analytics/src/scripts/export_dryrun.py
@@ -47,10 +47,7 @@ def main() -> None:
     parser.add_argument(
         "--output",
         default=None,
-        help=(
-            "Path to the .xlsx file to produce. Defaults to "
-            "./analytics-dryrun-<courseId>-<YYYY-MM-DD>.xlsx"
-        ),
+        help=("Path to the .xlsx file to produce. Defaults to ./analytics-dryrun-<courseId>-<YYYY-MM-DD>.xlsx"),
     )
     parser.add_argument(
         "--scripts",

--- a/apps/analytics/tests/test_aggregated_analytics_dates.py
+++ b/apps/analytics/tests/test_aggregated_analytics_dates.py
@@ -126,9 +126,7 @@ def test_load_participant_analytics_empty_scope_short_circuits_without_query():
 
 
 def test_save_aggregated_analytics_uses_date_objects_for_course_timestamp(monkeypatch):
-    module = importlib.import_module(
-        "src.modules.aggregated_analytics.save_aggregated_analytics"
-    )
+    module = importlib.import_module("src.modules.aggregated_analytics.save_aggregated_analytics")
 
     captured = {}
 
@@ -170,9 +168,7 @@ def test_save_aggregated_analytics_uses_date_objects_for_course_timestamp(monkey
 def test_save_aggregated_analytics_uses_date_objects_for_daily_iso_timestamp(
     monkeypatch,
 ):
-    module = importlib.import_module(
-        "src.modules.aggregated_analytics.save_aggregated_analytics"
-    )
+    module = importlib.import_module("src.modules.aggregated_analytics.save_aggregated_analytics")
 
     captured = {}
 

--- a/apps/analytics/tests/test_analytics_sql_contracts.py
+++ b/apps/analytics/tests/test_analytics_sql_contracts.py
@@ -54,7 +54,7 @@ class AnalyticsSqlContractTests(unittest.TestCase):
                 self.assertIn("JOIN eligible_pairs ep", statement[messages_cte:disclaimer_cte])
                 self.assertIn('EXTRACT(ISODOW FROM "createdAt")', statement)
                 self.assertIn('EXTRACT(HOUR   FROM "createdAt")', statement)
-                self.assertIn("::timestamptz AT TIME ZONE 'UTC'", statement)
+                self.assertIn("CAST(:win_start AS timestamptz) AT TIME ZONE 'UTC'", statement)
                 self.assertIn('cuc."acceptedDisclaimerId" = cb."disclaimerId"', statement)
                 self.assertIn('cuc."disclaimerDeclined" = false', statement)
 

--- a/apps/analytics/tests/test_chat_quiz_correlation_buffer.py
+++ b/apps/analytics/tests/test_chat_quiz_correlation_buffer.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -100,9 +100,7 @@ def test_compute_outcomes_bucket_assignment_matches_percentile_semantics():
     with intercept_writes(buffer):
         compute_participant_chat_outcomes(session=None, course_ids=["c1"])
 
-    by_participant = {
-        row["participantId"]: row for row in buffer.rows_by_table["ParticipantChatOutcome"]
-    }
+    by_participant = {row["participantId"]: row for row in buffer.rows_by_table["ParticipantChatOutcome"]}
     assert by_participant["p1"]["chatDoseBucket"] == "NONE"  # zero messages
     assert by_participant["p2"]["chatDoseBucket"] == "LOW"
     assert by_participant["p7"]["chatDoseBucket"] == "HIGH"

--- a/apps/analytics/tests/test_chat_topic_clustering_labels.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_labels.py
@@ -44,9 +44,7 @@ def test_derive_labels_filters_additional_german_fillers_from_prod_run():
     label = labels[0]
     assert "sigma" in label
     for filler in ("uhr", "auf", "kann", "wird", "werden", "nicht", "wie", "ich"):
-        assert filler not in label.split(" · "), (
-            f"expected '{filler}' to be filtered, got label: {label}"
-        )
+        assert filler not in label.split(" · "), f"expected '{filler}' to be filtered, got label: {label}"
 
 
 def test_derive_labels_deduplicates_overlapping_ngrams():
@@ -78,10 +76,7 @@ def test_derive_labels_deduplicates_overlapping_ngrams():
         for j, b in enumerate(tokenised):
             if i == j:
                 continue
-            assert not a.issubset(b), (
-                f"'{parts[i]}' is redundantly contained in '{parts[j]}' "
-                f"within label: {labels[0]}"
-            )
+            assert not a.issubset(b), f"'{parts[i]}' is redundantly contained in '{parts[j]}' within label: {labels[0]}"
 
 
 def test_derive_labels_restores_original_surface_casing():

--- a/apps/analytics/tests/test_chat_topic_clustering_params.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_params.py
@@ -59,6 +59,4 @@ def test_cluster_embeddings_recovers_multiple_clusters_on_separated_topics():
     )
 
     noise_fraction = (len(cluster_ids) - len(non_noise)) / len(cluster_ids)
-    assert noise_fraction < 0.5, (
-        f"noise fraction {noise_fraction:.2f} too high — clustering is degenerate"
-    )
+    assert noise_fraction < 0.5, f"noise fraction {noise_fraction:.2f} too high — clustering is degenerate"

--- a/apps/analytics/tests/test_chat_topic_clustering_sql.py
+++ b/apps/analytics/tests/test_chat_topic_clustering_sql.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+
+
+@pytest.mark.integration
+def test_load_user_text_enforces_current_consent_and_utc_window(session):
+    from src.modules.chat_topic_clustering.load_user_text import load_user_text
+
+    chatbot_id = UUID("00000000-0000-0000-0000-000000000001")
+    disclaimer_id = UUID("00000000-0000-0000-0000-000000000002")
+    stale_disclaimer_id = UUID("00000000-0000-0000-0000-000000000003")
+    current_participant_id = UUID("00000000-0000-0000-0000-000000000004")
+    stale_participant_id = UUID("00000000-0000-0000-0000-000000000005")
+    declined_participant_id = UUID("00000000-0000-0000-0000-000000000006")
+    current_thread_id = UUID("00000000-0000-0000-0000-000000000007")
+    stale_thread_id = UUID("00000000-0000-0000-0000-000000000008")
+    declined_thread_id = UUID("00000000-0000-0000-0000-000000000009")
+    included_message_id = UUID("00000000-0000-0000-0000-000000000010")
+
+    session.execute(text("SET LOCAL TIME ZONE 'Europe/Zurich'"))
+    session.execute(
+        text(
+            """
+            CREATE TEMP TABLE "Chatbot" (
+              id uuid PRIMARY KEY,
+              "disclaimerId" uuid
+            );
+            CREATE TEMP TABLE "ChatThread" (
+              id uuid PRIMARY KEY,
+              "chatbotId" uuid NOT NULL,
+              "participantId" uuid NOT NULL
+            );
+            CREATE TEMP TABLE "ChatUsageCredits" (
+              "participantId" uuid NOT NULL,
+              "chatbotId" uuid NOT NULL,
+              "acceptedDisclaimerId" uuid,
+              "disclaimerDeclined" boolean NOT NULL
+            );
+            CREATE TEMP TABLE "ChatMessage" (
+              id uuid PRIMARY KEY,
+              "threadId" uuid NOT NULL,
+              content jsonb NOT NULL,
+              role text NOT NULL,
+              "createdAt" timestamp(3) NOT NULL
+            );
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "Chatbot" (id, "disclaimerId")
+            VALUES (:chatbot_id, :disclaimer_id)
+            """
+        ),
+        {"chatbot_id": chatbot_id, "disclaimer_id": disclaimer_id},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatThread" (id, "chatbotId", "participantId")
+            VALUES
+              (:current_thread_id, :chatbot_id, :current_participant_id),
+              (:stale_thread_id, :chatbot_id, :stale_participant_id),
+              (:declined_thread_id, :chatbot_id, :declined_participant_id)
+            """
+        ),
+        {
+            "chatbot_id": chatbot_id,
+            "current_participant_id": current_participant_id,
+            "stale_participant_id": stale_participant_id,
+            "declined_participant_id": declined_participant_id,
+            "current_thread_id": current_thread_id,
+            "stale_thread_id": stale_thread_id,
+            "declined_thread_id": declined_thread_id,
+        },
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatUsageCredits"
+              ("participantId", "chatbotId", "acceptedDisclaimerId", "disclaimerDeclined")
+            VALUES
+              (:current_participant_id, :chatbot_id, :disclaimer_id, false),
+              (:stale_participant_id, :chatbot_id, :stale_disclaimer_id, false),
+              (:declined_participant_id, :chatbot_id, :disclaimer_id, true)
+            """
+        ),
+        {
+            "chatbot_id": chatbot_id,
+            "disclaimer_id": disclaimer_id,
+            "stale_disclaimer_id": stale_disclaimer_id,
+            "current_participant_id": current_participant_id,
+            "stale_participant_id": stale_participant_id,
+            "declined_participant_id": declined_participant_id,
+        },
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO "ChatMessage" (id, "threadId", content, role, "createdAt")
+            VALUES
+              (
+                :included_message_id,
+                :current_thread_id,
+                '[{"type":"text","text":"included"}]',
+                'user',
+                TIMESTAMP '2026-07-23 10:30:00'
+              ),
+              (
+                '00000000-0000-0000-0000-000000000011',
+                :current_thread_id,
+                '[{"type":"text","text":"exclusive end"}]',
+                'user',
+                TIMESTAMP '2026-07-23 11:00:00'
+              ),
+              (
+                '00000000-0000-0000-0000-000000000012',
+                :stale_thread_id,
+                '[{"type":"text","text":"stale consent"}]',
+                'user',
+                TIMESTAMP '2026-07-23 10:30:00'
+              ),
+              (
+                '00000000-0000-0000-0000-000000000013',
+                :declined_thread_id,
+                '[{"type":"text","text":"declined"}]',
+                'user',
+                TIMESTAMP '2026-07-23 10:30:00'
+              )
+            """
+        ),
+        {
+            "current_thread_id": current_thread_id,
+            "stale_thread_id": stale_thread_id,
+            "declined_thread_id": declined_thread_id,
+            "included_message_id": included_message_id,
+        },
+    )
+
+    rows = load_user_text(
+        session,
+        str(chatbot_id),
+        "2026-07-23T10:00:00Z",
+        "2026-07-23T11:00:00Z",
+    )
+
+    assert rows == [
+        {
+            "message_id": str(included_message_id),
+            "participant_id": current_participant_id,
+            "text": "included",
+        }
+    ]

--- a/apps/analytics/tests/test_db_helpers.py
+++ b/apps/analytics/tests/test_db_helpers.py
@@ -35,9 +35,7 @@ def test_row_to_dict_skips_unloaded_column_attributes():
         session.commit()
 
     with Session(engine) as session:
-        thing = session.execute(
-            select(_Thing).options(load_only(_Thing.id, _Thing.name))
-        ).scalar_one()
+        thing = session.execute(select(_Thing).options(load_only(_Thing.id, _Thing.name))).scalar_one()
 
         assert row_to_dict(thing) == {"id": 1, "name": "visible"}
 

--- a/apps/analytics/tests/test_live_quiz_analytics_sql.py
+++ b/apps/analytics/tests/test_live_quiz_analytics_sql.py
@@ -11,7 +11,7 @@ def test_aggregated_query_ranks_attempts_per_participant_and_instance():
 
     assert 'PARTITION BY lqr."participantId", lqr."instanceId"' in _AGGREGATED_SQL
     assert "attempt_asc = 1" in _AGGREGATED_SQL
-    assert "attempt_desc = 1" in _AGGREGATED_SQL
+    assert "attempt_asc = attempt_count" in _AGGREGATED_SQL
     assert "JOIN LATERAL" not in _AGGREGATED_SQL
 
 

--- a/apps/analytics/tests/test_participant_analytics_helpers.py
+++ b/apps/analytics/tests/test_participant_analytics_helpers.py
@@ -13,9 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 def test_detail_to_dict_uses_course_lookup_without_course_relationship(monkeypatch):
-    module = importlib.import_module(
-        "src.modules.participant_analytics.get_participant_responses"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
 
     created_at = datetime(2026, 4, 20, tzinfo=timezone.utc)
     detail = types.SimpleNamespace(
@@ -41,9 +39,7 @@ def test_detail_to_dict_uses_course_lookup_without_course_relationship(monkeypat
 
 
 def test_detail_to_dict_normalizes_timestamps_to_naive_utc(monkeypatch):
-    module = importlib.import_module(
-        "src.modules.participant_analytics.get_participant_responses"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
 
     detail = types.SimpleNamespace(
         createdAt=datetime(2026, 4, 20, 10, 30, tzinfo=timezone.utc),
@@ -67,9 +63,7 @@ def test_detail_to_dict_normalizes_timestamps_to_naive_utc(monkeypatch):
 
 
 def test_load_course_windows_selects_only_required_course_columns():
-    module = importlib.import_module(
-        "src.modules.participant_analytics.get_participant_responses"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
 
     captured = {}
 
@@ -95,9 +89,7 @@ def test_load_course_windows_selects_only_required_course_columns():
 
 
 def test_window_bounds_accept_aware_strings_and_compare_with_naive_datetimes():
-    module = importlib.import_module(
-        "src.modules.participant_analytics.get_participant_responses"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.get_participant_responses")
 
     start_ts, end_ts = module._coerce_window_bounds(
         "2026-02-15T00:00:00.000Z",
@@ -250,9 +242,7 @@ def test_numerical_exact_and_empty_solutions_match_product_grading(options, resp
 
 
 def test_selection_correctness_without_sample_solution_is_treated_as_correct():
-    module = importlib.import_module(
-        "src.modules.participant_analytics.compute_correctness"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
 
     result = module.compute_correctness_columns(
         _selection_instance_df({"hasSampleSolution": False, "numberOfInputs": 4}),
@@ -271,9 +261,7 @@ def test_selection_correctness_without_sample_solution_is_treated_as_correct():
     ],
 )
 def test_selection_correctness_matches_existing_product_grading(response, expected):
-    module = importlib.import_module(
-        "src.modules.participant_analytics.compute_correctness"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
 
     result = module.compute_correctness_columns(
         _selection_instance_df(
@@ -290,9 +278,7 @@ def test_selection_correctness_matches_existing_product_grading(response, expect
 
 
 def test_selection_correctness_returns_none_when_solution_metadata_missing():
-    module = importlib.import_module(
-        "src.modules.participant_analytics.compute_correctness"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
 
     result = module.compute_correctness_columns(
         _selection_instance_df({"hasSampleSolution": True, "numberOfInputs": 0}),
@@ -303,9 +289,7 @@ def test_selection_correctness_returns_none_when_solution_metadata_missing():
 
 
 def test_case_study_correctness_without_sample_solution_is_treated_as_correct():
-    module = importlib.import_module(
-        "src.modules.participant_analytics.compute_correctness"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
 
     result = module.compute_correctness_columns(
         _case_study_instance_df({"hasSampleSolution": False, "cases": []}),
@@ -371,12 +355,8 @@ def test_case_study_correctness_without_sample_solution_is_treated_as_correct():
         ),
     ],
 )
-def test_case_study_correctness_matches_existing_product_grading(
-    assessment, expected
-):
-    module = importlib.import_module(
-        "src.modules.participant_analytics.compute_correctness"
-    )
+def test_case_study_correctness_matches_existing_product_grading(assessment, expected):
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
 
     result = module.compute_correctness_columns(
         _case_study_instance_df(
@@ -405,9 +385,7 @@ def test_case_study_correctness_matches_existing_product_grading(
 
 
 def test_case_study_correctness_returns_none_when_solution_metadata_missing():
-    module = importlib.import_module(
-        "src.modules.participant_analytics.compute_correctness"
-    )
+    module = importlib.import_module("src.modules.participant_analytics.compute_correctness")
 
     result = module.compute_correctness_columns(
         _case_study_instance_df(

--- a/apps/analytics/tests/test_utils.py
+++ b/apps/analytics/tests/test_utils.py
@@ -25,6 +25,7 @@ from src.modules.utils import (  # noqa: E402
     analytics_run_config_from_env,
     analytics_window_since,
     apply_course_scope,
+    exclusive_day_end,
     iter_analytics_windows,
     render_uuid_in_clause,
     scoped_course_ids,
@@ -74,6 +75,31 @@ def test_cli_run_config_reads_immutable_chat_cutoff():
 
 
 # --- should_skip_window ----------------------------------------------------
+
+
+def test_exclusive_end_is_next_midnight():
+    assert exclusive_day_end("2026-07-23") == "2026-07-24T00:00:00.000Z"
+
+
+def test_daily_and_course_windows_use_exclusive_next_midnight():
+    calls: list[tuple[object, ...]] = []
+
+    def capture(*args: object, **_kwargs: object) -> object:
+        calls.append(args)
+        return None
+
+    iter_analytics_windows(
+        cast(Session, object()),
+        capture,
+        start_date="2026-07-23",
+        end_date="2026-07-23",
+        compute_weekly=False,
+        compute_monthly=False,
+    )
+
+    assert len(calls) == 2
+    assert calls[0][2] == "2026-07-24T00:00:00.000Z"
+    assert calls[1][2] == "2026-07-24T00:00:00.000Z"
 
 
 def test_skip_window_no_cutoff_keeps_every_window():

--- a/project/2026-07-23-learning-analytics-production-plan.md
+++ b/project/2026-07-23-learning-analytics-production-plan.md
@@ -1057,9 +1057,44 @@ the repository script that replaces it before continuing.
   frontend builds but could not resolve Google Fonts; the allowed rerun
   completed without a repository failure. Existing Rollup, page-size,
   translation, and cache warnings remain non-blocking.
-- Active: Request explicit publication confirmation for the verified stacked
-  heads. After publication, update both PR descriptions and read CI to a
-  terminal result without merging or deploying.
+- 2026-07-30: Publication was approved with an explicit request for clean
+  stacked PRs. The 94 implementation commits were replayed onto current `v3`
+  and split at 14 review boundaries. The original verified heads remain
+  available as `backup/chat-analytics-pre-restack-20260730` and
+  `backup/analytics-phase-a-pre-restack-20260730`.
+- 2026-07-30: A final tree comparison against the verified Phase 2 safety ref
+  found no implementation difference. After `v3` advanced once more, the
+  stack rebased cleanly onto `f424f03a16`; the only resulting difference from
+  the safety ref was the five-line upstream `AGENTS.md` change.
+- 2026-07-30: The full draft stack was published and read back from GitHub:
+
+  | Layer | Draft PR | Review scope |
+  | --- | --- | --- |
+  | 1 | [#5199](https://github.com/uzh-bf/klicker-uzh/pull/5199) | Chat, platform, live quiz, topic-cluster, and chat-to-quiz analytics domains |
+  | 2 | [#5073](https://github.com/uzh-bf/klicker-uzh/pull/5073) | Transitional Hatchet orchestration and dedicated worker |
+  | 3 | [#5230](https://github.com/uzh-bf/klicker-uzh/pull/5230) | Incremental recomputation and ended-course finalization |
+  | 4 | [#5231](https://github.com/uzh-bf/klicker-uzh/pull/5231) | Deterministic verification, consent, and reporting correctness |
+  | 5 | [#5232](https://github.com/uzh-bf/klicker-uzh/pull/5232) | Query indexes, late-data refresh, and decomposed DAG |
+  | 6 | [#5233](https://github.com/uzh-bf/klicker-uzh/pull/5233) | SQLAlchemy 2.x runtime migration |
+  | 7 | [#5234](https://github.com/uzh-bf/klicker-uzh/pull/5234) | Course scope, DAG hardening, and management API |
+  | 8 | [#5235](https://github.com/uzh-bf/klicker-uzh/pull/5235) | Read-only dry-run workbook and diagnostics |
+  | 9 | [#5236](https://github.com/uzh-bf/klicker-uzh/pull/5236) | Grading parity, query paths, and guarded index rollout |
+  | 10 | [#5237](https://github.com/uzh-bf/klicker-uzh/pull/5237) | Native Python Hatchet cutover, cancellation, and concurrency |
+  | 11 | [#5238](https://github.com/uzh-bf/klicker-uzh/pull/5238) | Consent reconciliation and finalization convergence |
+  | 12 | [#5239](https://github.com/uzh-bf/klicker-uzh/pull/5239) | Dry-run decomposition and curated model ownership |
+  | 13 | [#5240](https://github.com/uzh-bf/klicker-uzh/pull/5240) | Generated artifact reconciliation with current `v3` |
+  | 14 | [#5241](https://github.com/uzh-bf/klicker-uzh/pull/5241) | Runtime and test reconciliation with current `v3` |
+
+- 2026-07-30: Fresh stack-head Analytics verification passes Ruff format and
+  lint across 138 files and 184 tests with 15 PostgreSQL-only skips. The
+  database-enabled 199-test result, repository `check:all`, and 22-task Node 24
+  production build remain earlier verification of the identical
+  implementation tree. The fresh-worktree repository check ran before
+  generated workspace artifacts existed, and the pre-push build later stopped
+  on `ENOSPC`; both are recorded as warnings in the draft PR descriptions.
+- Active: Read the 14 draft PR checks to a terminal result, update stale
+  descriptions if GitHub reports a different branch range, and stop without
+  merging or deploying.
 
 ## Finish evidence
 
@@ -1073,9 +1108,8 @@ the repository script that replaces it before continuing.
 
 ## Next Steps
 
-1. After explicit publication confirmation, push `chat-analytics` and
-   `analytics-phase-a`, update both stacked draft PR descriptions, and read CI
-   to a terminal result without merging or deploying.
+1. Read every stacked draft PR check to a terminal result. Fix only failures
+   caused by the stack; leave all PRs draft and do not merge or deploy.
 2. Before staging, scan the exact image digest for CVEs, confirm the deployed
    Hatchet control-plane compatibility, and verify the owning
    ExternalSecret/Infisical sync is ready.


### PR DESCRIPTION
## What

This is layer 14 of 14. It reconciles the remaining Analytics runtime and test files after the history was split into reviewable layers.

The commit restores the exact runtime behavior from the previously verified Phase 2 head. It does not add another feature area. Keeping this reconciliation visible makes the restack auditable and prevents reviewed work from being lost during the move to current `v3`.

## Branch coverage

- Base: `analytics-stack-13-generated-v3-artifacts` at `8c77b9d918`
- Head: `24c5e4304e`
- Reviewed: 1 commit, 44 files, 530 insertions, 489 deletions
- Covered: SQLAlchemy helpers and models, scoped compute modules, SQL contracts, scripts, topic clustering, dry-run integration, regression tests, and the published stack record

## Review focus

- Review this diff as v3 integration reconciliation.
- Confirm runtime helpers retain exclusive reporting-window ends, course scope, and SQLAlchemy transaction behavior.
- Confirm the restored tests cover the same behavior they protect.

## Verification

Current head:

- `git diff` against the previously verified Phase 2 safety ref reports no implementation-path difference. The only differences are the five-line `AGENTS.md` change already merged into `v3` and the updated production-plan record.
- Analytics Ruff format and lint passed across 138 files.
- Analytics tests passed 184 cases; 15 PostgreSQL-only cases skipped because this worktree had no disposable database.

Earlier verification of the identical implementation tree:

- All 199 database-enabled Analytics tests passed.
- Repository `check:all` passed.
- All 22 production build tasks passed under Node 24.
- Independent Standards and Spec reviews reported no lost requirement, tRPC addition, or actionable finding.

Warnings:

- The fresh-worktree pre-push build completed 16 of 22 tasks before the disk filled while Next.js wrote `apps/chat/.next/trace`. The push will bypass that local hook for draft publication; GitHub CI remains blocking.

## Security / privacy

The final stack retains centralized consent eligibility, report-scoped de-identification, course-scoped recompute, and derived-data reconciliation. No credentials, participant exports, or production data are committed.

## Blocking before merge

- [ ] Layer 13 is merged first.
- [ ] Required GitHub checks pass.
- [ ] Maintainer, security, and privacy review are complete.
- [ ] Staging cold-cutover prerequisites are approved before deployment.

## Follow-up after merge

- Scan the exact image digest, confirm Hatchet control-plane compatibility and secret sync, then run the one-replica, one-slot staging cold cutover with a scoped course and privacy-convergence checks.
