### PR TITLE
chore(quality): harden repo quality gates

### DIFF
--- a/.github/workflows/check-gitleaks.yml
+++ b/.github/workflows/check-gitleaks.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       # Install the gitleaks binary directly (MIT-licensed release asset) instead
       # of gitleaks-action@v2, which requires a GITLEAKS_LICENSE for org-owned
@@ -29,11 +32,35 @@ jobs:
         shell: bash
         run: |
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          printf '%s  %s\n' \
+            '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb' \
+            /tmp/gitleaks.tar.gz | sha256sum --check --status
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo install /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
 
-      - name: Scan working tree for secrets
+      - name: Scan introduced commits for secrets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
-          gitleaks dir . --no-banner --redact --config .gitleaks.toml
+          if [[ -z "$BASE_SHA" || -z "$HEAD_SHA" ]]; then
+            echo 'Unable to determine the commit range for the secret scan.'
+            exit 1
+          fi
+
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'The secret scan received an invalid commit SHA.'
+            exit 1
+          fi
+
+          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            LOG_OPTS="--max-count=1 $HEAD_SHA"
+          else
+            LOG_OPTS="$BASE_SHA..$HEAD_SHA"
+          fi
+
+          # Scan only commits introduced by this push or pull request so
+          # historical findings are not re-reported as newly introduced leaks.
+          gitleaks git --log-opts="$LOG_OPTS" --no-banner --redact --config .gitleaks.toml

--- a/.github/workflows/check-knip.yml
+++ b/.github/workflows/check-knip.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         id: filter

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,7 +7,7 @@ title = "KlickerUZH gitleaks config"
 useDefault = true
 
 [allowlist]
-description = "Verified false positives (generated manifests, public client configs, templates, doc/test fixtures)"
+description = "Verified false positives (generated manifests, public client configs, templates)"
 paths = [
   # GraphQL persisted-operation manifest — values are SHA-256 hashes of queries.
   '''packages/graphql/src/public/client\.json''',
@@ -18,11 +18,9 @@ paths = [
   '''apps/docs/docusaurus\.config\.ts''',
   # Self-host docker-compose example env — placeholder/template values only.
   '''deploy/compose-traefik-proxy/.*\.env$''',
-  # Illustrative/mock tokens in docs and skill examples (e.g. truncated JWTs,
-  # "test-verification-abc123"). Real load-test tokens are injected via __ENV,
-  # never committed (see util/load-test/k6.js).
-  '''\.agents/skills/.*\.md$''',
-  '''project/.*\.md$''',
+  # Documentation-only fixture snippets with deliberately illustrative values.
+  '''^\.agents/skills/playwright-best-practices/advanced/authentication-flows\.md$''',
+  '''^project/plans_future/PLAN-k6-load-testing\.md$''',
   # Generated build output (gitignored, never committed) — only present after a
   # local build. CI scans a clean checkout where these do not exist; excluding
   # them keeps a local `gitleaks dir` on a built tree quiet.

--- a/project/2026-07-19-biome-knip-repo-quality.md
+++ b/project/2026-07-19-biome-knip-repo-quality.md
@@ -1,6 +1,6 @@
 # Repo Quality Migration — Biome + Knip + Gitleaks
 
-Status: PLAN (awaiting approval to start Phase 0)
+Status: COMPLETE (Phases 0–6 merged in PR #5186; Biome format enforced, Biome lint + Knip advisory, Gitleaks blocking)
 Date: 2026-07-19
 Branch: `claude/klicker-uzh-repo-quality-17a1bb` → target `v3`
 Owner: Roland Schlaefli

--- a/util/load-test/k6.js
+++ b/util/load-test/k6.js
@@ -14,6 +14,19 @@ export const options = {
   noConnectionReuse: true,
 }
 const id = __ENV.LIVE_QUIZ_ID || 'af59e777-f7e6-41c3-877e-8d4251a55cd9'
+const sessionToken = __ENV.KLICKER_SESSION_TOKEN
+const participantToken = __ENV.KLICKER_PARTICIPANT_TOKEN
+
+if (
+  !sessionToken ||
+  sessionToken.trim().length === 0 ||
+  !participantToken ||
+  participantToken.trim().length === 0
+) {
+  throw new Error(
+    'KLICKER_SESSION_TOKEN and KLICKER_PARTICIPANT_TOKEN must be set for authenticated load testing'
+  )
+}
 
 export function setup() {
   // check connectivity to student preview
@@ -28,8 +41,8 @@ export function setup() {
   // tokens from an authenticated staging session each run.
   const cookies = {
     cookies: {
-      'next-auth.session-token': __ENV.KLICKER_SESSION_TOKEN || '',
-      participant_token: __ENV.KLICKER_PARTICIPANT_TOKEN || '',
+      'next-auth.session-token': sessionToken,
+      participant_token: participantToken,
     },
   }
   res = http.get(`https://pwa.klicker.stg.df-app.ch/session/${id}`, cookies)


### PR DESCRIPTION
## Summary

- verify the pinned Gitleaks release checksum before installation
- scan only commits introduced by the push or pull request
- disable persisted checkout credentials in quality workflows
- narrow Gitleaks documentation fixtures to exact known files
- fail fast when k6 authenticated tokens are missing or empty
- mark the merged Biome/Knip/Gitleaks migration plan complete

## Verification

- `gitleaks dir . --no-banner --redact --config .gitleaks.toml`
- introduced-commit Gitleaks range scan
- staged Gitleaks scan
- k6 rejects missing tokens and inspects successfully with dummy runtime tokens
- Prettier check for changed Markdown/YAML
- Ruby YAML parse for both changed workflows
- `git diff --check`

This draft does not perform the separate staging signing-secret rotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authenticated load testing now requires and validates the necessary access tokens before execution.

- **Bug Fixes**
  - Improved secret scanning to verify downloads, handle initial pushes, and scan only newly introduced commits.
  - Strengthened workflow credential handling to prevent persisted Git credentials.

- **Documentation**
  - Updated repository quality documentation to reflect the completed tooling migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->