### PR TITLE
fix(frontend-pwa): remove unverified LTI 1.1 login path

### DIFF
--- a/apps/frontend-pwa/src/lib/getParticipantToken.ts
+++ b/apps/frontend-pwa/src/lib/getParticipantToken.ts
@@ -1,7 +1,6 @@
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { LoginParticipantWithLtiDocument } from '@klicker-uzh/graphql/dist/ops'
-import { signJWT, verifyJWT } from '@klicker-uzh/util'
-import bodyParser from 'body-parser'
+import { verifyJWT } from '@klicker-uzh/util'
 import { GetServerSidePropsContext } from 'next'
 import nookies from 'nookies'
 
@@ -14,7 +13,7 @@ export default async function getParticipantToken({
   courseId?: string
   ctx: GetServerSidePropsContext
 }) {
-  const { req, res, query } = ctx
+  const { query } = ctx
   const cookies = nookies.get(ctx)
 
   // if the user already has a participant token, skip registration
@@ -25,12 +24,7 @@ export default async function getParticipantToken({
       : cookies['participant_token']) ?? query.participantToken
 
   // TODO: only check for existing participantToken once participation issues with LTI are resolved
-  if (
-    participantToken &&
-    !cookies['lti-token'] &&
-    !query.jwt &&
-    !(req.method === 'POST')
-  ) {
+  if (participantToken && !cookies['lti-token'] && !query.jwt) {
     return {
       participantToken,
       cookiesAvailable:
@@ -72,57 +66,6 @@ export default async function getParticipantToken({
           })
         }
       } catch (e) {}
-    }
-    // LTI 1.1 authentication flow
-    else if (req.method === 'POST') {
-      // extract the body from the LTI request
-      // if there is a body, request a participant token
-      // TODO: verify that there is an LTI body and that it is valid
-      const { request }: any = await new Promise((resolve) => {
-        bodyParser.urlencoded({ extended: true })(req, res, () => {
-          bodyParser.json()(req, res, () => {
-            resolve({ request: req })
-          })
-        })
-      })
-
-      if (request?.body?.lis_person_sourcedid) {
-        const pwaOrigin =
-          process.env.ASSESSMENT_MODE === 'true'
-            ? process.env.APP_ORIGIN_ASSESSMENT_PWA
-            : process.env.APP_ORIGIN_PWA
-        if (!pwaOrigin) {
-          throw new Error(
-            'APP_ORIGIN_PWA and APP_ORIGIN_ASSESSMENT_PWA are required but not defined'
-          )
-        }
-
-        // send along a JWT to ensure only the next server is allowed to register participants from LTI
-        const signedLtiData = await signJWT(
-          {
-            sub: request?.body?.lis_person_sourcedid,
-            email: request?.body?.lis_person_contact_email_primary,
-            scope: 'LTI1.1',
-          },
-          process.env.APP_SECRET as string,
-          {
-            algorithm: 'HS256',
-            expiresIn: '5m',
-            issuer:
-              process.env.ASSESSMENT_MODE === 'true'
-                ? process.env.APP_ORIGIN_ASSESSMENT_PWA
-                : process.env.APP_ORIGIN_PWA,
-          }
-        )
-
-        result = await apolloClient.mutate({
-          mutation: LoginParticipantWithLtiDocument,
-          variables: {
-            signedLtiData,
-            courseId,
-          },
-        })
-      }
     }
 
     const ltiParticipantToken =

--- a/apps/frontend-pwa/src/pages/createAccount.tsx
+++ b/apps/frontend-pwa/src/pages/createAccount.tsx
@@ -1,4 +1,4 @@
-import { signJWT, verifyJWT } from '@klicker-uzh/util'
+import { verifyJWT } from '@klicker-uzh/util'
 import { toast } from '@uzh-bf/design-system'
 import generatePassword from 'generate-password'
 import { GetServerSidePropsContext } from 'next'
@@ -13,7 +13,6 @@ import { CreateParticipantAccountDocument } from '@klicker-uzh/graphql/dist/ops'
 import { addApolloState, initializeApollo } from '@lib/apollo'
 import getParticipantToken from '@lib/getParticipantToken'
 import useParticipantToken from '@lib/useParticipantToken'
-import bodyParser from 'body-parser'
 
 interface Props {
   signedLtiData?: string
@@ -112,7 +111,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   }
 
   try {
-    const { req, res, query } = ctx
+    const { query } = ctx
     const apolloClient = initializeApollo()
     const { participantToken, cookiesAvailable } = await getParticipantToken({
       apolloClient,
@@ -158,47 +157,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         signedLtiData.token = token
         signedLtiData.ssoId = parsedToken.sub
         signedLtiData.email = parsedToken.email
-      }
-    }
-    // LTI 1.1 authentication flow
-    else if (req.method === 'POST') {
-      const { request }: any = await new Promise((resolve) => {
-        bodyParser.urlencoded({ extended: true })(req, res, () => {
-          bodyParser.json()(req, res, () => {
-            resolve({ request: req })
-          })
-        })
-      })
-
-      if (request?.body?.lis_person_sourcedid) {
-        const pwaOrigin =
-          process.env.ASSESSMENT_MODE === 'true'
-            ? process.env.APP_ORIGIN_ASSESSMENT_PWA
-            : process.env.APP_ORIGIN_PWA
-        if (!pwaOrigin) {
-          throw new Error(
-            'APP_ORIGIN_PWA and APP_ORIGIN_ASSESSMENT_PWA are required but not defined'
-          )
-        }
-
-        signedLtiData.token = await signJWT(
-          {
-            sub: request.body.lis_person_sourcedid,
-            email: request.body.lis_person_contact_email_primary,
-            scope: 'LTI1.1',
-          },
-          process.env.APP_SECRET as string,
-          {
-            algorithm: 'HS256',
-            expiresIn: '5m',
-            issuer:
-              process.env.ASSESSMENT_MODE === 'true'
-                ? process.env.APP_ORIGIN_ASSESSMENT_PWA
-                : process.env.APP_ORIGIN_PWA,
-          }
-        )
-        signedLtiData.ssoId = request.body.lis_person_sourcedid
-        signedLtiData.email = request.body.lis_person_contact_email_primary
       }
     }
 

--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -36,7 +36,11 @@ The NextAuth cookie domain is derived by stripping the first subdomain label fro
 - **Magic link** — `services/accounts.ts:sendMagicLink` signs a 15-minute JWT and emails `${APP_ORIGIN_PWA}/magicLogin?token=…`; the `magicLogin` page exchanges it via `LoginParticipantMagicLinkDocument` (`loginParticipantMagicLink`).
 - **Edu-ID for participants** — separate NextAuth config in the same auth app (`EduIDParticipantProvider`), same `EDUID_CLIENT_SECRET` gating.
 - **Temporary (anonymous)** — `temporary_participant_token` cookie, role `TEMPORARY_PARTICIPANT`.
-- **LTI** — `apps/lti` (ltijs). Launch targets resolve in strict precedence `custom claim (klicker_redirect_to)` → `query redirectTo`, with **no env fallback**; validation fails closed on the first present-but-invalid source and checks URL hostnames exact/subdomain against `COOKIE_DOMAIN` and `DF_DOMAIN` — never substring matching (`apps/lti/src/launchTarget.ts`).
+- **LTI 1.3 only** — `apps/lti` (ltijs). Launch targets resolve in strict precedence `custom claim (klicker_redirect_to)` → `query redirectTo`, with **no env fallback**; validation fails closed on the first present-but-invalid source and checks URL hostnames exact/subdomain against `COOKIE_DOMAIN` and `DF_DOMAIN` — never substring matching (`apps/lti/src/launchTarget.ts`).
+
+**LTI 1.1 is retired and must not be reintroduced without signature verification.** The removed path derived a login identity from an unauthenticated form POST; no OAuth 1.0a signature was ever checked. `resolveOrCreateParticipantForLti` (`packages/graphql/src/services/accounts.ts`) now rejects any launch whose `scope` is not `LTI1.3`, so the trust boundary is enforced server-side rather than by the absence of a caller.
+
+Two related properties of that resolver are worth knowing before changing it: it resolves by `ssoId` and then falls back to matching `Participant.email`, and both happen **before** the `allowCreate` gate — so `allowCreate: false` constrains account creation only, never account resolution. Any new launch path must therefore be verified before it reaches this function, not inside it.
 
 Note the account-duplication trap: participant emails are only unique per auth mode (`@@unique([email, isSSOAccount])` — details in [Data & Migrations](./data-and-migrations.md)).
 

--- a/packages/graphql/src/services/accounts.ts
+++ b/packages/graphql/src/services/accounts.ts
@@ -573,6 +573,7 @@ type ResolveOrCreateParticipantForLtiResult =
         | 'not_found'
         | 'username_taken'
         | 'invalid_create_input'
+        | 'unsupported_scope'
     }
 
 interface ResolveOrCreateParticipantForLtiArgs {
@@ -602,6 +603,14 @@ async function resolveOrCreateParticipantForLti(
     email?: string
     sub: string
     scope: string
+  }
+
+  // LTI 1.1 is retired: its launches were never signature-verified, so any
+  // caller could mint a token for an arbitrary subject or email. Only accept
+  // LTI 1.3, which is verified by apps/lti before the JWT is issued.
+  if (ltiData.scope !== 'LTI1.3') {
+    console.warn(`event=lti_rejected_scope scope=${ltiData.scope}`)
+    return { type: 'unsupported_scope' }
   }
 
   return ctx.prisma.$transaction(async (prisma) => {

--- a/packages/graphql/test/accountLtiLinking.test.ts
+++ b/packages/graphql/test/accountLtiLinking.test.ts
@@ -46,7 +46,7 @@ async function createSignedLtiData({
 }: {
   sub: string
   email?: string
-  scope?: 'LTI1.1' | 'LTI1.3'
+  scope?: string
 }) {
   return signJWT(
     {
@@ -212,6 +212,68 @@ describe('LTI participant linking and creation', () => {
       where: { ssoId: ssoIdFor('idempotent') },
     })
     expect(accounts).toHaveLength(1)
+  })
+
+  it('rejects retired LTI 1.1 launches even when the ssoId matches an existing account', async () => {
+    const participant = await prisma.participant.create({
+      data: {
+        email: emailFor('lti11-ssoid'),
+        username: usernameFor('lti11-ssoid'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+        accounts: {
+          create: {
+            ssoId: ssoIdFor('lti11-ssoid'),
+            ssoType: 'LTI1.1',
+            ssoEmail: emailFor('lti11-ssoid'),
+          },
+        },
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('lti11-ssoid'),
+      email: emailFor('lti11-ssoid'),
+      scope: 'LTI1.1',
+    })
+
+    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(result).toBeNull()
+
+    // the pre-existing LTI 1.1 link must survive untouched -- retirement blocks
+    // the login, it does not rewrite historical account rows
+    const accounts = await prisma.participantAccount.findMany({
+      where: { participantId: participant.id },
+    })
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0]?.ssoType).toBe('LTI1.1')
+  })
+
+  it('rejects retired LTI 1.1 launches that would match an existing participant by email', async () => {
+    await prisma.participant.create({
+      data: {
+        email: emailFor('lti11-email'),
+        username: usernameFor('lti11-email'),
+        password: await bcrypt.hash('password123', 10),
+        isSSOAccount: false,
+      },
+    })
+
+    const signedLtiData = await createSignedLtiData({
+      sub: ssoIdFor('lti11-email-attacker'),
+      email: emailFor('lti11-email'),
+      scope: 'LTI1.1',
+    })
+
+    const result = await loginParticipantWithLti({ signedLtiData }, createCtx())
+
+    expect(result).toBeNull()
+
+    const accounts = await prisma.participantAccount.findMany({
+      where: { ssoId: ssoIdFor('lti11-email-attacker') },
+    })
+    expect(accounts).toHaveLength(0)
   })
 
   it('returns null for LTI login when no existing participant can be matched and auto-create is disabled', async () => {


### PR DESCRIPTION
## Summary

- LTI 1.1 is no longer a supported integration, so this removes the LTI 1.1 launch path instead of hardening it.
- That path was never signature-verified — it derived a login identity from an unauthenticated request — so it is removed rather than hardened.
- Removal alone would leave the trust boundary defined by "nothing calls it any more", so `resolveOrCreateParticipantForLti` now also rejects any launch whose `scope` is not `LTI1.3`.
- LTI 1.3 through `apps/lti` is unchanged and remains the only LMS entry point.
- Risk: **auth-path change**. Reviewers should focus on the two behaviour notes below.
- Draft until reviewed; mechanism details are deliberately kept out of this public repository.

## Implementation

| Area | Change |
| --- | --- |
| `apps/frontend-pwa/src/lib/getParticipantToken.ts` | Drop the LTI 1.1 POST branch and its `body-parser`/`signJWT` use |
| `apps/frontend-pwa/src/pages/createAccount.tsx` | Drop the same branch from `getServerSideProps` |
| `packages/graphql/src/services/accounts.ts` | Reject non-`LTI1.3` scopes in `resolveOrCreateParticipantForLti` via a new `unsupported_scope` result |
| `packages/graphql/test/accountLtiLinking.test.ts` | Two regression tests covering both resolution routes |
| `docs/auth-model.md` | Record the retirement and the resolver property behind it |

## Review Focus

1. **The `POST` short-circuit exception is gone.** `getParticipantToken` previously skipped its existing-token early return when `req.method === 'POST'`, so an LTI 1.1 launch could re-authenticate. With no LTI 1.1 branch left to reach, keeping it meant a POST fell through to `participantToken = null` and cleared a valid participant session. Removing it is a correctness fix, not tidying — worth a second opinion.
2. **The scope check is server-side on purpose.** `resolveOrCreateParticipantForLti` resolves by `ssoId` and then by `Participant.email`, and both run *before* the `allowCreate` gate — so `allowCreate: false` constrains account creation only, never account resolution. Any future launch path must be verified before reaching this function. This is now documented in `docs/auth-model.md`.
3. Historical `ParticipantAccount` rows with `ssoType = 'LTI1.1'` are intentionally left untouched; retirement blocks the login, it does not rewrite data. One regression test pins this.

## Verification

**Current head (`e9ddd388bc`), run in the devcontainer:**

- `pnpm run check` — 25/25 packages typecheck clean
- `eslint` on `frontend-pwa` — 0 errors (12 pre-existing warnings in files this PR does not touch)
- `prettier --check` on all changed files — clean
- `packages/graphql` `accountLtiLinking.test.ts` — 10/10 pass, including the 2 new tests

**Browser verification** (`agent-browser`, seeded local stack):

- Participant login (`testuser1`) succeeds and the course page renders — confirms the short-circuit change did not regress normal sessions.
- A POST carrying LTI 1.1 fields returns no `participant_token` and creates no `ParticipantAccount` row (verified in the database).

**GitHub checks on `e9ddd388bc`:** 24 pass, 12 skipped by workflow filters, 0 failures — including `check-types`, `check-lint`, `check-format`, `check-syncpack`, `build-and-compile`, `test-graphql`, all 8 `test-playwright` shards, CodeQL (java-kotlin, javascript-typescript, python), and GitGuardian.

**Known-unrelated:** 20 `packages/graphql` suites fail *locally* on a missing `HATCHET_CLIENT_TOKEN`. Confirmed environmental — reproduced identically on the base commit with this branch's changes stashed, and `test-graphql` passes in CI.

## Security / Privacy

Removes an unverified authentication path and enforces the surviving one server-side. No secrets, migrations, or stored-data changes. No participant data is read or written differently; historical rows are untouched.

## Blocking Before Merge

- Human review of the auth-path change, particularly Review Focus items 1 and 2.
- CI green. ✅ 24/24 required checks pass on `e9ddd388bc`.

## Follow-Up After Merge

- `ssoType` is a free-form `String` defaulting to `"LTI1.1"`, so it no longer describes reality for new rows. Changing the default needs a migration and is tracked in the participant-privacy plan (#5128), not here.
- Removing the email-fallback link branch stays in that plan's Slice 3, where it gets migration handling for participants who link by email today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Authentication**
  - LTI 1.1 launches are no longer supported.
  - LTI 1.3 authentication continues through approved token sources.
  - Unsupported LTI scopes are rejected before account linking or creation.

- **Account Linking**
  - Retired LTI 1.1 launches cannot match or modify existing accounts, including matches by SSO ID or email.

- **Documentation**
  - Updated authentication guidance to clarify supported LTI 1.3 launches, rejected scopes, and account resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->